### PR TITLE
Remove trailing semicolon

### DIFF
--- a/packages/typescript/src/components/FunctionCallExpression.tsx
+++ b/packages/typescript/src/components/FunctionCallExpression.tsx
@@ -10,6 +10,6 @@ export function FunctionCallExpression(props: FunctionCallExpressionProps) {
     mapJoin(props.args, (arg) => arg, { joiner: ", " })
   : null;
   return <>
-        <Reference refkey={props.refkey} />({args});
+        <Reference refkey={props.refkey} />({args})
     </>;
 }

--- a/packages/typescript/test/function-call-expression.test.tsx
+++ b/packages/typescript/test/function-call-expression.test.tsx
@@ -21,11 +21,11 @@ it("can declare and call a function with parameters", () => {
                 console.log(message);
                 if(baz) console.log(baz)
             </FunctionDeclaration>
-            <FunctionCallExpression refkey={functionRefkey} args={[`"Hello!"`]} />
-            <FunctionCallExpression refkey={functionRefkey} />
-            <FunctionCallExpression refkey={functionRefkey} args={[<>"Hello {<>World</>}!"</>]} />
-            <FunctionCallExpression refkey={functionRefkey} args={[<>"Hey there!"</>]} />
-            <FunctionCallExpression refkey={functionRefkey} args={[<>"Hello World"</>, <>12345</>]} />
+            <FunctionCallExpression refkey={functionRefkey} args={[`"Hello!"`]} />;
+            <FunctionCallExpression refkey={functionRefkey} />;
+            <FunctionCallExpression refkey={functionRefkey} args={[<>"Hello {<>World</>}!"</>]} />;
+            <FunctionCallExpression refkey={functionRefkey} args={[<>"Hey there!"</>]} />;
+            <FunctionCallExpression refkey={functionRefkey} args={[<>"Hello World"</>, <>12345</>]} />;
           </SourceFile>
         </PackageDirectory>
       </Output>,


### PR DESCRIPTION
Remove trailing semicolon to FunctionCallExpression, there are scenarios where the semicolon is not valid. For example

```ts
const foo = {
   bar: fnCall()
}
```