### PR TITLE
Function Declarartion can take Children as return type

### DIFF
--- a/packages/typescript/src/components/FunctionDeclaration.tsx
+++ b/packages/typescript/src/components/FunctionDeclaration.tsx
@@ -1,5 +1,6 @@
 import {
   childrenArray,
+  code,
   findKeyedChild,
   findUnkeyedChildren,
   mapJoin,
@@ -30,7 +31,7 @@ export interface FunctionDeclarationProps
   extends Omit<DeclarationProps, "nameKind"> {
   async?: boolean;
   parameters?: Record<string, Children | ParameterDescriptor>;
-  returnType?: string;
+  returnType?: Children;
   children?: Children;
 }
 
@@ -63,11 +64,11 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
 }
 
 function getReturnType(
-  returnType: string | undefined,
+  returnType: Children | undefined,
   options: { async?: boolean } = { async: false },
 ) {
   if (returnType) {
-    return options.async ? `Promise<${returnType}>` : returnType;
+    return options.async ? code`Promise<${returnType}>` : returnType;
   }
 }
 export interface FunctionParametersProps {

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -1,4 +1,4 @@
-import { refkey } from "@alloy-js/core";
+import { Props, refkey } from "@alloy-js/core";
 import { d } from "@alloy-js/core/testing";
 import { describe, expect, it } from "vitest";
 import { FunctionDeclaration, VarDeclaration } from "../src/index.js";
@@ -50,6 +50,21 @@ it("can be an async function with returnType", () => {
   expect(
     toSourceText(
       <FunctionDeclaration async export name="foo" returnType="Foo"/>,
+    ),
+  ).toBe(d`
+    export async function foo(): Promise<Foo> {
+      
+    }
+  `);
+});
+
+it("can be an async function with returnType element", () => {
+  function Foo(_props?: Props) {
+    return <>Foo</>;
+  }
+  expect(
+    toSourceText(
+      <FunctionDeclaration async export name="foo" returnType={<Foo />}/>,
     ),
   ).toBe(d`
     export async function foo(): Promise<Foo> {


### PR DESCRIPTION
Function Declarartion can take Children as return type instead of just a string