### PR TITLE
Add support for emitting JSON

### DIFF
--- a/.chronus/changes/json-2025-1-4-17-40-28.md
+++ b/.chronus/changes/json-2025-1-4-17-40-28.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/json"
+---
+
+Add JSON support.

--- a/.chronus/changes/json-2025-1-4-17-41-35.md
+++ b/.chronus/changes/json-2025-1-4-17-41-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/core"
+---
+
+* Add support for adding refkeys to symbols after symbol creation.

--- a/.chronus/changes/json-2025-1-4-17-43-33.md
+++ b/.chronus/changes/json-2025-1-4-17-43-33.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@alloy-js/typescript"
+---
+
+Adopt types changes

--- a/.chronus/changes/json-2025-1-4-17-43-6.md
+++ b/.chronus/changes/json-2025-1-4-17-43-6.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/core"
+---
+
+Improve types of JSX elements so typescript and editors can provide accurate errors when providing props to components. For example, component props can be unions of props interfaces, enabling an overload-like pattern.

--- a/.chronus/changes/json-2025-1-4-17-52-29.md
+++ b/.chronus/changes/json-2025-1-4-17-52-29.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/core"
+---
+
+Add Tappers, which allow getting a reference to contexts provided by nested components from a parent component. Useful for allowing nested components to create things like symbols when the parent component merely needs access to it but doesn't care how its created.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
       "import": "./dist/src/index.js"
     },
     "./jsx-runtime": {
+      "types": "./dist/src/jsx-runtime.d.ts",
       "development": "./src/jsx-runtime.ts",
       "import": "./dist/src/jsx-runtime.js"
     },

--- a/packages/core/src/components/Output.tsx
+++ b/packages/core/src/components/Output.tsx
@@ -7,9 +7,10 @@ import { BinderContext } from "../context/binder.js";
 import { NamePolicyContext } from "../context/name-policy.js";
 import { Children } from "../jsx-runtime.js";
 import { NamePolicy } from "../name-policy.js";
