### PR TITLE
Use development exports key instead of vitest alias

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
       "import": "./dist/src/jsx-runtime.js"
     },
     "./testing": {
-      "development": "./src/testing/index.ts",
+      "development": "./testing/index.ts",
       "import": "./dist/testing/index.js"
     },
     "./stc": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,11 +6,13 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "import": "./dist/src/index.js",
       "require": "./dist/src/index.js",
       "types": "./dist/src/index.d.ts"
     },
     "./jsx-runtime": {
+      "development": "./src/jsx-runtime.ts",
       "import": "./dist/src/jsx-runtime.js",
       "require": "./dist/src/jsx-runtime.js",
       "types": "./dist/src/jsx-runtime.d.ts"
@@ -21,6 +23,7 @@
       "types": "./dist/testing/index.d.ts"
     },
     "./stc": {
+      "development": "./src/components/stc/index.ts",
       "import": "./dist/src/components/stc/index.js",
       "require": "./dist/src/components/stc/index.js",
       "types": "./dist/src/components/stc/index.d.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,30 +3,22 @@
   "version": "1.0.0",
   "description": "",
   "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
       "development": "./src/index.ts",
-      "import": "./dist/src/index.js",
-      "require": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "import": "./dist/src/index.js"
     },
     "./jsx-runtime": {
       "development": "./src/jsx-runtime.ts",
-      "import": "./dist/src/jsx-runtime.js",
-      "require": "./dist/src/jsx-runtime.js",
-      "types": "./dist/src/jsx-runtime.d.ts"
+      "import": "./dist/src/jsx-runtime.js"
     },
     "./testing": {
-      "import": "./dist/testing/index.js",
-      "require": "./dist/testing/index.js",
-      "types": "./dist/testing/index.d.ts"
+      "development": "./src/testing/index.ts",
+      "import": "./dist/testing/index.js"
     },
     "./stc": {
       "development": "./src/components/stc/index.ts",
-      "import": "./dist/src/components/stc/index.js",
-      "require": "./dist/src/components/stc/index.js",
-      "types": "./dist/src/components/stc/index.d.ts"
+      "import": "./dist/src/components/stc/index.js"
     }
   },
   "scripts": {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,13 +7,6 @@ export default defineConfig({
     jsx: "preserve",
     sourcemap: "both",
   },
-  resolve: {
-    alias: {
-      "@alloy-js/core/jsx-runtime": resolve(__dirname, "./src/jsx-runtime.ts"),
-      "@alloy-js/core/stc": resolve(__dirname, "./src/components/stc/index.ts"),
-      "@alloy-js/core": resolve(__dirname, "./src/index.ts"),
-    },
-  },
   plugins: [
     babel({
       inputSourceMap: true as any,

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "exports": {
     ".": {
-      "import": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "development": "./src/index.ts",
+      "import": "./dist/src/index.js"
     },
     "./stc": {
-      "import": "./dist/src/components/stc/index.js",
-      "types": "./dist/src/components/stc/index.d.ts"
+      "development": "./src/components/stc/index.ts",
+      "import": "./dist/src/components/stc/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
This has the benefit of a centralize config for exports which allows dependent package from loading the sources