### PR TITLE
Change type of parameters prop to guarantee emitting parameters in order of insertion

### DIFF
--- a/packages/sample/src/index.tsx
+++ b/packages/sample/src/index.tsx
@@ -7,10 +7,10 @@ const result = ay.render(
   <ay.Output externals={[ts.node.fs]}>
   <ts.PackageDirectory name="greeting-lib" path="greeting-lib" version="1.0.0">
     <ts.SourceFile path="greetings.ts">
-      <ts.FunctionDeclaration name="getGreeting" parameters={{
-        foo: "string",
-        bar: "string"
-      }}>
+      <ts.FunctionDeclaration name="getGreeting" parameters={[[
+        "foo", "string"],
+        ["bar", "string"]
+        ]}>
         <ts.VarDeclaration name="foo">"string"</ts.VarDeclaration>
         return "Hello world!";
       </ts.FunctionDeclaration>

--- a/packages/typescript/src/components/FunctionDeclaration.tsx
+++ b/packages/typescript/src/components/FunctionDeclaration.tsx
@@ -30,7 +30,7 @@ function isParameterDescriptor(
 }
 export interface FunctionDeclarationProps extends BaseDeclarationProps {
   async?: boolean;
-  parameters?: Record<string, Children | ParameterDescriptor>;
+  parameters?: [string, Children | ParameterDescriptor][];
   returnType?: Children;
   children?: Children;
 }
@@ -72,7 +72,7 @@ function getReturnType(
   }
 }
 export interface FunctionParametersProps {
-  parameters?: Record<string, Children | ParameterDescriptor>;
+  parameters?: [string, Children | ParameterDescriptor][];
   children?: Children;
 }
 
@@ -94,8 +94,8 @@ FunctionDeclaration.Parameters = taggedComponent(
       }
 
       value = mapJoin(
-        new Map(Object.entries(props.parameters)),
-        (key, value) => {
+        props.parameters,
+        ([key, value]) => {
           const descriptor: ParameterDescriptor = isParameterDescriptor(value) ?
             value
           : {

--- a/packages/typescript/test/basic.test.tsx
+++ b/packages/typescript/test/basic.test.tsx
@@ -34,7 +34,7 @@ it("works", () => {
         <ts.FunctionDeclaration
           name={"say" + fnSpec.greeting}
           refkey={greetKey}
-          parameters={{str: "string"}}
+          parameters={[["str", "string"]]}
         >
           return "{fnSpec.greeting} " + str;
         </ts.FunctionDeclaration>
@@ -42,7 +42,7 @@ it("works", () => {
         <ts.FunctionDeclaration
           name={"say" + fnSpec.farewell}
           refkey={farewellKey}
-          parameters={{str: "string"}}
+          parameters={[["str", "string"]]}
         >
           return "{fnSpec.farewell} " + str;
         </ts.FunctionDeclaration>

--- a/packages/typescript/test/function-call-expression.test.tsx
+++ b/packages/typescript/test/function-call-expression.test.tsx
@@ -16,7 +16,7 @@ it("can declare and call a function with parameters", () => {
         <PackageDirectory path="." name="test" version="1.0.0">
           <SourceFile path="index.ts">
             <VarDeclaration name="foo" value={`"Foo"`} const />
-            <FunctionDeclaration refkey={functionRefkey} name="bar" parameters={{"foo?": "string", "baz?": "number"}} >
+            <FunctionDeclaration refkey={functionRefkey} name="bar" parameters={[["foo?", "string"], ["baz?", "number"]]} >
                 const message = foo ? foo : "Hello, World!";
                 console.log(message);
                 if(baz) console.log(baz)

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -148,7 +148,7 @@ describe("symbols", () => {
 
     const decl =
       <>
-        <FunctionDeclaration name="foo" parameters={{sym: { type: "any", refkey: rk }}}>
+        <FunctionDeclaration name="foo" parameters={[["sym", { type: "any", refkey: rk }]]}>
           <FunctionDeclaration name="bar">
             {rk}
           </FunctionDeclaration>
@@ -167,7 +167,7 @@ describe("symbols", () => {
   it("creates symbols for parameters and addresses conflicts", () => {
     const decl =
       <>
-        <FunctionDeclaration name="foo" parameters={{conflict: "any"}}>
+        <FunctionDeclaration name="foo" parameters={[["conflict", "any"]]}>
           <VarDeclaration name="conflict">1</VarDeclaration>
         </FunctionDeclaration>
       </>;
@@ -187,7 +187,7 @@ describe("symbols", () => {
     };
     const decl =
       <>
-        <FunctionDeclaration name="foo" parameters={{foo: paramDesc}}>
+        <FunctionDeclaration name="foo" parameters={[["foo", paramDesc]]}>
           console.log(foo);
         </FunctionDeclaration>
       </>;


### PR DESCRIPTION
This is to avoid cases where a param rename shuffles all the parameters around. We need control also to guarantee that optional parameters are inserted at the end.