-import { SourceDirectory } from "./SourceDirectory.js";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { extensionEffects } from "../slot.js";
+import { SourceDirectory } from "./SourceDirectory.js";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { SourceFile } from "./SourceFile.js";
 
 export interface OutputProps {

--- a/packages/core/src/components/SourceDirectory.tsx
+++ b/packages/core/src/components/SourceDirectory.tsx
@@ -6,7 +6,7 @@ import { Children, getContext } from "../jsx-runtime.js";
 
 export interface SourceDirectoryProps {
   path: string;
-  children?: Children[];
+  children?: Children;
 }
 
 export function SourceDirectory(props: SourceDirectoryProps) {

--- a/packages/core/src/components/SourceFile.tsx
+++ b/packages/core/src/components/SourceFile.tsx
@@ -17,7 +17,7 @@ export interface SourceFileProps {
    */
   filetype: string;
 
-  children?: Children[];
+  children?: Children;
 
   /**
    * The component to use to render refkeys references within the file's

--- a/packages/core/src/context/member-declaration.ts
+++ b/packages/core/src/context/member-declaration.ts
@@ -1,5 +1,9 @@
 import { OutputSymbol } from "../binder.js";
-import { ComponentContext, createNamedContext } from "../context.js";
+import {
+  ComponentContext,
+  createNamedContext,
+  useContext,
+} from "../context.js";
 
 /**
  * Provides the symbol for the member currently being declared.
@@ -8,3 +12,7 @@ import { ComponentContext, createNamedContext } from "../context.js";
  */
 export const MemberDeclarationContext: ComponentContext<OutputSymbol> =
   createNamedContext("MemberDeclaration");
+
+export function useMemberDeclaration() {
+  return useContext(MemberDeclarationContext);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,5 +17,6 @@ export * from "./jsx-runtime.js";
 export * from "./name-policy.js";
 export * from "./refkey.js";
 export * from "./render.js";
+export * from "./tap.js";
 export * from "./utils.js";
 import "./debug.js";

--- a/packages/core/src/jsx-runtime.ts
+++ b/packages/core/src/jsx-runtime.ts
@@ -117,7 +117,7 @@ export function effect<T>(fn: (prev?: T) => T, current?: T) {
   cleanup(() => cleanupFn(true));
 }
 
-function cleanup(fn: Disposable) {
+export function cleanup(fn: Disposable) {
   if (globalContext != null) {
     globalContext.disposables.push(fn);
   }
@@ -129,13 +129,14 @@ export type Child =
   | number
   | undefined
   | null
-  | (() => Child | Children)
+  | void
+  | (() => Children)
   | Child[]
   | Ref
   | Refkey;
 
 export type Children = Child | Child[];
-export type Props = Record<string, unknown>;
+export type Props = Record<string, any>;
 
 export interface ComponentDefinition<TProps = Props> {
   (props: TProps): Child | Children;
@@ -213,6 +214,29 @@ function inspectProps(props: Props) {
 export function isComponentCreator(item: unknown): item is ComponentCreator {
   return typeof item === "function" && (item as any).component;
 }
+
+/**
+ * This namespace is predominantly for interop with React tooling in VSCode
+ * and controls the type of JSX elements, components, and the like.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace JSX {
+  export interface IntrinsicElements {}
+  export type ElementType = ComponentDefinition<any>;
+  export type Element = Children;
+  export interface ElementChildrenAttribute {
+    children: {};
+  }
+  export interface ElementAttributesProperty {
+    props: {};
+  }
+}
+
+export function jsx(type: Component<any>, props: Record<string, unknown>) {
+  return createComponent(type, props);
+}
+
+export const jsxs = jsx;
 
 export function createComponent<TProps extends Props = Props>(
   C: Component<TProps>,

--- a/packages/core/src/tap.ts
+++ b/packages/core/src/tap.ts
@@ -1,0 +1,69 @@
+import { ShallowRef, shallowRef } from "@vue/reactivity";
+import { OutputScope, OutputSymbol } from "./binder.js";
+import { useContext } from "./context.js";
+import { DeclarationContext } from "./context/declaration.js";
+import { MemberDeclarationContext } from "./context/member-declaration.js";
+import { useScope } from "./context/scope.js";
+import { SourceFileContext } from "./context/source-file.js";
+import { ComponentDefinition } from "./jsx-runtime.js";
+
+export interface Tap<T> extends ComponentDefinition {
+  ref: ShallowRef<T | undefined>;
+}
+
+export interface Tapper<T> {
+  (): T | undefined;
+}
+
+export interface Handler<T> {
+  (value: T): void;
+}
+
+export function createTap<T = unknown>(
+  tapper: Tapper<T>,
+  handler?: Handler<T>,
+): Tap<T> {
+  const signal = shallowRef<T | undefined>(undefined);
+  const fn = () => {
+    signal.value = tapper();
+    if (handler && signal.value !== undefined) {
+      handler(signal.value);
+    }
+
+    return "";
+  };
+
+  fn.ref = signal;
+
+  return fn;
+}
+
+export function createDeclarationTap<
+  TSymbol extends OutputSymbol = OutputSymbol,
+>(handler?: Handler<TSymbol>) {
+  return createTap<TSymbol>(() => {
+    return useContext(DeclarationContext) as any;
+  }, handler);
+}
+
+export function createMemberTap<TSymbol extends OutputSymbol = OutputSymbol>(
+  handler?: Handler<TSymbol>,
+) {
+  return createTap<TSymbol>(() => {
+    return useContext(MemberDeclarationContext) as any;
+  }, handler);
+}
+
+export function createScopeTap<TScope extends OutputScope = OutputScope>(
+  handler?: Handler<TScope>,
+) {
+  return createTap<TScope>(() => {
+    return useScope() as any;
+  }, handler);
+}
+
+export function createSourceFileTap(handler?: Handler<SourceFileContext>) {
+  return createTap(() => {
+    return useContext(SourceFileContext);
+  }, handler);
+}

--- a/packages/core/test/symbols.test.ts
+++ b/packages/core/test/symbols.test.ts
@@ -20,7 +20,6 @@ it("works", () => {
   const symbol = binder.createSymbol({
     name: "sym",
     scope,
-    refkey: "foo",
   });
 
   expect([...scope.getSymbolNames()]).toEqual(["sym"]);
@@ -41,13 +40,11 @@ it("resolves symbol conflicts", () => {
   const _s1 = binder.createSymbol({
     name: "sym",
     scope,
-    refkey: "foo",
   });
 
   const s2 = binder.createSymbol({
     name: "sym",
     scope,
-    refkey: "foo",
   });
 
   expect(s2.name).toEqual("sym_2");
@@ -504,5 +501,64 @@ describe("symbol name resolution", () => {
     });
 
     expect(result.value).toEqual(instance);
+  });
+});
+
+describe("refkey resolution", () => {
+  it("resolves existing symbols by refkey", () => {
+    const key = refkey();
+    const binder = createOutputBinder();
+    const sym = binder.createSymbol({
+      name: "foo",
+      refkey: key,
+      scope: binder.globalScope,
+    });
+
+    const resolvedSym = binder.resolveDeclarationByKey(
+      undefined,
+      undefined,
+      key,
+    );
+    expect(resolvedSym.value?.targetDeclaration).toBe(sym);
+  });
+
+  it("resolves symbols by refkey when symbol is added later", () => {
+    const key = refkey();
+    const binder = createOutputBinder();
+
+    const resolvedSym = binder.resolveDeclarationByKey(
+      undefined,
+      undefined,
+      key,
+    );
+
+    const sym = binder.createSymbol({
+      name: "foo",
+      refkey: key,
+      scope: binder.globalScope,
+    });
+
+    expect(resolvedSym.value?.targetDeclaration).toBe(sym);
+  });
+
+  it("resolves symbols by refkey when refkey is added later", () => {
+    const key = refkey();
+    const binder = createOutputBinder();
+
+    const resolvedSym = binder.resolveDeclarationByKey(
+      undefined,
+      undefined,
+      key,
+    );
+
+    const sym = binder.createSymbol({
+      name: "foo",
+      scope: binder.globalScope,
+    });
+
+    expect(resolvedSym.value).toBe(undefined);
+
+    sym.refkey = key;
+    expect(resolvedSym.value?.targetDeclaration).toBe(sym);
   });
 });

--- a/packages/docs/scripts/components/DocDeclaration.ts
+++ b/packages/docs/scripts/components/DocDeclaration.ts
@@ -1,10 +1,10 @@
 import {
-  Declaration,
   refkey,
   SourceFileContext,
   useBinder,
   useContext,
 } from "@alloy-js/core";
+import { Declaration } from "@alloy-js/core/stc";
 import type { ApiItem } from "@microsoft/api-extractor-model";
 import type { DocSymbol } from "../symbols/doc-symbol.js";
 

--- a/packages/docs/scripts/components/InterfaceMembers.ts
+++ b/packages/docs/scripts/components/InterfaceMembers.ts
@@ -17,7 +17,13 @@ export interface InterfaceMembersProps {
 export function InterfaceMembers(props: InterfaceMembersProps) {
   let members = props.iface.members as ApiItem[];
   if (props.flatten) {
-    for (const extendsType of props.iface.extendsTypes) {
+    try {
+      for (const extendsType of props.iface.extendsTypes) {
+      }
+    } catch (e) {
+      console.log("Failure to do anything with", props.iface);
+    }
+    for (const extendsType of props.iface.extendsTypes ?? []) {
       const refType = resolveExcerptReference(
         extendsType.excerpt.spannedTokens[0],
         props.iface,

--- a/packages/docs/scripts/components/SeeAlso.ts
+++ b/packages/docs/scripts/components/SeeAlso.ts
@@ -53,7 +53,7 @@ export function SeeAlso(props: SeeAlsoProps) {
 
   const contextsProvidedList =
     contextsProvided.length > 0 &&
-    MdxSection({ title: "Contexts provided", level: 3 }).children(
+    MdxSection({ title: "Contexts provided", level: 2 }).children(
       mapJoin(contextsProvided, (seeBlock) => {
         return code`
           * ${TsDoc({ node: seeBlock, context: props.type })}

--- a/packages/docs/scripts/components/TsDoc.ts
+++ b/packages/docs/scripts/components/TsDoc.ts
@@ -106,7 +106,7 @@ export interface TsDocSectionProps {
 }
 
 export function TsDocSection(props: TsDocSectionProps) {
-  return mapJoin(props.node.nodes as DocNode[], (node) => TsDoc({ node }), {
+  return mapJoin(props.node.nodes as DocNode[], (node) => stc.TsDoc({ node }), {
     joiner: "\n\n",
   });
 }

--- a/packages/docs/scripts/components/component/ComponentDoc.ts
+++ b/packages/docs/scripts/components/component/ComponentDoc.ts
@@ -1,10 +1,12 @@
+import { mapJoin, type Children } from "@alloy-js/core";
 import type { ApiItem } from "@microsoft/api-extractor-model";
 import type { ComponentApi } from "../../build-json.js";
-import { Examples } from "../Examples.js";
 import {
   ComponentProps,
   ComponentSignature,
   DocSourceFile,
+  Examples,
+  MdxSection,
   Remarks,
   SeeAlso,
   Summary,
@@ -17,14 +19,29 @@ export interface ComponentDocProps {
 export function ComponentDoc(props: ComponentDocProps) {
   const { componentFunction, componentProps } = props.component;
   const title = componentFunction.displayName;
-  const declares: ApiItem[] = [componentFunction];
-  if (componentProps) {
-    declares.push(componentProps);
+
+  let overloadBlocks: Children;
+
+  if (componentProps.length === 0) {
+    overloadBlocks = [ComponentSignature({ component: props.component })];
+  } else {
+    let index = 1;
+    if (componentProps.length > 1) debugger;
+    overloadBlocks = mapJoin(componentProps, (iface) => {
+      return MdxSection({ title: "Overload " + index++, level: 2 }).children(
+        Summary({ type: iface }),
+        ComponentSignature({ component: props.component, propsType: iface }),
+        ComponentProps({ propType: iface }),
+      );
+    });
   }
-  return DocSourceFile({ title, declares }).children(
+
+  return DocSourceFile({
+    title,
+    declares: (componentProps as ApiItem[]).concat(componentFunction),
+  }).children(
     Summary({ type: componentFunction }),
-    ComponentSignature({ component: props.component }),
-    ComponentProps({ propType: componentProps }),
+    overloadBlocks,
     Remarks({ type: componentFunction }),
     Examples({ type: componentFunction }),
     SeeAlso({ type: componentFunction, splitContexts: true }),

--- a/packages/docs/scripts/components/component/ComponentSignature.ts
+++ b/packages/docs/scripts/components/component/ComponentSignature.ts
@@ -1,9 +1,13 @@
-import type { ApiPropertySignature } from "@microsoft/api-extractor-model";
+import type {
+  ApiInterface,
+  ApiPropertySignature,
+} from "@microsoft/api-extractor-model";
 import type { ComponentApi } from "../../build-json.js";
 import { Code, MdxParagraph } from "../stc/index.js";
 
 export interface ComponentSignatureProps {
   component: ComponentApi;
+  propsType?: ApiInterface;
 }
 
 export function ComponentSignature(props: ComponentSignatureProps) {
@@ -11,9 +15,8 @@ export function ComponentSignature(props: ComponentSignatureProps) {
   let stcParamHelp = "";
 
   // construct the code snippet for the component signature
-  if (props.component.componentProps) {
-    const propType = props.component.componentProps;
-    const allParamHelp = (propType.members as ApiPropertySignature[])
+  if (props.propsType) {
+    const allParamHelp = (props.propsType.members as ApiPropertySignature[])
       .filter((prop) => prop.name !== "children")
       .map(propHelp);
 
@@ -23,7 +26,7 @@ export function ComponentSignature(props: ComponentSignatureProps) {
       paramHelp = allParamHelp.join(" ");
     }
 
-    const allStcParamHelp = (propType.members as ApiPropertySignature[])
+    const allStcParamHelp = (props.propsType.members as ApiPropertySignature[])
       .filter((prop) => prop.name !== "children")
       .map(stcPropHelp);
 
@@ -41,7 +44,7 @@ export function ComponentSignature(props: ComponentSignatureProps) {
   const jsxCode = `
     import { ${name} } from "${packageSrc}";
 
-    <${name} ${paramHelp}>
+    <${name}${paramHelp.length > 0 ? " " + paramHelp : ""}>
       {children}
     </${name}> 
   `;
@@ -49,7 +52,7 @@ export function ComponentSignature(props: ComponentSignatureProps) {
   const stcCode = `
     import { ${name} } from "${packageSrc}/stc";
 
-    ${name}({ ${stcParamHelp}}).children(children)
+    ${name}({ ${stcParamHelp} }).children(children)
   `;
 
   return MdxParagraph().code`

--- a/packages/json/api-extractor.json
+++ b/packages/json/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "../../api-extractor.base.json"
+}

--- a/packages/json/babel.config.cjs
+++ b/packages/json/babel.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  sourceMaps: true,
+  presets: ["@babel/preset-typescript", "@alloy-js/babel-preset"],
+};

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@alloy-js/json",
+  "version": "0.3.0",
+  "description": "",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./stc": {
+      "development": "./src/components/stc/index.ts",
+      "import": "./dist/src/components/stc/index.js"
+    }
+  },
+  "scripts": {
+    "build-src": "babel src -d dist/src --extensions .ts,.tsx",
+    "build-tsc": "tsc -p .",
+    "generate-docs": "api-extractor run",
+    "build": "npm run build-src && npm run build-tsc && npm run generate-docs",
+    "clean": "rimraf dist/ .temp/",
+    "watch-src": "babel src -d dist/src --extensions '.ts,.tsx' --watch",
+    "watch-tsc": "tsc -p . --watch",
+    "watch": "concurrently --kill-others \"npm run watch-src\" \"npm run watch-tsc\"",
+    "test": "vitest run"
+  },
+  "keywords": [],
+  "author": "brian.terlson@microsoft.com",
+  "license": "MIT",
+  "dependencies": {
+    "@alloy-js/core": "workspace:~",
+    "pathe": "catalog:"
+  },
+  "devDependencies": {
+    "@babel/cli": "catalog:",
+    "@babel/preset-typescript": "catalog:",
+    "@microsoft/api-extractor": "^7.47.7",
+    "@rollup/plugin-babel": "catalog:",
+    "@rollup/plugin-typescript": "catalog:",
+    "@alloy-js/babel-preset": "workspace:~",
+    "concurrently": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "type": "module"
+}

--- a/packages/json/src/components/JsonArray.tsx
+++ b/packages/json/src/components/JsonArray.tsx
@@ -1,0 +1,138 @@
+import {
+  Children,
+  mapJoin,
+  MemberDeclaration,
+  MemberScope,
+  OutputSymbolFlags,
+  Refkey,
+  useMemberDeclaration,
+  useMemberScope,
+} from "@alloy-js/core";
+import { createJsonOutputSymbol } from "../symbols/json-symbol.js";
+import { JsonValue } from "./JsonValue.jsx";
+
+export interface JsonArrayPropsBase {
+  /** The refkey for the JSON array. When provided, this value can be referenced
+   * elsewhere via this refkey.
+   **/
+  refkey?: Refkey;
+}
+
+/**
+ * Create a JSON Array by serializing the given JavaScript array to JSON.
+ */
+export interface JsonArrayPropsWithJsValue extends JsonArrayPropsBase {
+  /**
+   * The value to serialize to a JSON array.
+   */
+  jsValue: unknown[];
+}
+
+/**
+ * Create a JSON Array by providing the children. To create an array element,
+ * see {@link JsonArrayElement}.
+ */
+export interface JsonArrayPropsWithChildren extends JsonArrayPropsBase {
+  /**
+   * The contents of the JSON Array. Likely to contain {@link JsonArrayElement}
+   * components.
+   */
+  children?: Children;
+}
+
+export type JsonArrayProps =
+  | JsonArrayPropsWithJsValue
+  | JsonArrayPropsWithChildren;
+
+/**
+ * Create a JSON Array. You can provide children, or else pass a JS value that
+ * will be serialized to JSON.
+ *
+ * @see {@link @alloy-js/core#(MemberScopeContext:variable)}
+ */
+export function JsonArray(props: JsonArrayProps) {
+  const memberSymbol = useMemberDeclaration();
+  if (!memberSymbol) {
+    throw new Error("Missing assignment symbol.");
+  }
+  const binder = memberSymbol.binder;
+  binder.addStaticMembersToSymbol(memberSymbol);
+  if (props.refkey) {
+    memberSymbol.refkey = props.refkey;
+  }
+
+  if (!("jsValue" in props)) {
+    return <MemberScope owner={memberSymbol}>
+      [
+        {props.children}
+      ]
+    </MemberScope>;
+  }
+
+  const jsValue = props.jsValue ?? [];
+
+  if (jsValue.length === 0) {
+    return "[]";
+  }
+
+  const elements = mapJoin(
+    jsValue,
+    (value) => {
+      return <JsonArrayElement><JsonValue jsValue={value} /></JsonArrayElement>;
+    },
+    { joiner: ",\n" },
+  );
+
+  let contents;
+  if (jsValue.length === 1) {
+    contents = <>[{elements}]</>;
+  } else {
+    contents = <>
+      [
+        {elements}
+      ]
+    </>;
+  }
+
+  return <MemberScope owner={memberSymbol}>
+    {contents}
+  </MemberScope>;
+}
+
+export interface JsonArrayElementProps {
+  children: Children;
+}
+
+/**
+ * Create a JSON Array element. This component should be used inside of a
+ * {@link JsonArray} component.
+ *
+ * @remarks
+ *
+ * It does not add any syntax, but is required in
+ * order to establish the correct scope for the array element, allowing
+ * references to array elements to work properly.
+ *
+ * @see {@link @alloy-js/core#(MemberDeclarationContext:variable)}
+ */
+export function JsonArrayElement(props: JsonArrayElementProps) {
+  const memberScope = useMemberScope();
+  if (!memberScope) {
+    throw new Error("Missing member scope.");
+  }
+
+  if (!memberScope.staticMembers) {
+    throw new Error("Missing static members scope.");
+  }
+
+  const name = String(memberScope.staticMembers.symbols.size);
+
+  const sym = createJsonOutputSymbol({
+    name,
+    flags: OutputSymbolFlags.StaticMember,
+  });
+
+  return <MemberDeclaration symbol={sym}>
+    {props.children}
+  </MemberDeclaration>;
+}

--- a/packages/json/src/components/JsonObject.tsx
+++ b/packages/json/src/components/JsonObject.tsx
@@ -1,0 +1,150 @@
+import {
+  Children,
+  computed,
+  mapJoin,
+  MemberDeclaration,
+  MemberScope,
+  OutputSymbolFlags,
+  Refkey,
+  useMemberDeclaration,
+} from "@alloy-js/core";
+import { createJsonOutputSymbol } from "../symbols/json-symbol.js";
+import { JsonValue } from "./JsonValue.jsx";
+
+export interface JsonObjectPropsBase {
+  /** The refkey for the JSON array. When provided, this value can be referenced
+   * elsewhere via this refkey.
+   **/
+  refkey?: Refkey;
+}
+
+/**
+ * Create a JSON object by providing children that define the object's contents.
+ * The children should use the {@link JsonObjectProperty} component to define
+ * individual object properties.
+ */
+export interface JsonObjectPropsWithChildren extends JsonObjectPropsBase {
+  /**
+   * The contents of the JSON object. Likely to contain
+   * {@link JsonObjectProperty} components.
+   */
+  children: Children;
+}
+
+/**
+ * Create a JSON object by providing a JS value that will be serialized to JSON.
+ */
+export interface JsonObjectPropsWithJsValue extends JsonObjectPropsBase {
+  /**
+   * The JS value to serialize to JSON. This can be an array of key-value pairs,
+   * a map, or a vanilla JS object.
+   */
+  jsValue: [string, unknown][] | Map<string, unknown> | Record<string, unknown>;
+}
+
+export type JsonObjectProps =
+  | JsonObjectPropsWithChildren
+  | JsonObjectPropsWithJsValue;
+
+/**
+ * Create a JSON Object. An object can be created by providing a JS object
+ * value which will be serialized to JSON. Else, you can provide children that
+ * comprise the object's JSON representation.
+ *
+ * @see {@link @alloy-js/core#MemberScopeContext}
+ */
+export function JsonObject(props: JsonObjectProps) {
+  const memberSymbol = useMemberDeclaration();
+  if (!memberSymbol) {
+    throw new Error("Missing assignment symbol.");
+  }
+  const binder = memberSymbol.binder;
+  binder.addStaticMembersToSymbol(memberSymbol);
+  if (props.refkey) {
+    memberSymbol.refkey = props.refkey;
+  }
+
+  if (!("jsValue" in props)) {
+    return <MemberScope owner={memberSymbol}>
+      {"{"}
+        {props.children}
+      {"}"}
+    </MemberScope>;
+  }
+
+  const elements = computed(() => {
+    const jsValue = props.jsValue;
+    let properties: [string, unknown][];
+    if (Array.isArray(jsValue)) {
+      properties = jsValue;
+    } else if (jsValue instanceof Map) {
+      properties = [...jsValue.entries()];
+    } else if (jsValue !== undefined) {
+      properties = globalThis.Object.entries(jsValue);
+    } else {
+      properties = [];
+    }
+    const elements = mapJoin(
+      properties,
+      ([name, value]) => {
+        return <JsonObjectProperty name={name} jsValue={value} />;
+      },
+      { joiner: ",\n" },
+    );
+
+    return elements;
+  });
+
+  return <MemberScope owner={memberSymbol}>
+    {"{"}
+      {elements}
+    {"}"}
+  </MemberScope>;
+}
+
+/**
+ * Create a JSON object property with a name and children. The children become
+ * the value of the property.
+ */
+export interface ObjectPropertyPropsWithChildren {
+  name: string;
+  children: Children;
+}
+
+/**
+ * Create a JSON object property with a name and a JS value. The JS value is
+ * serialized to JSON for the property
+ */
+export interface ObjectPropertyPropsWithJsValue {
+  name: string;
+  jsValue: unknown;
+}
+
+export type ObjectPropertyProps =
+  | ObjectPropertyPropsWithChildren
+  | ObjectPropertyPropsWithJsValue;
+
+/**
+ * Create a JSON object property. A property can be created by providing a JS
+ * property value or children that defines the value.
+ *
+ * @see {@link @alloy-js/core#(MemberDeclarationContext:variable)}
+ */
+export function JsonObjectProperty(props: ObjectPropertyProps) {
+  const sym = createJsonOutputSymbol({
+    name: props.name,
+    flags: OutputSymbolFlags.StaticMember,
+  });
+
+  const wrap = (children: Children) => {
+    return <MemberDeclaration symbol={sym}>
+      "{props.name}": {children}
+    </MemberDeclaration>;
+  };
+
+  if (!("jsValue" in props)) {
+    return wrap(props.children);
+  }
+
+  return wrap(<JsonValue jsValue={props.jsValue} />);
+}

--- a/packages/json/src/components/JsonValue.tsx
+++ b/packages/json/src/components/JsonValue.tsx
@@ -3,7 +3,8 @@ import { JsonArray } from "./JsonArray.jsx";
 import { JsonObject } from "./JsonObject.jsx";
 
 export interface JsonValueProps {
-  /** The refkey for the JSON array. When provided, this value can be referenced
+  /**
+   * The refkey for the JSON value. When provided, this value can be referenced
    * elsewhere via this refkey.
    **/
   refkey?: Refkey;

--- a/packages/json/src/components/JsonValue.tsx
+++ b/packages/json/src/components/JsonValue.tsx
@@ -1,0 +1,58 @@
+import { Refkey, useMemberDeclaration } from "@alloy-js/core";
+import { JsonArray } from "./JsonArray.jsx";
+import { JsonObject } from "./JsonObject.jsx";
+
+export interface JsonValueProps {
+  /** The refkey for the JSON array. When provided, this value can be referenced
+   * elsewhere via this refkey.
+   **/
+  refkey?: Refkey;
+
+  /**
+   * The JS value to serialize to JSON. When provided, thi
+   */
+  jsValue: unknown;
+}
+
+/**
+ * Create a JSON value from a JS value. When the provided JS value is an object,
+ * the {@link JsonObject} component will be used. When the provided JS value is
+ * an array, the {@link JsonArray} component will be used. Otherwise, the JS
+ * value will be serialized to a string, number, boolean, or null as
+ * appropriate.
+ */
+export function JsonValue(props: JsonValueProps) {
+  if (props.jsValue === null) {
+    setMemberRefkey(props.refkey);
+    return "null";
+  }
+
+  if (typeof props.jsValue === "number" || typeof props.jsValue === "boolean") {
+    setMemberRefkey(props.refkey);
+    return String(props.jsValue);
+  }
+
+  if (typeof props.jsValue === "string") {
+    setMemberRefkey(props.refkey);
+    return `"${props.jsValue}"`;
+  }
+
+  if (Array.isArray(props.jsValue)) {
+    return <JsonArray jsValue={props.jsValue} />;
+  }
+
+  if (typeof props.jsValue === "object") {
+    return <JsonObject jsValue={props.jsValue as any} />;
+  }
+
+  throw new Error("Cannot emit js value with type of " + typeof props.jsValue);
+}
+
+function setMemberRefkey(key?: Refkey) {
+  if (!key) return;
+  const member = useMemberDeclaration();
+  if (!member) {
+    throw new Error("Missing member declaration.");
+  }
+  member.refkey = key;
+}

--- a/packages/json/src/components/Reference.tsx
+++ b/packages/json/src/components/Reference.tsx
@@ -1,0 +1,23 @@
+import { Refkey } from "@alloy-js/core";
+import { ref } from "../symbols/index.js";
+
+export interface ReferenceProps {
+  /**
+   * The refkey for the symbol to reference.
+   */
+  refkey: Refkey;
+}
+
+/**
+ * Emit a reference to a JSON value by its refkey.
+ *
+ * @remarks
+ *
+ * Note that when you place a refkey in a template, the refkey will be converted
+ * into a reference automatically. Using this component directly is generally
+ * not required or recommended.
+ */
+export function Reference(props: ReferenceProps) {
+  const reference = ref(props.refkey);
+  return <>"{reference}"</>;
+}

--- a/packages/json/src/components/SourceFile.tsx
+++ b/packages/json/src/components/SourceFile.tsx
@@ -1,0 +1,48 @@
+import {
+  Children,
+  SourceFile as CoreSourceFile,
+  createSourceFileTap,
+  MemberDeclaration,
+} from "@alloy-js/core";
+import { JsonFileContext } from "../context/JsonFileContext.js";
+import { createJsonOutputSymbol } from "../symbols/json-symbol.js";
+import { Reference } from "./Reference.jsx";
+
+export interface SourceFileProps {
+  /** The path for this source file relative to the parent directory */
+  path: string;
+
+  /** The contents of the source file */
+  children?: Children;
+}
+
+/**
+ * Creates a JSON source file which defines a JSON value.
+ *
+ * @see {@link (JsonFileContext:variable)}
+ * @see {@link @alloy-js/core#(MemberDeclarationContext:variable)}
+ * @see {@link @alloy-js/core#(SourceFileContext:variable)}
+ *
+ */
+export function SourceFile(props: SourceFileProps) {
+  const jsonValueSym = createJsonOutputSymbol({
+    name: "",
+  });
+
+  const fileContext: JsonFileContext = {
+    symbol: jsonValueSym,
+    path: props.path,
+  };
+
+  const SfTapper = createSourceFileTap((context) => {
+    jsonValueSym.name = context.path;
+  });
+
+  return <CoreSourceFile filetype="json" path={props.path} reference={Reference}>
+    <SfTapper /><JsonFileContext.Provider value={fileContext}>
+      <MemberDeclaration symbol={jsonValueSym}>
+        {props.children}
+      </MemberDeclaration>
+    </JsonFileContext.Provider>
+  </CoreSourceFile>;
+}

--- a/packages/json/src/components/index.ts
+++ b/packages/json/src/components/index.ts
@@ -1,0 +1,5 @@
+export * from "./JsonArray.jsx";
+export * from "./JsonObject.jsx";
+export * from "./JsonValue.jsx";
+export * from "./Reference.jsx";
+export * from "./SourceFile.jsx";

--- a/packages/json/src/components/stc/index.ts
+++ b/packages/json/src/components/stc/index.ts
@@ -1,0 +1,10 @@
+import { stc } from "@alloy-js/core";
+import * as Jsx from "../index.js";
+
+export const JsonArray = stc(Jsx.JsonArray);
+export const JsonArrayElement = stc(Jsx.JsonArrayElement);
+export const JsonObject = stc(Jsx.JsonObject);
+export const JsonObjectProperty = stc(Jsx.JsonObjectProperty);
+export const JsonValue = stc(Jsx.JsonValue);
+export const Reference = stc(Jsx.Reference);
+export const SourceFile = stc(Jsx.SourceFile);

--- a/packages/json/src/context/JsonFileContext.ts
+++ b/packages/json/src/context/JsonFileContext.ts
@@ -1,0 +1,28 @@
+import {
+  ComponentContext,
+  createNamedContext,
+  useContext,
+} from "@alloy-js/core";
+import { JsonOutputSymbol } from "../symbols/json-symbol.js";
+
+export interface JsonFileContext {
+  /** The path of the current JSON file. May be different from the path on disk. */
+  path?: string;
+
+  /** The URL of the current JSON file */
+  url?: string;
+
+  /** The symbol for the value in this JSON file */
+  symbol: JsonOutputSymbol;
+}
+
+/**
+ * Provides information about the current JSON source file. This context is used
+ * to allow references between JSON files.
+ */
+export const JsonFileContext: ComponentContext<JsonFileContext> =
+  createNamedContext<JsonFileContext>("JsonFile");
+
+export function useJsonFileContext(): JsonFileContext | undefined {
+  return useContext(JsonFileContext);
+}

--- a/packages/json/src/context/index.ts
+++ b/packages/json/src/context/index.ts
@@ -1,0 +1,1 @@
+export * from "./JsonFileContext.js";

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./components/index.js";
+export * from "./context/index.js";
+export * from "./symbols/index.js";

--- a/packages/json/src/symbols/index.ts
+++ b/packages/json/src/symbols/index.ts
@@ -1,0 +1,43 @@
+import { memo, OutputScope, Refkey, resolve } from "@alloy-js/core";
+import { dirname, relative } from "pathe";
+import { useJsonFileContext } from "../context/JsonFileContext.js";
+import { JsonOutputSymbol } from "./json-symbol.js";
+export * from "./json-symbol.js";
+
+export function ref(refkey: Refkey) {
+  const sourceFile = useJsonFileContext();
+  if (!sourceFile) {
+    return "<Unresolved Symbol>";
+  }
+
+  const resolveResult = resolve<OutputScope, JsonOutputSymbol>(refkey);
+
+  return memo(() => {
+    if (resolveResult.value === undefined) {
+      return "<Unresolved Symbol>";
+    }
+    const { targetDeclaration, memberPath } = resolveResult.value;
+
+    let ref = "";
+    if (targetDeclaration !== sourceFile.symbol) {
+      const currentPath = sourceFile.symbol.name;
+      const targetPath = targetDeclaration.name;
+      ref += relative(dirname(currentPath), targetPath);
+    }
+
+    ref += "#";
+
+    if (!memberPath || memberPath.length === 0) {
+      return ref;
+    }
+
+    ref += "/";
+
+    ref += memberPath
+      .slice(1)
+      .map((segment) => segment.name)
+      .join("/");
+
+    return ref;
+  });
+}

--- a/packages/json/src/symbols/json-symbol.ts
+++ b/packages/json/src/symbols/json-symbol.ts
@@ -1,0 +1,68 @@
+import {
+  CreateSymbolOptions,
+  OutputScope,
+  OutputSymbol,
+  OutputSymbolFlags,
+  useBinder,
+  useMemberScope,
+} from "@alloy-js/core";
+
+// prettier-ignore
+export enum JsonSymbolFlags {
+  None = 0,
+  Object = 1 << 0,
+  Array = 1 << 1,
+}
+
+/**
+ * JsonOutputSymbol is created for JSON Values with a refkey. For JSON objects
+ * and arrays, the symbol will have the `StaticMemberContainer` flag. For JSON
+ * values that are members of an object or an array, the symbol will have the
+ * `StaticMember` flag.
+ */
+export interface JsonOutputSymbol extends OutputSymbol {
+  scope: OutputScope;
+  jsonFlags: JsonSymbolFlags;
+}
+
+export interface createJsonSymbolOptions extends CreateSymbolOptions {
+  jsonFlags?: JsonSymbolFlags;
+}
+
+export function createJsonOutputSymbol(
+  options: createJsonSymbolOptions,
+): JsonOutputSymbol {
+  const scope =
+    options.scope ??
+    (useDefaultScope(options.flags) as OutputScope) ??
+    useBinder().globalScope;
+
+  const binder = scope.binder;
+  const sym = binder.createSymbol<JsonOutputSymbol>({
+    name: options.name,
+    scope,
+    refkey: options.refkey,
+    flags: options.flags ?? OutputSymbolFlags.None,
+    jsonFlags: options.jsonFlags ?? JsonSymbolFlags.None,
+  });
+
+  return sym;
+}
+
+export function useDefaultScope(
+  flags: OutputSymbolFlags = OutputSymbolFlags.None,
+) {
+  if ((flags & OutputSymbolFlags.Member) === 0) {
+    return useBinder().globalScope;
+  } else {
+    const memberScope = useMemberScope();
+    if (!memberScope) {
+      throw new Error("Cannot declare member symbols without a member scope");
+    }
+    if (flags & OutputSymbolFlags.InstanceMember) {
+      return memberScope.instanceMembers;
+    } else {
+      return memberScope.staticMembers;
+    }
+  }
+}

--- a/packages/json/test/array.test.tsx
+++ b/packages/json/test/array.test.tsx
@@ -1,0 +1,31 @@
+import "@alloy-js/core/testing";
+import { expect, it } from "vitest";
+import { jsonTest } from "./utils.jsx";
+
+it("renders empty arrays", () => {
+  const template = jsonTest([]);
+
+  expect(template).toRenderTo(`[]`);
+});
+
+it("renders arrays", () => {
+  const template = jsonTest([1, "hello"]);
+
+  expect(template).toRenderTo(`
+    [
+      1,
+      "hello"
+    ]
+  `);
+});
+
+it("renders nested arrays", () => {
+  const template = jsonTest([1, ["hello"]]);
+
+  expect(template).toRenderTo(`
+    [
+      1,
+      ["hello"]
+    ]
+  `);
+});

--- a/packages/json/test/object.test.tsx
+++ b/packages/json/test/object.test.tsx
@@ -1,0 +1,60 @@
+import { Output } from "@alloy-js/core";
+import "@alloy-js/core/testing";
+import { expect, it } from "vitest";
+import {
+  JsonObject,
+  JsonObjectProperty,
+} from "../src/components/JsonObject.jsx";
+import { SourceFile } from "../src/components/SourceFile.jsx";
+import { jsonTest } from "./utils.jsx";
+
+it("renders objects", () => {
+  const template = jsonTest({
+    a: 1,
+    b: "hello",
+  });
+
+  expect(template).toRenderTo(`
+    {
+      "a": 1,
+      "b": "hello"
+    }
+  `);
+});
+
+it("renders nested objects", () => {
+  const template = jsonTest({
+    a: {
+      b: 1,
+    },
+  });
+
+  expect(template).toRenderTo(`
+    {
+      "a": {
+        "b": 1
+      }
+    }
+  `);
+});
+
+it("can can manually assemble objects", () => {
+  const template =
+    <Output>
+      <SourceFile path="test.json">
+        <JsonObject>
+          <JsonObjectProperty name="foo">12</JsonObjectProperty>,
+          <JsonObjectProperty name="bar">
+            13
+          </JsonObjectProperty>
+        </JsonObject>
+      </SourceFile>
+    </Output>;
+
+  expect(template).toRenderTo(`
+    {
+      "foo": 12,
+      "bar": 13
+    }
+  `);
+});

--- a/packages/json/test/primitives.test.tsx
+++ b/packages/json/test/primitives.test.tsx
@@ -1,0 +1,16 @@
+import "@alloy-js/core/testing";
+import { expect, it } from "vitest";
+import { jsonTest } from "./utils.jsx";
+
+it("renders primitives", () => {
+  expect(jsonTest(true)).toRenderTo("true");
+  expect(jsonTest(false)).toRenderTo("false");
+
+  expect(jsonTest(10)).toRenderTo("10");
+  expect(jsonTest(-10)).toRenderTo("-10");
+  expect(jsonTest(1.314)).toRenderTo("1.314");
+
+  expect(jsonTest("hello")).toRenderTo('"hello"');
+
+  expect(jsonTest(null)).toRenderTo("null");
+});

--- a/packages/json/test/reference.test.tsx
+++ b/packages/json/test/reference.test.tsx
@@ -1,0 +1,173 @@
+import { Output, refkey, SourceDirectory } from "@alloy-js/core";
+import "@alloy-js/core/testing";
+import { expect, it } from "vitest";
+import { JsonArray, JsonArrayElement } from "../src/components/JsonArray.jsx";
+import {
+  JsonObject,
+  JsonObjectProperty,
+} from "../src/components/JsonObject.jsx";
+import { JsonValue } from "../src/components/JsonValue.jsx";
+import { SourceFile } from "../src/components/SourceFile.jsx";
+
+it("references objects within the same file", () => {
+  const objectValue = refkey();
+  const nullKey = refkey();
+  const template =
+    <Output>
+      <SourceFile path="test.json">
+        <JsonObject refkey={objectValue}>
+          <JsonObjectProperty name="nullValue">
+            <JsonValue jsValue={null} refkey={nullKey} />,
+          </JsonObjectProperty>
+          <JsonObjectProperty name="refToNull">{nullKey}</JsonObjectProperty>,
+          <JsonObjectProperty name="refToObject">{objectValue}</JsonObjectProperty>
+        </JsonObject>
+      </SourceFile>
+    </Output>;
+
+  expect(template).toRenderTo(`
+    {
+      "nullValue": null,
+      "refToNull": "#/nullValue",
+      "refToObject": "#"
+    }
+  `);
+});
+
+it("references objects across files", () => {
+  const objectValue = refkey();
+  const nullKey = refkey();
+  const template =
+    <Output>
+      <SourceFile path="test.json">
+        <JsonObject refkey={objectValue}>
+          <JsonObjectProperty name="nullValue">
+            <JsonValue jsValue={null} refkey={nullKey} />,
+          </JsonObjectProperty>
+        </JsonObject>
+      </SourceFile>
+      <SourceFile path="test.json">
+        <JsonObject>
+          <JsonObjectProperty name="refToNull">{nullKey}</JsonObjectProperty>,
+          <JsonObjectProperty name="refToObject">{objectValue}</JsonObjectProperty>
+        </JsonObject>
+      </SourceFile>
+    </Output>;
+
+  expect(template).toRenderTo(`
+    {
+      "nullValue": null,
+    }
+    {
+      "refToNull": "test.json#/nullValue",
+      "refToObject": "test.json#"
+    }
+  `);
+});
+
+it("references objects across files and directories", () => {
+  const objectValue = refkey();
+  const nullKey = refkey();
+  const template =
+    <Output>
+      <SourceDirectory path="subdir">
+        <SourceFile path="test.json">
+          <JsonObject refkey={objectValue}>
+            <JsonObjectProperty name="nullValue">
+              <JsonValue jsValue={null} refkey={nullKey} />,
+            </JsonObjectProperty>
+          </JsonObject>
+        </SourceFile>  
+      </SourceDirectory>
+      <SourceFile path="test.json">
+        <JsonObject>
+          <JsonObjectProperty name="refToNull">{nullKey}</JsonObjectProperty>,
+          <JsonObjectProperty name="refToObject">{objectValue}</JsonObjectProperty>
+        </JsonObject>
+      </SourceFile>
+    </Output>;
+
+  expect(template).toRenderTo(`
+    {
+      "nullValue": null,
+    }
+    {
+      "refToNull": "subdir/test.json#/nullValue",
+      "refToObject": "subdir/test.json#"
+    }
+  `);
+});
+
+it("references arrays within the same file", () => {
+  const arrayValue = refkey();
+  const nullKey = refkey();
+  const template =
+    <Output>
+      <SourceFile path="test.json">
+        <JsonArray refkey={arrayValue}>
+          <JsonArrayElement>{nullKey}</JsonArrayElement>,
+          <JsonArrayElement>{arrayValue}</JsonArrayElement>,
+          <JsonArrayElement>
+            <JsonValue jsValue={null} refkey={nullKey} />
+          </JsonArrayElement>
+        </JsonArray>
+      </SourceFile>
+    </Output>;
+
+  expect(template).toRenderTo(`
+    [
+      "#/2",
+      "#",
+      null
+    ]
+  `);
+});
+
+it("does complex references", () => {
+  const objectValue = refkey();
+  const arrayValue = refkey();
+  const nullKey = refkey();
+  const nestedKey = refkey();
+  const template =
+    <Output>
+      <SourceFile path="test.json">
+        <JsonObject refkey={objectValue}>
+          <JsonObjectProperty name="nullValue">
+            <JsonValue jsValue={null} refkey={nullKey} />,
+          </JsonObjectProperty>
+          <JsonObjectProperty name="refToNull">{nullKey}</JsonObjectProperty>,
+          <JsonObjectProperty name="refToObject">{objectValue}</JsonObjectProperty>
+          <JsonObjectProperty name="refToNested">{nestedKey}</JsonObjectProperty>
+          <JsonObjectProperty name="nestedArray">
+            <JsonArray refkey={arrayValue}>
+              <JsonArrayElement>{nullKey}</JsonArrayElement>,
+              <JsonArrayElement>{arrayValue}</JsonArrayElement>
+              <JsonArrayElement>
+                <JsonObject>
+                  <JsonObjectProperty name="nestedProp">
+                    <JsonValue jsValue="hi" refkey={nestedKey} />
+                  </JsonObjectProperty>
+                </JsonObject>
+              </JsonArrayElement>
+            </JsonArray>
+          </JsonObjectProperty>
+        </JsonObject>
+      </SourceFile>
+    </Output>;
+
+  expect(template).toRenderTo(`
+    {
+      "nullValue": null,
+      "refToNull": "#/nullValue",
+      "refToObject": "#"
+      "refToNested": "#/nestedArray/2/nestedProp"
+      "nestedArray": [
+        "#/nullValue",
+        "#/nestedArray"
+        {
+          "nestedProp": "hi"
+        }
+      ]
+    }
+  `);
+});

--- a/packages/json/test/utils.tsx
+++ b/packages/json/test/utils.tsx
@@ -1,0 +1,11 @@
+import { Output } from "@alloy-js/core";
+import { JsonValue } from "../src/components/JsonValue.jsx";
+import { SourceFile } from "../src/components/SourceFile.jsx";
+
+export function jsonTest(jsValue: unknown) {
+  return <Output>
+    <SourceFile path="test.json">
+      <JsonValue jsValue={jsValue} />
+    </SourceFile>
+  </Output>;
+}

--- a/packages/json/test/vitest.d.ts
+++ b/packages/json/test/vitest.d.ts
@@ -1,0 +1,10 @@
+import "vitest";
+
+interface CustomMatchers<R = unknown> {
+  toRenderTo: (str: string) => R;
+}
+
+declare module "vitest" {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers {}
+}

--- a/packages/json/tsconfig.json
+++ b/packages/json/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "references": [{ "path": "../core" }],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/json/vitest.config.ts
+++ b/packages/json/vitest.config.ts
@@ -1,0 +1,18 @@
+import { babel } from "@rollup/plugin-babel";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "preserve",
+    sourcemap: "both",
+  },
+  plugins: [
+    babel({
+      inputSourceMap: true as any,
+      sourceMaps: "both",
+      babelHelpers: "bundled",
+      extensions: [".ts", ".tsx"],
+      presets: ["@babel/preset-typescript", "@alloy-js/babel-preset"],
+    }),
+  ],
+});

--- a/packages/typescript/src/components/ValueExpression.tsx
+++ b/packages/typescript/src/components/ValueExpression.tsx
@@ -1,4 +1,4 @@
-import { memo } from "@alloy-js/core";
+import { Children, memo } from "@alloy-js/core";
 import { ArrayExpression } from "./ArrayExpression.js";
 import { ObjectExpression } from "./ObjectExpression.js";
 
@@ -6,8 +6,8 @@ export interface ValueExpressionProps {
   jsValue?: unknown;
 }
 
-export function ValueExpression(props: ValueExpressionProps) {
-  return memo(() => {
+export function ValueExpression(props: ValueExpressionProps): Children {
+  return memo((): Children => {
     const jsValue = props.jsValue;
 
     if (typeof jsValue === "undefined") {
@@ -28,7 +28,7 @@ export function ValueExpression(props: ValueExpressionProps) {
       }
     } else if (typeof jsValue === "function") {
       // functions are inserted as-is.
-      return jsValue;
+      return jsValue as () => Children;
     }
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^4.18.1
       version: 4.20.0
     typescript:
-      specifier: ^5.5.4
-      version: 5.5.4
+      specifier: ^5.7.3
+      version: 5.7.3
     typescript-eslint:
       specifier: ^8.1.0
       version: 8.1.0
@@ -127,13 +127,13 @@ importers:
         version: 9.9.0
       eslint-plugin-vitest:
         specifier: 'catalog:'
-        version: 0.5.4(eslint@9.9.0)(typescript@5.5.4)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1))
+        version: 0.5.4(eslint@9.9.0)(typescript@5.7.3)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1))
       prettier:
         specifier: 'catalog:'
         version: 3.3.3
       prettier-plugin-organize-imports:
         specifier: 'catalog:'
-        version: 4.0.0(prettier@3.3.3)(typescript@5.5.4)
+        version: 4.0.0(prettier@3.3.3)(typescript@5.7.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -142,7 +142,7 @@ importers:
         version: 4.19.1
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.1.0(eslint@9.9.0)(typescript@5.5.4)
+        version: 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -179,7 +179,7 @@ importers:
         version: 11.0.4(@babel/core@7.25.2)
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -256,13 +256,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -296,13 +296,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -382,13 +382,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -398,6 +398,9 @@ importers:
       '@alloy-js/core':
         specifier: workspace:~
         version: link:../core
+      pathe:
+        specifier: 'catalog:'
+        version: 1.1.2
     devDependencies:
       '@alloy-js/babel-preset':
         specifier: workspace:~
@@ -416,13 +419,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -434,7 +437,7 @@ importers:
         version: 3.3.3
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -468,13 +471,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -505,7 +508,7 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       '@types/node':
         specifier: 'catalog:'
         version: 20.14.15
@@ -514,7 +517,7 @@ importers:
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1)
@@ -545,7 +548,7 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       '@types/node':
         specifier: 'catalog:'
         version: 20.14.15
@@ -554,7 +557,7 @@ importers:
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1)
@@ -4608,6 +4611,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
@@ -6351,11 +6359,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.20.0
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
       resolve: 1.22.8
-      typescript: 5.5.4
+      typescript: 5.7.3
     optionalDependencies:
       rollup: 4.30.1
       tslib: 2.6.3
@@ -6679,34 +6687,34 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.5.4))(eslint@9.9.0)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.7.3))(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.1.0
-      '@typescript-eslint/type-utils': 8.1.0(eslint@9.9.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.1.0
       eslint: 9.9.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.1.0
       '@typescript-eslint/types': 8.1.0
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.1.0
       debug: 4.3.6
       eslint: 9.9.0
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6720,14 +6728,14 @@ snapshots:
       '@typescript-eslint/types': 8.1.0
       '@typescript-eslint/visitor-keys': 8.1.0
 
-  '@typescript-eslint/type-utils@8.1.0(eslint@9.9.0)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.1.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       debug: 4.3.6
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -6736,7 +6744,7 @@ snapshots:
 
   '@typescript-eslint/types@8.1.0': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -6745,13 +6753,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.1.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.1.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.1.0
       '@typescript-eslint/visitor-keys': 8.1.0
@@ -6760,29 +6768,29 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@9.9.0)(typescript@5.5.4)':
+  '@typescript-eslint/utils@7.18.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.0)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.3)
       eslint: 9.9.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.1.0(eslint@9.9.0)(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.1.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.0)
       '@typescript-eslint/scope-manager': 8.1.0
       '@typescript-eslint/types': 8.1.0
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
       eslint: 9.9.0
     transitivePeerDependencies:
       - supports-color
@@ -7589,9 +7597,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-vitest@0.5.4(eslint@9.9.0)(typescript@5.5.4)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)):
+  eslint-plugin-vitest@0.5.4(eslint@9.9.0)(typescript@5.7.3)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
-      '@typescript-eslint/utils': 7.18.0(eslint@9.9.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.9.0)(typescript@5.7.3)
       eslint: 9.9.0
     optionalDependencies:
       vitest: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -9264,10 +9272,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-organize-imports@4.0.0(prettier@3.3.3)(typescript@5.5.4):
+  prettier-plugin-organize-imports@4.0.0(prettier@3.3.3)(typescript@5.7.3):
     dependencies:
       prettier: 3.3.3
-      typescript: 5.5.4
+      typescript: 5.7.3
 
   prettier@2.8.7:
     optional: true
@@ -9950,9 +9958,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@1.3.0(typescript@5.5.4):
+  ts-api-utils@1.3.0(typescript@5.7.3):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
 
   tsconfck@3.1.4(typescript@5.5.4):
     optionalDependencies:
@@ -9993,13 +10001,13 @@ snapshots:
     dependencies:
       semver: 7.6.3
 
-  typescript-eslint@8.1.0(eslint@9.9.0)(typescript@5.5.4):
+  typescript-eslint@8.1.0(eslint@9.9.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.5.4))(eslint@9.9.0)(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.7.3))(eslint@9.9.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -10007,6 +10015,8 @@ snapshots:
   typescript@5.4.2: {}
 
   typescript@5.5.4: {}
+
+  typescript@5.7.3: {}
 
   ufo@1.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^4.18.1
       version: 4.20.0
     typescript:
-      specifier: ^5.5.4
-      version: 5.5.4
+      specifier: ^5.7.3
+      version: 5.7.3
     typescript-eslint:
       specifier: ^8.1.0
       version: 8.1.0
@@ -127,13 +127,13 @@ importers:
         version: 9.9.0
       eslint-plugin-vitest:
         specifier: 'catalog:'
-        version: 0.5.4(eslint@9.9.0)(typescript@5.6.3)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1))
+        version: 0.5.4(eslint@9.9.0)(typescript@5.7.3)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1))
       prettier:
         specifier: 'catalog:'
         version: 3.3.3
       prettier-plugin-organize-imports:
         specifier: 'catalog:'
