### PR TITLE
Use imports instead of browser mapping

### DIFF
--- a/.chronus/changes/joheredi-fix-browser-2025-1-12-22-7-35.md
+++ b/.chronus/changes/joheredi-fix-browser-2025-1-12-22-7-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+Fix browser mappings

--- a/.chronus/changes/joheredi-fix-browser-2025-1-12-22-7-35.md
+++ b/.chronus/changes/joheredi-fix-browser-2025-1-12-22-7-35.md
@@ -4,4 +4,4 @@ packages:
   - "@alloy-js/core"
 ---
 
-Fix browser mappings
+Fix browser mappings to use import

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,9 +26,11 @@
       "import": "./dist/src/components/index.js"
     }
   },
-  "browser": {
-    "./dist/src/write-output.js": "./dist/src/write-output.browser.js",
-    "./src/write-output.ts": "./src/write-output.browser.ts"
+  "imports": {
+    "#write-output": {
+      "browser": "./dist/src/write-output.browser.js",
+      "default": "./dist/src/write-output.js"
+    }
   },
   "scripts": {
     "build-src": "babel src -d dist/src --extensions .ts,.tsx",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,5 +19,5 @@ export * from "./refkey.js";
 export * from "./render.js";
 export * from "./tap.js";
 export * from "./utils.js";
-export * from "./write-output.js";
+export * from "#write-output";
 import "./debug.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "#write-output";
 export {
   computed,
   isProxy,
@@ -19,5 +20,4 @@ export * from "./refkey.js";
 export * from "./render.js";
 export * from "./tap.js";
 export * from "./utils.js";
-export * from "#write-output";
 import "./debug.js";


### PR DESCRIPTION
Since we use conditional exports, it takes precedence over browser mappings. Using imports should fix this