### PR TITLE
update typescript component exports to reference js instead of jsx

### DIFF
--- a/packages/typescript/src/components/index.ts
+++ b/packages/typescript/src/components/index.ts
@@ -16,5 +16,5 @@ export * from "./Interface.js";
 export * from "./ExportStatement.js";
 export * from "./Name.js";
 export * from "./TsConfigJson.js";
-export * from "./EnumDeclaration.jsx";
-export * from "./EnumMember.jsx";
+export * from "./EnumDeclaration.js";
+export * from "./EnumMember.js";


### PR DESCRIPTION
Noticed some issues when trying to actually import the package due to referencing `jsx` files.