-        version: 4.0.0(prettier@3.3.3)(typescript@5.6.3)
+        version: 4.0.0(prettier@3.3.3)(typescript@5.7.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -142,7 +142,7 @@ importers:
         version: 4.19.1
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.1.0(eslint@9.9.0)(typescript@5.6.3)
+        version: 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -179,7 +179,7 @@ importers:
         version: 11.0.4(@babel/core@7.25.2)
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -256,13 +256,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -296,13 +296,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -382,13 +382,50 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
+
+  packages/json:
+    dependencies:
+      '@alloy-js/core':
+        specifier: workspace:~
+        version: link:../core
+      pathe:
+        specifier: 'catalog:'
+        version: 1.1.2
+    devDependencies:
+      '@alloy-js/babel-preset':
+        specifier: workspace:~
+        version: link:../babel-preset-alloy
+      '@babel/cli':
+        specifier: 'catalog:'
+        version: 7.24.8(@babel/core@7.25.2)
+      '@babel/preset-typescript':
+        specifier: 'catalog:'
+        version: 7.24.7(@babel/core@7.25.2)
+      '@microsoft/api-extractor':
+        specifier: ^7.47.7
+        version: 7.47.7(@types/node@22.2.0)
+      '@rollup/plugin-babel':
+        specifier: 'catalog:'
+        version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
+      '@rollup/plugin-typescript':
+        specifier: 'catalog:'
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
+      concurrently:
+        specifier: 'catalog:'
+        version: 8.2.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -400,7 +437,7 @@ importers:
         version: 3.3.3
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -434,13 +471,13 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -471,7 +508,7 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       '@types/node':
         specifier: 'catalog:'
         version: 20.14.15
@@ -480,7 +517,7 @@ importers:
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1)
@@ -511,7 +548,7 @@ importers:
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.30.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)
       '@types/node':
         specifier: 'catalog:'
         version: 20.14.15
