### PR TITLE
Migrate to pnpm catalogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "catalog:",
-    "babel-preset-alloy": "catalog:",
+    "babel-preset-alloy": "workspace:~",
     "concurrently": "catalog:",
     "prettier": "catalog:",
     "rimraf": "catalog:",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     }
   },
   "devDependencies": {
-    "@babel/preset-typescript": "^7.24.7",
-    "babel-preset-alloy": "workspace:~",
-    "concurrently": "^8.2.2",
-    "prettier": "^3.3.3",
-    "rimraf": "^6.0.1",
-    "vitest": "^2.0.5"
+    "@babel/preset-typescript": "catalog:",
+    "babel-preset-alloy": "catalog:",
+    "concurrently": "catalog:",
+    "prettier": "catalog:",
+    "rimraf": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/babel-plugin-alloy/package.json
+++ b/packages/babel-plugin-alloy/package.json
@@ -21,21 +21,21 @@
   },
   "homepage": "https://github.com/alloy-framework/alloy#readme",
   "dependencies": {
-    "@babel/generator": "^7.25.0",
-    "@babel/helper-module-imports": "7.18.6",
-    "@babel/plugin-syntax-jsx": "^7.18.6",
-    "@babel/types": "^7.20.7"
+    "@babel/generator": "catalog:",
+    "@babel/helper-module-imports": "catalog:",
+    "@babel/plugin-syntax-jsx": "catalog:",
+    "@babel/types": "catalog:"
   },
   "peerDependencies": {
-    "@babel/core": "^7.20.12"
+    "@babel/core": "^7.24.7"
   },
   "devDependencies": {
-    "@types/babel__core": "^7.20.5",
-    "@types/babel__generator": "^7.6.8",
-    "@types/babel__traverse": "^7.20.6",
-    "babel-plugin-tester": "^11.0.4",
-    "vitest": "^2.0.5",
-    "typescript": "^5.5.4"
+    "@types/babel__core": "catalog:",
+    "@types/babel__generator": "catalog:",
+    "@types/babel__traverse": "catalog:",
+    "babel-plugin-tester": "catalog:",
+    "vitest": "catalog:",
+    "typescript": "catalog:"
   },
   "type": "module"
 }

--- a/packages/babel-plugin-jsx-dom-expressions/package.json
+++ b/packages/babel-plugin-jsx-dom-expressions/package.json
@@ -17,19 +17,19 @@
     "test:coverage": "pnpm run build && jest --coverage --no-cache"
   },
   "dependencies": {
-    "@babel/helper-module-imports": "7.18.6",
-    "@babel/plugin-syntax-jsx": "^7.18.6",
-    "@babel/types": "^7.20.7",
-    "html-entities": "2.3.3",
-    "validate-html-nesting": "^1.2.1"
+    "@babel/helper-module-imports": "catalog:",
+    "@babel/plugin-syntax-jsx": "catalog:",
+    "@babel/types": "catalog:",
+    "html-entities": "catalog:",
+    "validate-html-nesting": "catalog:"
   },
   "peerDependencies": {
-    "@babel/core": "^7.20.12"
+    "@babel/core": "^7.24.7"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.12",
-    "@rollup/plugin-node-resolve": "^15.2.3",
-    "rollup": "^4.18.1"
+    "@babel/core": "catalog:",
+    "@rollup/plugin-node-resolve": "catalog:",
+    "rollup": "catalog:"
   },
   "gitHead": "eb463c653325e24824422cff6bfed0d35113ef33"
 }

--- a/packages/babel-preset-alloy/package.json
+++ b/packages/babel-preset-alloy/package.json
@@ -7,8 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@alloy-js/babel-plugin-alloy": "catalog:",
-    "@alloy-js/babel-plugin-jsx-dom-expressions": "catalog:"
+    "@alloy-js/babel-plugin-alloy": "workspace:~",
+    "@alloy-js/babel-plugin-jsx-dom-expressions": "workspace:~"
   },
   "keywords": [],
   "author": "",

--- a/packages/babel-preset-alloy/package.json
+++ b/packages/babel-preset-alloy/package.json
@@ -7,8 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@alloy-js/babel-plugin-alloy": "workspace:*",
-    "@alloy-js/babel-plugin-jsx-dom-expressions": "workspace:*"
+    "@alloy-js/babel-plugin-alloy": "catalog:",
+    "@alloy-js/babel-plugin-jsx-dom-expressions": "catalog:"
   },
   "keywords": [],
   "author": "",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "@babel/core": "catalog:",
     "@babel/preset-typescript": "catalog:",
     "@vue/reactivity": "catalog:",
