### PR TITLE
Improved parameters and class constructors

### DIFF
--- a/packages/csharp/src/components/Enum.tsx
+++ b/packages/csharp/src/components/Enum.tsx
@@ -7,6 +7,7 @@ import { Name } from "./Name.jsx";
 
 // properties for creating an enum
 export interface EnumProps extends Omit<core.DeclarationProps, "nameKind"> {
+  name: string;
   accessModifier?: AccessModifier;
 }
 
@@ -29,7 +30,7 @@ export function Enum(props: EnumProps) {
     scope.binder,
     scope,
     thisEnumSymbol,
-    "enum",
+    "enum-decl",
   );
 
   return <core.Declaration symbol={thisEnumSymbol}>
@@ -54,12 +55,20 @@ export interface EnumMemberProps {
 // a member within a C# enum
 export function EnumMember(props: EnumMemberProps) {
   const scope = useCSharpScope();
-  if (scope.kind === "member" && scope.name !== "enum") {
-    throw new Error("can't define an enum member outside of an enum scope");
+  if (scope.kind === "member" && scope.name !== "enum-decl") {
+    throw new Error(
+      "can't define an enum member outside of an enum-decl scope",
+    );
   }
-  const name = useCSharpNamePolicy().getName(props.name, "enum-member");
 
-  return <core.Declaration name={name} refkey={props.refkey}>
+  const name = useCSharpNamePolicy().getName(props.name, "enum-member");
+  const thisEnumValueSymbol = scope.binder.createSymbol<CSharpOutputSymbol>({
+    name: name,
+    scope,
+    refkey: props.refkey ?? core.refkey(props.name),
+  });
+
+  return <core.Declaration symbol={thisEnumValueSymbol}>
       <Name />
     </core.Declaration>;
 }

--- a/packages/csharp/src/components/Parameters.tsx
+++ b/packages/csharp/src/components/Parameters.tsx
@@ -1,17 +1,51 @@
 import * as core from "@alloy-js/core";
 import { useCSharpNamePolicy } from "../name-policy.js";
+import { CSharpOutputSymbol } from "../symbols/csharp-output-symbol.js";
+import { useCSharpScope } from "../symbols/scopes.js";
+import { Name } from "./Name.js";
+
+export interface ParameterProps {
+  name: string;
+  type: core.Children;
+  refkey?: core.Refkey;
+  symbol?: core.OutputSymbol;
+}
+
+// a constructor/method parameter
+export function Parameter(props: ParameterProps) {
+  const name = useCSharpNamePolicy().getName(props.name, "parameter");
+  const scope = useCSharpScope();
+  if (
+    scope.kind !== "member" ||
+    (scope.name !== "constructor-decl" && scope.name !== "method-decl")
+  ) {
+    throw new Error(
+      "can't define a parameter outside of a constructor-decl or method-decl scope",
+    );
+  }
+
+  const memberSymbol = scope.binder.createSymbol<CSharpOutputSymbol>({
+    name: name,
+    scope,
+    refkey: props.refkey ?? core.refkey(props.name),
+  });
+
+  return <core.Declaration symbol={memberSymbol}>
+      {props.type} <Name />
+    </core.Declaration>;
+}
 
 export interface ParametersProps {
   // param name and type
-  parameters: Record<string, core.Child>;
+  parameters: Array<ParameterProps>;
 }
 
-// param names and type
+// a collection of parameters
 export function Parameters(props: ParametersProps): Array<core.Child | string> {
   return core.mapJoin(
-    new Map(Object.entries(props.parameters)),
-    (name, type) => {
-      return [type, " ", useCSharpNamePolicy().getName(name, "parameter")];
+    props.parameters,
+    (param) => {
+      return <Parameter {...param} />;
     },
     { joiner: ", " },
   );

--- a/packages/csharp/src/components/ProjectDirectory.tsx
+++ b/packages/csharp/src/components/ProjectDirectory.tsx
@@ -18,6 +18,9 @@ export interface ProjectDirectoryProps {
   // directory name for source files. defaults to "src"
   srcDir?: string;
 
+  // the .NET TFM for this project. defaults to net8.0
+  targetFrameworkMoniker?: string;
+
   // child components of the project
   children?: core.Children;
 }
@@ -28,6 +31,10 @@ export function ProjectDirectory(props: ProjectDirectoryProps) {
     props.srcDir = "src";
   }
 
+  if (!props.targetFrameworkMoniker) {
+    props.targetFrameworkMoniker = "net8.0";
+  }
+
   return <core.SourceDirectory path={join(props.path, props.name)}>
     <core.SourceFile path={props.name+".csproj"} filetype="xml">
       {core.code`
@@ -35,6 +42,7 @@ export function ProjectDirectory(props: ProjectDirectoryProps) {
           <PropertyGroup>
             <Version>${props.version}</Version>
             <Description>${props.description}</Description>
+            <TargetFramework>${props.targetFrameworkMoniker}</TargetFramework>
           </PropertyGroup>
         </Project>
       `}

--- a/packages/csharp/src/components/stc/index.ts
+++ b/packages/csharp/src/components/stc/index.ts
@@ -2,10 +2,12 @@ import * as core from "@alloy-js/core";
 import * as base from "../index.js";
 
 export const Class = core.stc(base.Class);
+export const ClassConstructor = core.stc(base.ClassConstructor);
 export const ClassMember = core.stc(base.ClassMember);
 export const ClassMethod = core.stc(base.ClassMethod);
 export const Enum = core.stc(base.Enum);
 export const EnumMember = core.stc(base.EnumMember);
+export const Parameter = core.stc(base.Parameter);
 export const Parameters = core.stc(base.Parameters);
 export const ProjectDirectory = core.stc(base.ProjectDirectory);
 export const UsingDirective = core.stc(base.UsingDirective);

--- a/packages/csharp/src/name-policy.ts
+++ b/packages/csharp/src/name-policy.ts
@@ -11,7 +11,8 @@ export type CSharpElements =
   | "interface"
   | "class-member"
   | "class-method"
-  | "parameter";
+  | "parameter"
+  | "type-parameter";
 
 // creates the C# naming policy
 export function createCSharpNamePolicy(): core.NamePolicy<CSharpElements> {
@@ -22,6 +23,7 @@ export function createCSharpNamePolicy(): core.NamePolicy<CSharpElements> {
       case "enum-member":
       case "interface":
       case "class-method":
+      case "type-parameter":
         return changecase.pascalCase(name);
       case "constant":
         return changecase.constantCase(name);

--- a/packages/csharp/src/symbols/scopes.ts
+++ b/packages/csharp/src/symbols/scopes.ts
@@ -20,7 +20,11 @@ export function createCSharpNamespaceScope(
 }
 
 // the kind of member scope. i.e. are we in an enum, class, etc
-export type CSharpMemberScopeName = "class" | "enum" | "method";
+export type CSharpMemberScopeName =
+  | "class-decl"
+  | "constructor-decl"
+  | "enum-decl"
+  | "method-decl";
 
 // indicates that the scope for a symbol resides within a type
 // e.g. for an enum value, class field etc, these would have

--- a/packages/csharp/test/projectdirectory.test.tsx
+++ b/packages/csharp/test/projectdirectory.test.tsx
@@ -30,6 +30,58 @@ it("defines a project directory file with multiple source files", () => {
       <PropertyGroup>
         <Version>0.1.0</Version>
         <Description>a test project</Description>
+        <TargetFramework>net8.0</TargetFramework>
+      </PropertyGroup>
+    </Project>
+  `);
+
+  const srcDir = projDir.contents[1] as core.OutputDirectory;
+
+  expect(srcDir.contents[0].path).equals("~/projects/TestProject/src/Test1.cs");
+  expect(srcDir.contents[0].contents).toBe(coretest.d`
+    namespace TestCode
+    {
+      public class TestClass1;
+    }
+  `);
+
+  expect(srcDir.contents[1].path).equals("~/projects/TestProject/src/Test2.cs");
+  expect(srcDir.contents[1].contents).toBe(coretest.d`
+    namespace TestCode
+    {
+      public class TestClass2;
+    }
+  `);
+});
+
+it("defines a project directory file with multiple source files and a custom TFM", () => {
+  const res = core.render(
+    <core.Output>
+      <csharp.ProjectDirectory name="TestProject" path="~/projects" version="0.1.0" description="a test project" targetFrameworkMoniker="netstandard2.1">
+        <csharp.Namespace name='TestCode'>
+          <csharp.SourceFile path="Test1.cs">
+            <csharp.Class accessModifier='public' name="TestClass1" />
+          </csharp.SourceFile>
+          <csharp.SourceFile path="Test2.cs">
+            <csharp.Class accessModifier='public' name="TestClass2" />
+          </csharp.SourceFile>
+        </csharp.Namespace>
+      </csharp.ProjectDirectory>
+    </core.Output>,
+  );
+
+  const projDir = res.contents[0] as core.OutputDirectory;
+
+  expect(projDir.path).equals("~/projects/TestProject");
+  expect(projDir.contents[0].path).equals(
+    "~/projects/TestProject/TestProject.csproj",
+  );
+  expect(projDir.contents[0].contents).toBe(coretest.d`
+    <Project Sdk="Microsoft.NET.Sdk">
+      <PropertyGroup>
+        <Version>0.1.0</Version>
+        <Description>a test project</Description>
+        <TargetFramework>netstandard2.1</TargetFramework>
       </PropertyGroup>
     </Project>
   `);

--- a/packages/csharp/test/using.test.tsx
+++ b/packages/csharp/test/using.test.tsx
@@ -36,9 +36,12 @@ it("uses multiple namespaces", () => {
 
 it("adds using statement across namespaces", () => {
   const inputTypeRefkey = core.refkey();
-  const params = {
-    BodyParam: inputTypeRefkey,
-  };
+  const params = [
+    {
+      name: "BodyParam",
+      type: inputTypeRefkey,
+    },
+  ];
 
   const res = core.render(
     <core.Output namePolicy={csharp.createCSharpNamePolicy()}>


### PR DESCRIPTION
Added Parameter so that they have symbols and can be resolved by refkey. Added ClassConstructor to emit class constructors. Name name prop for Class and ClassMethod required. Fixed scope for ClassMethod so its params have the correct scope. Added field for .NET TFM when generating the csproj file. Naming for type parameters.
Renamed some scope names to follow C# language spec.