@@ -520,7 +557,7 @@ importers:
         version: 8.2.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1)
@@ -2979,9 +3016,6 @@ packages:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
     engines: {node: '>=18'}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
 
@@ -3390,9 +3424,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  loupe@3.1.1:
-    resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
@@ -4574,8 +4605,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -6322,11 +6353,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.20.0
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.5.4)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.30.1)(tslib@2.6.3)(typescript@5.7.3)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
       resolve: 1.22.8
-      typescript: 5.5.4
+      typescript: 5.7.3
     optionalDependencies:
       rollup: 4.30.1
       tslib: 2.6.3
@@ -6650,34 +6681,34 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.6.3))(eslint@9.9.0)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.7.3))(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.1.0
-      '@typescript-eslint/type-utils': 8.1.0(eslint@9.9.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.1.0
       eslint: 9.9.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.1.0
       '@typescript-eslint/types': 8.1.0
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.1.0
       debug: 4.3.6
       eslint: 9.9.0
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6691,14 +6722,14 @@ snapshots:
       '@typescript-eslint/types': 8.1.0
       '@typescript-eslint/visitor-keys': 8.1.0
 
-  '@typescript-eslint/type-utils@8.1.0(eslint@9.9.0)(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.1.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
       debug: 4.3.6
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -6707,7 +6738,7 @@ snapshots:
 
   '@typescript-eslint/types@8.1.0': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -6716,13 +6747,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.1.0(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.1.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.1.0
       '@typescript-eslint/visitor-keys': 8.1.0
@@ -6731,29 +6762,29 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@9.9.0)(typescript@5.6.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.0)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.3)
       eslint: 9.9.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.1.0(eslint@9.9.0)(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.1.0(eslint@9.9.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.0)
       '@typescript-eslint/scope-manager': 8.1.0
       '@typescript-eslint/types': 8.1.0
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
       eslint: 9.9.0
     transitivePeerDependencies:
       - supports-color
@@ -6777,6 +6808,14 @@ snapshots:
       '@vitest/utils': 3.0.4
       chai: 5.1.2
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.0.4(vite@6.0.7(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1))':
+    dependencies:
+      '@vitest/spy': 3.0.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.0.7(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1)
 
   '@vitest/mocker@3.0.4(vite@6.0.7(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1))':
     dependencies:
@@ -7217,7 +7256,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.1
+      loupe: 3.1.2
       pathval: 2.0.0
 
   chalk@2.4.2:
@@ -7552,9 +7591,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-vitest@0.5.4(eslint@9.9.0)(typescript@5.6.3)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)):
+  eslint-plugin-vitest@0.5.4(eslint@9.9.0)(typescript@5.7.3)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)):
     dependencies:
