### PR TITLE
Pascal-case public class fields

### DIFF
--- a/packages/csharp/src/components/Class.tsx
+++ b/packages/csharp/src/components/Class.tsx
@@ -5,7 +5,7 @@ import {
   getMethodModifier,
   MethodModifier,
 } from "../modifiers.js";
-import { useCSharpNamePolicy } from "../name-policy.js";
+import { CSharpElements, useCSharpNamePolicy } from "../name-policy.js";
 import { CSharpOutputSymbol } from "../symbols/csharp-output-symbol.js";
 import { createCSharpMemberScope, useCSharpScope } from "../symbols/scopes.js";
 import { Name } from "./Name.js";
@@ -133,7 +133,11 @@ export interface ClassMemberProps {
 
 // a C# class member (i.e. a field within a class like "private int count")
 export function ClassMember(props: ClassMemberProps) {
-  const name = useCSharpNamePolicy().getName(props.name, "class-member");
+  let nameElement: CSharpElements = "class-member-private";
+  if (props.accessModifier === "public") {
+    nameElement = "class-member-public";
+  }
+  const name = useCSharpNamePolicy().getName(props.name, nameElement);
   const scope = useCSharpScope();
   if (scope.kind !== "member" || scope.name !== "class-decl") {
     throw new Error(

--- a/packages/csharp/src/name-policy.ts
+++ b/packages/csharp/src/name-policy.ts
@@ -9,7 +9,8 @@ export type CSharpElements =
   | "enum-member"
   | "function"
   | "interface"
-  | "class-member"
+  | "class-member-private"
+  | "class-member-public"
   | "class-method"
   | "parameter"
   | "type-parameter";
@@ -22,6 +23,7 @@ export function createCSharpNamePolicy(): core.NamePolicy<CSharpElements> {
       case "enum":
       case "enum-member":
       case "interface":
+      case "class-member-public":
       case "class-method":
       case "type-parameter":
         return changecase.pascalCase(name);

--- a/packages/csharp/test/class.test.tsx
+++ b/packages/csharp/test/class.test.tsx
@@ -30,7 +30,7 @@ it("declares class with some members", () => {
     {
       public class TestClass
       {
-        public string memberOne;
+        public string MemberOne;
         private int memberTwo;
       }
     }
@@ -87,6 +87,9 @@ it("declares class with params and return type", () => {
 
 it("uses refkeys for members, params, and return type", () => {
   const inputTypeRefkey = core.refkey();
+  const testResultTypeRefkey = core.refkey();
+  const enumTypeRefkey = core.refkey();
+
   const params = [
     {
       name: "IntParam",
@@ -102,16 +105,16 @@ it("uses refkeys for members, params, and return type", () => {
     <core.Output namePolicy={csharp.createCSharpNamePolicy()}>
       <csharp.Namespace name='TestCode'>
         <csharp.SourceFile path="Test.cs">
-          <csharp.Enum accessModifier='public' name="TestEnum">
+          <csharp.Enum accessModifier='public' name="TestEnum" refkey={enumTypeRefkey}>
             <csharp.EnumMember name="One" />,
             <csharp.EnumMember name="Two" />
           </csharp.Enum>
           <csharp.Class accessModifier="public" name="TestInput" refkey={inputTypeRefkey} />
-          <csharp.Class accessModifier="public" name="TestResult" />
+          <csharp.Class accessModifier="public" name="TestResult" refkey={testResultTypeRefkey} />
           <csharp.Class accessModifier='public' name="TestClass">
-            <csharp.ClassMember accessModifier="private" name="MemberOne" type={core.refkey("TestEnum")} />
-            <csharp.ClassMethod accessModifier="public" name="MethodOne" parameters={params} returns={core.refkey("TestResult")}>
-              return new {core.refkey("TestResult")}();
+            <csharp.ClassMember accessModifier="private" name="MemberOne" type={enumTypeRefkey} />
+            <csharp.ClassMethod accessModifier="public" name="MethodOne" parameters={params} returns={testResultTypeRefkey}>
+              return new {testResultTypeRefkey}();
             </csharp.ClassMethod>
           </csharp.Class>
         </csharp.SourceFile>
@@ -149,8 +152,8 @@ it("declares class with generic parameters", () => {
 
   const res = utils.toSourceText(
     <csharp.Class accessModifier='public' name="TestClass" typeParameters={typeParameters}>
-      <csharp.ClassMember accessModifier="public" name="MemberOne" type={typeParameters.T} />
-      <csharp.ClassMember accessModifier="private" name="MemberTwo" type={typeParameters.U} />
+      <csharp.ClassMember accessModifier="public" name="memberOne" type={typeParameters.T} />
+      <csharp.ClassMember accessModifier="private" name="memberTwo" type={typeParameters.U} />
     </csharp.Class>,
   );
 
@@ -159,7 +162,7 @@ it("declares class with generic parameters", () => {
     {
       public class TestClass<T, U>
       {
-        public T memberOne;
+        public T MemberOne;
         private U memberTwo;
       }
     }

--- a/packages/csharp/test/using.test.tsx
+++ b/packages/csharp/test/using.test.tsx
@@ -36,6 +36,9 @@ it("uses multiple namespaces", () => {
 
 it("adds using statement across namespaces", () => {
   const inputTypeRefkey = core.refkey();
+  const outputTypeRefkey = core.refkey();
+  const twoValRefkey = core.refkey();
+
   const params = [
     {
       name: "BodyParam",
@@ -48,19 +51,19 @@ it("adds using statement across namespaces", () => {
       <csharp.Namespace name='Models'>
         <csharp.SourceFile path="Models.cs">
           <csharp.Class accessModifier='public' name="Input" refkey={inputTypeRefkey} />
-          <csharp.Class accessModifier='public' name="Output" />
+          <csharp.Class accessModifier='public' name="Output" refkey={outputTypeRefkey} />
           <csharp.Enum accessModifier='public' name="TestEnum">
             <csharp.EnumMember name="One" />,
-            <csharp.EnumMember name="Two" />
+            <csharp.EnumMember name="Two" refkey={twoValRefkey} />
           </csharp.Enum>
         </csharp.SourceFile>
       </csharp.Namespace>
       <csharp.Namespace name='Client'>
         <csharp.SourceFile path="Client.cs">
           <csharp.Class accessModifier='public' name="Client">
-            <csharp.ClassMethod accessModifier="public" name="MethodOne" parameters={params} returns={core.refkey("Output")} />
+            <csharp.ClassMethod accessModifier="public" name="MethodOne" parameters={params} returns={outputTypeRefkey} />
           </csharp.Class>
-          {core.refkey("Two")};
+          {twoValRefkey};
         </csharp.SourceFile>
       </csharp.Namespace>
     </core.Output>,


### PR DESCRIPTION
Use predefined refkeys instead of fetching a ref by name. The behavior is inconsistent and might go away in the future.