### PR TITLE
Support async function declarations

### DIFF
--- a/packages/typescript/src/components/FunctionDeclaration.tsx
+++ b/packages/typescript/src/components/FunctionDeclaration.tsx
@@ -66,11 +66,9 @@ function getReturnType(
   returnType: string | undefined,
   options: { async?: boolean } = { async: false },
 ) {
-  if (!returnType) {
-    return options.async ? "Promise<void>" : undefined;
+  if (returnType) {
+    return options.async ? `Promise<${returnType}>` : returnType;
   }
-
-  return options.async ? `Promise<${returnType}>` : returnType;
 }
 export interface FunctionParametersProps {
   parameters?: Record<string, Children | ParameterDescriptor>;

--- a/packages/typescript/src/components/FunctionDeclaration.tsx
+++ b/packages/typescript/src/components/FunctionDeclaration.tsx
@@ -28,6 +28,7 @@ function isParameterDescriptor(
 }
 export interface FunctionDeclarationProps
   extends Omit<DeclarationProps, "nameKind"> {
+  async?: boolean;
   parameters?: Record<string, Children | ParameterDescriptor>;
   returnType?: string;
   children?: Children;
@@ -41,7 +42,8 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
   const parametersChild = findKeyedChild(children, functionParametersTag);
   const bodyChild = findKeyedChild(children, functionBodyTag);
   const filteredChildren = findUnkeyedChildren(children);
-  const sReturnType = props.returnType ? <>: {props.returnType}</> : undefined;
+  const returnType = getReturnType(props.returnType, { async: props.async });
+  const sReturnType = returnType ? <>: {returnType}</> : undefined;
 
   const sParams =
     parametersChild ?? <FunctionDeclaration.Parameters parameters={props.parameters} />;
@@ -49,8 +51,10 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
   let sBody =
     bodyChild ?? <FunctionDeclaration.Body>{filteredChildren}</FunctionDeclaration.Body>;
 
+  const asyncKwd = props.async ? "async " : "";
+
   return <Declaration {...props} nameKind="function">
-      function <Name /><Scope name={props.name} kind="function">
+      {asyncKwd}function <Name /><Scope name={props.name} kind="function">
         ({sParams}){sReturnType} {"{"}
           {sBody}
         {"}"}
@@ -58,6 +62,16 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
     </Declaration>;
 }
 
+function getReturnType(
+  returnType: string | undefined,
+  options: { async?: boolean } = { async: false }
+) {
+  if (!returnType) {
+    return options.async ? 'Promise<void>' : undefined;
+  }
+
+  return options.async ? `Promise<${returnType}>` : returnType;
+}
 export interface FunctionParametersProps {
   parameters?: Record<string, Children | ParameterDescriptor>;
   children?: Children;

--- a/packages/typescript/src/components/FunctionDeclaration.tsx
+++ b/packages/typescript/src/components/FunctionDeclaration.tsx
@@ -64,10 +64,10 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
 
 function getReturnType(
   returnType: string | undefined,
-  options: { async?: boolean } = { async: false }
+  options: { async?: boolean } = { async: false },
 ) {
   if (!returnType) {
-    return options.async ? 'Promise<void>' : undefined;
+    return options.async ? "Promise<void>" : undefined;
   }
 
   return options.async ? `Promise<${returnType}>` : returnType;

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -38,6 +38,24 @@ it("can be a default export", () => {
     `);
 });
 
+it("can be an async function", () => {
+  expect(toSourceText(<FunctionDeclaration async export name="foo" />))
+  .toBe(d`
+    export async function foo(): Promise<void> {
+      
+    }
+  `);
+});
+
+it("can be an async function with returnType", () => {
+  expect(toSourceText(<FunctionDeclaration async export name="foo" returnType="Foo"/>))
+  .toBe(d`
+    export async function foo(): Promise<Foo> {
+      
+    }
+  `);
+});
+
 it("supports parameters by element", () => {
   const decl =
     <FunctionDeclaration name="foo">

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -39,8 +39,7 @@ it("can be a default export", () => {
 });
 
 it("can be an async function", () => {
-  expect(toSourceText(<FunctionDeclaration async export name="foo" />))
-  .toBe(d`
+  expect(toSourceText(<FunctionDeclaration async export name="foo" />)).toBe(d`
     export async function foo(): Promise<void> {
       
     }
@@ -48,8 +47,11 @@ it("can be an async function", () => {
 });
 
 it("can be an async function with returnType", () => {
-  expect(toSourceText(<FunctionDeclaration async export name="foo" returnType="Foo"/>))
-  .toBe(d`
+  expect(
+    toSourceText(
+      <FunctionDeclaration async export name="foo" returnType="Foo"/>,
+    ),
+  ).toBe(d`
     export async function foo(): Promise<Foo> {
       
     }

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -40,7 +40,7 @@ it("can be a default export", () => {
 
 it("can be an async function", () => {
   expect(toSourceText(<FunctionDeclaration async export name="foo" />)).toBe(d`
-    export async function foo(): Promise<void> {
+    export async function foo() {
       
     }
   `);


### PR DESCRIPTION
Adds an `async` prop to function declaration and handles the return type to be wrapped by a Promise