-      '@typescript-eslint/utils': 7.18.0(eslint@9.9.0)(typescript@5.6.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.9.0)(typescript@5.7.3)
       eslint: 9.9.0
     optionalDependencies:
       vitest: 3.0.4(@types/debug@4.1.12)(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1)
@@ -7780,8 +7819,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.2.0: {}
-
-  get-func-name@2.0.2: {}
 
   get-tsconfig@4.8.1:
     dependencies:
@@ -8303,10 +8340,6 @@ snapshots:
   lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
-
-  loupe@3.1.1:
-    dependencies:
-      get-func-name: 2.0.2
 
   loupe@3.1.2: {}
 
@@ -9227,10 +9260,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-organize-imports@4.0.0(prettier@3.3.3)(typescript@5.6.3):
+  prettier-plugin-organize-imports@4.0.0(prettier@3.3.3)(typescript@5.7.3):
     dependencies:
       prettier: 3.3.3
-      typescript: 5.6.3
+      typescript: 5.7.3
 
   prettier@2.8.7:
     optional: true
@@ -9913,9 +9946,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@1.3.0(typescript@5.6.3):
+  ts-api-utils@1.3.0(typescript@5.7.3):
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
 
   tsconfck@3.1.4(typescript@5.5.4):
     optionalDependencies:
