### PR TITLE
Interface member optional and readonly

### DIFF
--- a/packages/typescript/src/components/Interface.tsx
+++ b/packages/typescript/src/components/Interface.tsx
@@ -34,14 +34,18 @@ export interface InterfaceMemberProps {
   indexer?: Children;
   type?: Children;
   children?: Children;
+  optional?: boolean;
+  readonly?: boolean;
 }
 
 export function InterfaceMember(props: InterfaceMemberProps) {
   const namer = useTSNamePolicy();
   const type = props.type ?? props.children;
+  const optionality = props.optional ? "?" : "";
+  const readonly = props.readonly ? "readonly " : "";
   if (props.indexer) {
     return <>[{props.indexer}]: {type}</>;
   } else {
-    return <>{namer.getName(props.name!, "interface-member")}: {type}</>;
+    return <>{readonly}{namer.getName(props.name!, "interface-member")}{optionality}: {type}</>;
   }
 }

--- a/packages/typescript/test/interface.test.tsx
+++ b/packages/typescript/test/interface.test.tsx
@@ -57,6 +57,42 @@ it("can create members", () => {
   `);
 });
 
+it("can create optional members", () => {
+  const res = toSourceText(
+    <ts.InterfaceDeclaration name="Foo">
+      <ts.InterfaceMember name="member" type="string" />;
+      <ts.InterfaceMember optional name="circular" type={<Reference refkey={refkey("Foo")} />} />;
+      <ts.InterfaceMember indexer="str: string" type="number" />;
+    </ts.InterfaceDeclaration>,
+  );
+
+  expect(res).toEqual(d`
+    interface Foo {
+      member: string;
+      circular?: Foo;
+      [str: string]: number;
+    }
+  `);
+});
+
+it("can create readonly members", () => {
+  const res = toSourceText(
+    <ts.InterfaceDeclaration name="Foo">
+      <ts.InterfaceMember readonly name="member" type="string" />;
+      <ts.InterfaceMember name="circular" type={<Reference refkey={refkey("Foo")} />} />;
+      <ts.InterfaceMember indexer="str: string" type="number" />;
+    </ts.InterfaceDeclaration>,
+  );
+
+  expect(res).toEqual(d`
+    interface Foo {
+      readonly member: string;
+      circular: Foo;
+      [str: string]: number;
+    }
+  `);
+});
+
 it("has interface expressions", () => {
   const res = toSourceText(
     <ts.InterfaceExpression>


### PR DESCRIPTION
Add props to set an interface member as optional and readonly