-    "babel-preset-alloy": "catalog:",
+    "babel-preset-alloy": "workspace:~",
     "pathe": "catalog:"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,19 +37,19 @@
   "author": "brian.terlson@microsoft.com",
   "license": "ISC",
   "dependencies": {
-    "@babel/core": "^7.24.7",
-    "@babel/preset-typescript": "^7.24.7",
-    "@vue/reactivity": "^3.4.30",
-    "babel-preset-alloy": "workspace:*",
-    "pathe": "^1.1.2"
+    "@babel/core": "catalog:",
+    "@babel/preset-typescript": "catalog:",
+    "@vue/reactivity": "catalog:",
+    "babel-preset-alloy": "catalog:",
+    "pathe": "catalog:"
   },
   "devDependencies": {
-    "@babel/cli": "^7.24.7",
-    "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-typescript": "^11.1.6",
-    "concurrently": "^8.2.2",
-    "typescript": "^5.5.4",
-    "vitest": "^2.0.5"
+    "@babel/cli": "catalog:",
+    "@rollup/plugin-babel": "catalog:",
+    "@rollup/plugin-typescript": "catalog:",
+    "concurrently": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "overrides": {
     "esbuild": "0.23"

--- a/packages/prettier-plugin-alloy/package.json
+++ b/packages/prettier-plugin-alloy/package.json
@@ -24,11 +24,10 @@
     "test": "vitest run",
     "test:watch": "vitest -w"
   },
-  "dependencies": {},
   "devDependencies": {
-    "prettier": "^3.3.3",
-    "typescript": "^5.5.2",
-    "vitest": "^2.0.5"
+    "prettier": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "bugs": "https://github.com/timotheeguerin/chronus/issues"
 }

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -16,19 +16,19 @@
   "author": "brian.terlson@microsoft.com",
   "license": "ISC",
   "dependencies": {
-    "@alloy-js/core": "workspace:*",
-    "@alloy-js/typescript": "workspace:*"
+    "@alloy-js/core": "catalog:",
+    "@alloy-js/typescript": "catalog:"
   },
   "devDependencies": {
-    "@babel/cli": "^7.24.7",
-    "@babel/preset-typescript": "^7.24.7",
-    "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-typescript": "^11.1.6",
-    "@types/node": "^20.14.12",
-    "babel-preset-alloy": "workspace:*",
-    "concurrently": "^8.2.2",
-    "typescript": "^5.5.4",
-    "vitest": "^2.0.5"
+    "@babel/cli": "catalog:",
+    "@babel/preset-typescript": "catalog:",
+    "@rollup/plugin-babel": "catalog:",
+    "@rollup/plugin-typescript": "catalog:",
+    "@types/node": "catalog:",
+    "babel-preset-alloy": "catalog:",
+    "concurrently": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "overrides": {
     "esbuild": "0.23"

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -16,8 +16,8 @@
   "author": "brian.terlson@microsoft.com",
   "license": "ISC",
   "dependencies": {
-    "@alloy-js/core": "catalog:",
-    "@alloy-js/typescript": "catalog:"
+    "@alloy-js/core": "workspace:~",
+    "@alloy-js/typescript": "workspace:~"
   },
   "devDependencies": {
     "@babel/cli": "catalog:",
@@ -25,7 +25,7 @@
     "@rollup/plugin-babel": "catalog:",
     "@rollup/plugin-typescript": "catalog:",
     "@types/node": "catalog:",
-    "babel-preset-alloy": "catalog:",
+    "babel-preset-alloy": "workspace:~",
     "concurrently": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -26,7 +26,7 @@
   "author": "brian.terlson@microsoft.com",
   "license": "ISC",
   "dependencies": {
-    "@alloy-js/core": "catalog:",
+    "@alloy-js/core": "workspace:~",
     "change-case": "catalog:",
     "pathe": "catalog:"
   },
@@ -35,7 +35,7 @@
     "@babel/preset-typescript": "catalog:",
     "@rollup/plugin-babel": "catalog:",
     "@rollup/plugin-typescript": "catalog:",
-    "babel-preset-alloy": "catalog:",
+    "babel-preset-alloy": "workspace:~",
     "concurrently": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -26,19 +26,19 @@
   "author": "brian.terlson@microsoft.com",
   "license": "ISC",
   "dependencies": {
-    "@alloy-js/core": "workspace:*",
-    "change-case": "^5.4.4",
-    "pathe": "^1.1.2"
+    "@alloy-js/core": "catalog:",
+    "change-case": "catalog:",
+    "pathe": "catalog:"
   },
   "devDependencies": {
-    "@babel/cli": "^7.24.7",
-    "@babel/preset-typescript": "^7.24.7",
-    "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-typescript": "^11.1.6",
-    "babel-preset-alloy": "workspace:*",
-    "concurrently": "^8.2.2",
-    "typescript": "^5.5.4",
-    "vitest": "^2.0.5"
+    "@babel/cli": "catalog:",
+    "@babel/preset-typescript": "catalog:",
+    "@rollup/plugin-babel": "catalog:",
+    "@rollup/plugin-typescript": "catalog:",
+    "babel-preset-alloy": "catalog:",
+    "concurrently": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "overrides": {
     "esbuild": "0.23"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,87 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@babel/cli':
+      specifier: ^7.24.7
+      version: 7.24.8
+    '@babel/core':
+      specifier: ^7.24.7
+      version: 7.25.2
+    '@babel/generator':
+      specifier: ^7.25.0
+      version: 7.25.0
+    '@babel/helper-module-imports':
+      specifier: 7.18.6
+      version: 7.18.6
+    '@babel/plugin-syntax-jsx':
+      specifier: ^7.18.6
+      version: 7.24.7
+    '@babel/preset-typescript':
+      specifier: ^7.24.7
+      version: 7.24.7
+    '@babel/types':
+      specifier: ^7.20.7
+      version: 7.25.2
+    '@rollup/plugin-babel':
+      specifier: ^6.0.4
+      version: 6.0.4
+    '@rollup/plugin-node-resolve':
+      specifier: ^15.2.3
+      version: 15.2.3
+    '@rollup/plugin-typescript':
+      specifier: ^11.1.6
+      version: 11.1.6
+    '@types/babel__core':
+      specifier: ^7.20.5
+      version: 7.20.5
+    '@types/babel__generator':
+      specifier: ^7.6.8
+      version: 7.6.8
+    '@types/babel__traverse':
+      specifier: ^7.20.6
+      version: 7.20.6
+    '@types/node':
+      specifier: ^20.14.12
+      version: 20.14.15
+    '@vue/reactivity':
+      specifier: ^3.4.30
+      version: 3.4.37
+    babel-plugin-tester:
+      specifier: ^11.0.4
+      version: 11.0.4
+    change-case:
+      specifier: ^5.4.4
+      version: 5.4.4
+    concurrently:
+      specifier: ^8.2.2
+      version: 8.2.2
+    html-entities:
+      specifier: 2.3.3
+      version: 2.3.3
+    pathe:
+      specifier: ^1.1.2
+      version: 1.1.2
+    prettier:
+      specifier: ^3.3.3
+      version: 3.3.3
+    rimraf:
+      specifier: ^6.0.1
+      version: 6.0.1
+    rollup:
+      specifier: ^4.18.1
+      version: 4.20.0
+    typescript:
+      specifier: ^5.5.4
+      version: 5.5.4
+    validate-html-nesting:
+      specifier: ^1.2.1
+      version: 1.2.2
+    vitest:
+      specifier: ^2.0.5
+      version: 2.0.5
+
 overrides:
   esbuild: '0.23'
 
@@ -12,219 +93,219 @@ importers:
   .:
     devDependencies:
       '@babel/preset-typescript':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.24.7(@babel/core@7.25.2)
       babel-preset-alloy:
         specifier: workspace:~
         version: link:packages/babel-preset-alloy
       concurrently:
-        specifier: ^8.2.2
+        specifier: 'catalog:'
         version: 8.2.2
       prettier:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
       rimraf:
-        specifier: ^6.0.1
+        specifier: 'catalog:'
         version: 6.0.1
       vitest:
-        specifier: ^2.0.5
+        specifier: 'catalog:'
         version: 2.0.5(@types/node@22.2.0)
 
   packages/babel-plugin-alloy:
     dependencies:
       '@babel/core':
-        specifier: ^7.20.12
+        specifier: ^7.24.7
         version: 7.25.2
       '@babel/generator':
-        specifier: ^7.25.0
+        specifier: 'catalog:'
         version: 7.25.0
       '@babel/helper-module-imports':
-        specifier: 7.18.6
+        specifier: 'catalog:'
         version: 7.18.6
       '@babel/plugin-syntax-jsx':
-        specifier: ^7.18.6
+        specifier: 'catalog:'
         version: 7.24.7(@babel/core@7.25.2)
       '@babel/types':
-        specifier: ^7.20.7
+        specifier: 'catalog:'
         version: 7.25.2
     devDependencies:
       '@types/babel__core':
-        specifier: ^7.20.5
+        specifier: 'catalog:'
         version: 7.20.5
       '@types/babel__generator':
-        specifier: ^7.6.8
+        specifier: 'catalog:'
         version: 7.6.8
       '@types/babel__traverse':
-        specifier: ^7.20.6
+        specifier: 'catalog:'
         version: 7.20.6
       babel-plugin-tester:
-        specifier: ^11.0.4
+        specifier: 'catalog:'
         version: 11.0.4(@babel/core@7.25.2)
       typescript:
-        specifier: ^5.5.4
+        specifier: 'catalog:'
         version: 5.5.4
       vitest:
-        specifier: ^2.0.5
+        specifier: 'catalog:'
         version: 2.0.5(@types/node@22.2.0)
 
   packages/babel-plugin-jsx-dom-expressions:
     dependencies:
       '@babel/helper-module-imports':
-        specifier: 7.18.6
+        specifier: 'catalog:'
         version: 7.18.6
       '@babel/plugin-syntax-jsx':
-        specifier: ^7.18.6
+        specifier: 'catalog:'
         version: 7.24.7(@babel/core@7.25.2)
       '@babel/types':
-        specifier: ^7.20.7
+        specifier: 'catalog:'
         version: 7.25.2
       html-entities:
-        specifier: 2.3.3
+        specifier: 'catalog:'
         version: 2.3.3
       validate-html-nesting:
-        specifier: ^1.2.1
+        specifier: 'catalog:'
         version: 1.2.2
     devDependencies:
       '@babel/core':
-        specifier: ^7.20.12
+        specifier: 'catalog:'
         version: 7.25.2
       '@rollup/plugin-node-resolve':
-        specifier: ^15.2.3
+        specifier: 'catalog:'
         version: 15.2.3(rollup@4.20.0)
       rollup:
-        specifier: ^4.18.1
+        specifier: 'catalog:'
         version: 4.20.0
 
   packages/babel-preset-alloy:
     dependencies:
       '@alloy-js/babel-plugin-alloy':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../babel-plugin-alloy
       '@alloy-js/babel-plugin-jsx-dom-expressions':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../babel-plugin-jsx-dom-expressions
 
   packages/core:
     dependencies:
       '@babel/core':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.25.2
       '@babel/preset-typescript':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.24.7(@babel/core@7.25.2)
       '@vue/reactivity':
-        specifier: ^3.4.30
+        specifier: 'catalog:'
         version: 3.4.37
       babel-preset-alloy:
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../babel-preset-alloy
       pathe:
-        specifier: ^1.1.2
+        specifier: 'catalog:'
         version: 1.1.2
     devDependencies:
       '@babel/cli':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.24.8(@babel/core@7.25.2)
       '@rollup/plugin-babel':
-        specifier: ^6.0.4
+        specifier: 'catalog:'
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.20.0)
       '@rollup/plugin-typescript':
-        specifier: ^11.1.6
+        specifier: 'catalog:'
         version: 11.1.6(rollup@4.20.0)(tslib@2.6.3)(typescript@5.5.4)
       concurrently:
-        specifier: ^8.2.2
+        specifier: 'catalog:'
         version: 8.2.2
       typescript:
-        specifier: ^5.5.4
+        specifier: 'catalog:'
         version: 5.5.4
       vitest:
-        specifier: ^2.0.5
+        specifier: 'catalog:'
         version: 2.0.5(@types/node@22.2.0)
 
   packages/prettier-plugin-alloy:
     devDependencies:
       prettier:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.3.3
       typescript:
-        specifier: ^5.5.2
+        specifier: 'catalog:'
         version: 5.5.4
       vitest:
-        specifier: ^2.0.5
+        specifier: 'catalog:'
         version: 2.0.5(@types/node@22.2.0)
 
   packages/sample:
     dependencies:
       '@alloy-js/core':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../core
       '@alloy-js/typescript':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../typescript
     devDependencies:
       '@babel/cli':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.24.8(@babel/core@7.25.2)
       '@babel/preset-typescript':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.24.7(@babel/core@7.25.2)
       '@rollup/plugin-babel':
-        specifier: ^6.0.4
+        specifier: 'catalog:'
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.20.0)
       '@rollup/plugin-typescript':
-        specifier: ^11.1.6
+        specifier: 'catalog:'
         version: 11.1.6(rollup@4.20.0)(tslib@2.6.3)(typescript@5.5.4)
       '@types/node':
-        specifier: ^20.14.12
+        specifier: 'catalog:'
         version: 20.14.15
       babel-preset-alloy:
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../babel-preset-alloy
       concurrently:
-        specifier: ^8.2.2
+        specifier: 'catalog:'
         version: 8.2.2
       typescript:
-        specifier: ^5.5.4
+        specifier: 'catalog:'
         version: 5.5.4
       vitest:
-        specifier: ^2.0.5
+        specifier: 'catalog:'
         version: 2.0.5(@types/node@20.14.15)
 
   packages/typescript:
     dependencies:
       '@alloy-js/core':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../core
       change-case:
-        specifier: ^5.4.4
+        specifier: 'catalog:'
         version: 5.4.4
       pathe:
-        specifier: ^1.1.2
+        specifier: 'catalog:'
         version: 1.1.2
     devDependencies:
       '@babel/cli':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.24.8(@babel/core@7.25.2)
       '@babel/preset-typescript':
-        specifier: ^7.24.7
+        specifier: 'catalog:'
         version: 7.24.7(@babel/core@7.25.2)
       '@rollup/plugin-babel':
-        specifier: ^6.0.4
+        specifier: 'catalog:'
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.20.0)
       '@rollup/plugin-typescript':
-        specifier: ^11.1.6
+        specifier: 'catalog:'
         version: 11.1.6(rollup@4.20.0)(tslib@2.6.3)(typescript@5.5.4)
       babel-preset-alloy:
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../babel-preset-alloy
       concurrently:
-        specifier: ^8.2.2
+        specifier: 'catalog:'
         version: 8.2.2
       typescript:
-        specifier: ^5.5.4
+        specifier: 'catalog:'
         version: 5.5.4
       vitest:
-        specifier: ^2.0.5
+        specifier: 'catalog:'
         version: 2.0.5(@types/node@22.2.0)
 
 packages:
@@ -1764,11 +1845,13 @@ snapshots:
   '@rollup/plugin-babel@6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.20.0)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.24.7
       '@rollup/pluginutils': 5.1.0(rollup@4.20.0)
     optionalDependencies:
       '@types/babel__core': 7.20.5
       rollup: 4.20.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@4.20.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,6 @@
 packages:
   - packages/*
 catalog:
-  "@alloy-js/babel-plugin-alloy": 1.0.0
-  "@alloy-js/babel-plugin-jsx-dom-expressions": 0.37.21
-  "@alloy-js/core": 1.0.0
-  "@alloy-js/typescript": 1.0.0
   "@babel/cli": ^7.24.7
   "@babel/core": ^7.24.7
   "@babel/generator": ^7.25.0
@@ -21,7 +17,6 @@ catalog:
   "@types/node": ^20.14.12
   "@vue/reactivity": ^3.4.30
   babel-plugin-tester: ^11.0.4
-  babel-preset-alloy: 1.0.0
   change-case: ^5.4.4
   concurrently: ^8.2.2
   html-entities: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,34 @@
 packages:
-  - "packages/*"
+  - packages/*
+catalog:
+  "@alloy-js/babel-plugin-alloy": 1.0.0
+  "@alloy-js/babel-plugin-jsx-dom-expressions": 0.37.21
+  "@alloy-js/core": 1.0.0
+  "@alloy-js/typescript": 1.0.0
+  "@babel/cli": ^7.24.7
+  "@babel/core": ^7.24.7
+  "@babel/generator": ^7.25.0
+  "@babel/helper-module-imports": 7.18.6
+  "@babel/plugin-syntax-jsx": ^7.18.6
+  "@babel/preset-typescript": ^7.24.7
+  "@babel/types": ^7.20.7
+  "@rollup/plugin-babel": ^6.0.4
+  "@rollup/plugin-node-resolve": ^15.2.3
+  "@rollup/plugin-typescript": ^11.1.6
+  "@types/babel__core": ^7.20.5
+  "@types/babel__generator": ^7.6.8
+  "@types/babel__traverse": ^7.20.6
+  "@types/node": ^20.14.12
+  "@vue/reactivity": ^3.4.30
+  babel-plugin-tester: ^11.0.4
+  babel-preset-alloy: 1.0.0
+  change-case: ^5.4.4
+  concurrently: ^8.2.2
+  html-entities: 2.3.3
+  pathe: ^1.1.2
+  prettier: ^3.3.3
+  rimraf: ^6.0.1
+  rollup: ^4.18.1
+  typescript: ^5.5.4
+  validate-html-nesting: ^1.2.1
+  vitest: ^2.0.5


### PR DESCRIPTION
Allows us to use the same version across packages without extra tools to make sure they are. Reducing diffs when upgrading