@@ -9956,13 +9989,13 @@ snapshots:
     dependencies:
       semver: 7.6.3
 
-  typescript-eslint@8.1.0(eslint@9.9.0)(typescript@5.6.3):
+  typescript-eslint@8.1.0(eslint@9.9.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.6.3))(eslint@9.9.0)(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0(eslint@9.9.0)(typescript@5.7.3))(eslint@9.9.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.7.3)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -9971,7 +10004,7 @@ snapshots:
 
   typescript@5.5.4: {}
 
-  typescript@5.6.3: {}
+  typescript@5.7.3: {}
 
   ufo@1.5.4: {}
 
@@ -10187,7 +10220,7 @@ snapshots:
   vitest@3.0.4(@types/debug@4.1.12)(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1):
     dependencies:
       '@vitest/expect': 3.0.4
-      '@vitest/mocker': 3.0.4(vite@6.0.7(@types/node@22.2.0)(tsx@4.19.1)(yaml@2.5.1))
+      '@vitest/mocker': 3.0.4(vite@6.0.7(@types/node@20.14.15)(tsx@4.19.1)(yaml@2.5.1))
       '@vitest/pretty-format': 3.0.4
       '@vitest/runner': 3.0.4
       '@vitest/snapshot': 3.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,6 @@ catalog:
   rimraf: ^6.0.1
   rollup: ^4.18.1
   typescript-eslint: "^8.1.0"
