### PR TITLE
Remove debugger from FunctionDeclaration

### DIFF
--- a/packages/typescript/src/components/FunctionDeclaration.tsx
+++ b/packages/typescript/src/components/FunctionDeclaration.tsx
@@ -66,7 +66,6 @@ export interface FunctionParametersProps {
 FunctionDeclaration.Parameters = taggedComponent(
   functionParametersTag,
   function Parameters(props: FunctionParametersProps) {
-    debugger;
     const namePolicy = useTSNamePolicy();
 
     let value;


### PR DESCRIPTION
Removing `debugger;` from FunctionDeclaration