-  typescript: ^5.5.4
+  typescript: ^5.7.3
   validate-html-nesting: ^1.2.1
   vitest: ^3.0.4

--- a/samples/client-emitter/src/components/Client.tsx
+++ b/samples/client-emitter/src/components/Client.tsx
@@ -1,9 +1,9 @@
-import { mapJoin, refkey } from "@alloy-js/core";
+import { Children, mapJoin, refkey } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { useApi } from "../context/api.js";
 import { ClientMethod } from "./ClientMethod.jsx";
 
-export function Client() {
+export function Client(): Children {
   const schema = useApi().schema;
   const operations = schema.operations;
   const methods = mapJoin(operations, (op) => <ClientMethod operation={op} />);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "declarationMap": true,
     "jsx": "preserve",
+    "jsxImportSource": "@alloy-js/core",
     "composite": true,
     "incremental": true
   },
@@ -19,6 +20,7 @@
     { "path": "packages/typescript" },
     { "path": "packages/prettier-plugin-alloy" },
     { "path": "packages/java" },
+    { "path": "packages/json" },
     { "path": "samples/client-emitter" },
     { "path": "samples/basic-project" }
   ]


### PR DESCRIPTION
This PR adds `@alloy-js/json` for defining JSON files with Alloy. You can define JSON files and the JSON values contained therein with various components. References via JSON Pointer are supported.

This PR also fixes the types of components and various other things in the JSX runtime, providing significantly more accurate types and enabling unions for prop types which enable overload-like scenarios.