### PR TITLE
Docs updates

### DIFF
--- a/.chronus/changes/docs-updates-2025-2-17-15-11-54.md
+++ b/.chronus/changes/docs-updates-2025-2-17-15-11-54.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/core"
+---
+
+Add `text` helper that processes a string template similar to a JSX template with respect to whitespace handling.

--- a/.chronus/changes/docs-updates-2025-2-17-15-12-48.md
+++ b/.chronus/changes/docs-updates-2025-2-17-15-12-48.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/core"
+---
+
+Add `ProviderStc` to context for providing context inside string template components.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,13 @@
     "prettier-plugin-organize-imports": "catalog:",
     "rimraf": "catalog:",
     "tsx": "^4.19.1",
+    "typedoc": "^0.28.0",
     "typescript-eslint": "catalog:",
     "vitest": "catalog:"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@microsoft/tsdoc@0.15.0": "patches/@microsoft__tsdoc@0.15.0.patch"
+    }
   }
 }

--- a/packages/core/src/binder.ts
+++ b/packages/core/src/binder.ts
@@ -370,15 +370,11 @@ export interface Binder {
  * When we resolve the refkey for `bar` from within `namespace scope 2`, we will get the following
  * resolution result:
  *
- * **targetDeclaration**: symbol bar, the symbol we resolved.
- *
- * **commonScope**: global scope, because this is the most specific scope that contains both the declaration and the reference.
- *
- * **pathUp**: [namespace scope 2], because this is the scope between the reference and the common scope.
- *
- * **pathDown**: [namespace scope 1], because this is the scope between the common scope and the declaration
- *
- * **memberPath**: [foo, bar], because we resolved a member symbol and these are the symbols that lead from the base declaration to the member symbol.
+ * * **targetDeclaration**: symbol bar, the symbol we resolved.
+ * * **commonScope**: global scope, because this is the most specific scope that contains both the declaration and the reference.
+ * * **pathUp**: [namespace scope 2], because this is the scope between the reference and the common scope.
+ * * **pathDown**: [namespace scope 1], because this is the scope between the common scope and the declaration
+ * * **memberPath**: [foo, bar], because we resolved a member symbol and these are the symbols that lead from the base declaration to the member symbol.
  */
 export interface ResolutionResult<
   TScope extends OutputScope,

--- a/packages/core/src/components/Block.tsx
+++ b/packages/core/src/components/Block.tsx
@@ -23,8 +23,8 @@ export interface BlockProps {
 
 /**
  * Create an indented block of source text. The block has `opener` text which is
- * added prior to the block, which defaults to "\{", and `closer` text which is
- * added after the block, which defaults to "\}".
+ * added prior to the block, which defaults to `"{"`, and `closer` text which is
+ * added after the block, which defaults to `"}"`.
  */
 export function Block(props: BlockProps) {
   const childCount = computed(() => childrenArray(() => props.children).length);

--- a/packages/core/src/components/For.tsx
+++ b/packages/core/src/components/For.tsx
@@ -1,7 +1,7 @@
 import { Children, memo } from "@alloy-js/core/jsx-runtime";
 import { isRef, Ref } from "@vue/reactivity";
-import { mapJoin } from "../utils.js";
-import { BaseListProps, baseListPropsToMapJoinArgs } from "./List.jsx";
+import { baseListPropsToMapJoinArgs, mapJoin } from "../utils.js";
+import { BaseListProps } from "./List.jsx";
 
 export type ForCallbackArgs<T> =
   T extends Ref<infer U> ? ForCallbackArgs<U>

--- a/packages/core/src/components/List.tsx
+++ b/packages/core/src/components/List.tsx
@@ -1,5 +1,5 @@
 import { Children, memo, splitProps } from "@alloy-js/core/jsx-runtime";
-import { childrenArray, JoinOptions } from "../utils.js";
+import { childrenArray } from "../utils.js";
 import { For } from "./For.jsx";
 
 export type BreakKind = "none" | "space" | "soft" | "hard" | "literal";
@@ -30,42 +30,6 @@ export interface BaseListProps {
    * Place the join punctuation at the end, but without a line break.
    */
   enderPunctuation?: boolean;
-}
-
-export function baseListPropsToMapJoinArgs(props: BaseListProps): JoinOptions {
-  let joiner, punctuation;
-  if ("joiner" in props) {
-    joiner = props.joiner;
-  } else {
-    punctuation =
-      props.comma ? ","
-      : props.semicolon ? ";"
-      : "";
-
-    joiner = (
-      <>
-        {punctuation}
-        {props.softline ?
-          <sbr />
-        : props.hardline ?
-          <hbr />
-        : props.literalline ?
-          <lbr />
-        : props.line ?
-          <br />
-        : props.space ?
-          <> </>
-        : <hbr />}
-      </>
-    );
-  }
-
-  const ender =
-    "ender" in props ? props.ender
-    : props.enderPunctuation ? punctuation
-    : undefined;
-
-  return { joiner, ender };
 }
 
 export interface ListProps extends BaseListProps {

--- a/packages/core/src/components/stc/index.ts
+++ b/packages/core/src/components/stc/index.ts
@@ -1,4 +1,4 @@
-import { stc, sti } from "../../stc.js";
+import { stc } from "../../stc.js";
 import * as base from "../index.js";
 
 export const Block = stc(base.Block);
@@ -19,8 +19,4 @@ export const SourceFile = stc(base.SourceFile);
 export const Switch = stc(base.Switch);
 export const Wrap = stc(base.Wrap);
 
-export const indent = sti("indent");
-export const hbr = sti("hbr");
-export const sbr = sti("sbr");
-export const lbr = sti("lbr");
-export const br = sti("br");
+export * from "./sti.js";

--- a/packages/core/src/components/stc/sti.ts
+++ b/packages/core/src/components/stc/sti.ts
@@ -1,0 +1,10 @@
+import { sti } from "../../index.js";
+
+export const indent = sti("indent");
+export const group = sti("group");
+export const ifBreak = sti("ifBreak");
+export const hbr = sti("hbr");
+export const sbr = sti("sbr");
+export const lbr = sti("lbr");
+export const br = sti("br");
+export const dedentToRoot = sti("dedentToRoot");

--- a/packages/core/src/components/stc/sti.ts
+++ b/packages/core/src/components/stc/sti.ts
@@ -1,4 +1,4 @@
-import { sti } from "../../index.js";
+import { sti } from "../../sti.js";
 
 export const indent = sti("indent");
 export const group = sti("group");

--- a/packages/core/src/context/assignment.ts
+++ b/packages/core/src/context/assignment.ts
@@ -52,7 +52,13 @@ export function createAssignmentContext(
   };
 }
 
-export function getAssignmentSymbol() {
+/**
+ * Get the symbol being defined.
+ *
+ * @returns The symbol currently being defined, or `undefined` if no symbol is
+ * being defined.
+ */
+export function getAssignmentSymbol(): OutputSymbol | undefined {
   const assignmentContext = useContext(AssignmentContext);
   if (assignmentContext) {
     return assignmentContext.target;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from "./name-policy.js";
 export * from "./refkey.js";
 export * from "./render.js";
 export * from "./stc.js";
+export * from "./sti.js";
 export * from "./tap.js";
 export * from "./utils.js";
 export * from "./write-output.js";

--- a/packages/core/src/stc.ts
+++ b/packages/core/src/stc.ts
@@ -6,20 +6,35 @@ import {
   IntrinsicElementBase,
   JSX,
 } from "@alloy-js/core/jsx-runtime";
-import { code } from "./code.js";
+import { code, text } from "./code.js";
 
-export function sti<T extends keyof JSX.IntrinsicElements>(name: T) {
-  return (
-    ...args: unknown extends T ? []
-    : {} extends Omit<JSX.IntrinsicElements[T], "children"> ?
-      [props?: JSX.IntrinsicElements[T]]
-    : [props: JSX.IntrinsicElements[T]]
-  ) => {
+export type StiSignature<T extends keyof JSX.IntrinsicElements> = (
+  ...args: unknown extends T ? []
+  : {} extends Omit<JSX.IntrinsicElements[T], "children"> ?
+    [props?: JSX.IntrinsicElements[T]]
+  : [props: JSX.IntrinsicElements[T]]
+) => StiComponentCreator<T>;
+
+export type StiComponentCreator<T extends keyof JSX.IntrinsicElements> =
+  (() => IntrinsicElementBase<T>) & {
+    code(
+      template: TemplateStringsArray,
+      ...substitutions: Children[]
+    ): () => IntrinsicElementBase<T>;
+    text(
+      template: TemplateStringsArray,
+      ...substitutions: Children[]
+    ): () => IntrinsicElementBase<T>;
+    children(...children: Children[]): () => IntrinsicElementBase<T>;
+  };
+
+export function sti<T extends keyof JSX.IntrinsicElements>(
+  name: T,
+): StiSignature<T> {
+  return (...args) => {
     const props: JSX.IntrinsicElements[T] | undefined = args[0];
-    const fn = () => createIntrinsic(name, props!);
-    fn.children = (
-      ...children: Children[]
-    ): (() => IntrinsicElementBase<T>) => {
+    const fn: StiComponentCreator<T> = () => createIntrinsic(name, props!);
+    fn.children = (...children: Children[]) => {
       const propsWithChildren = {
         ...(props ?? {}),
         children,
@@ -28,13 +43,19 @@ export function sti<T extends keyof JSX.IntrinsicElements>(name: T) {
       return () => createIntrinsic(name, propsWithChildren as any);
     };
 
-    fn.code = (
-      template: TemplateStringsArray,
-      ...substitutions: Children[]
-    ): (() => IntrinsicElementBase<T>) => {
+    fn.code = (template, ...substitutions) => {
       const propsWithChildren = {
         ...(args[0] ?? {}),
         children: code(template, ...substitutions),
+      };
+
+      return () => createIntrinsic(name, propsWithChildren as any);
+    };
+
+    fn.text = (template, ...substitutions) => {
+      const propsWithChildren = {
+        ...(args[0] ?? {}),
+        children: text(template, ...substitutions),
       };
 
       return () => createIntrinsic(name, propsWithChildren as any);
@@ -48,25 +69,32 @@ export type MakeChildrenOptional<T extends object> =
     Omit<T, "children"> & Partial<Pick<T, "children">>
   : T;
 
-export function stc<T extends {}>(Component: ComponentDefinition<T>) {
-  return (
-    ...args: unknown extends T ? []
-    : {} extends Omit<T, "children"> ? [props?: MakeChildrenOptional<T>]
-    : [props: MakeChildrenOptional<T>]
-  ) => {
-    const fn: ComponentCreator<T> & {
-      code(
-        template: TemplateStringsArray,
-        ...substitutions: Children[]
-      ): ComponentCreator<T>;
-      children(...children: Children[]): ComponentCreator<T>;
-    } = () => Component(args[0] as any);
+export type StcSignature<T extends {}> = (
+  ...args: unknown extends T ? []
+  : {} extends Omit<T, "children"> ? [props?: MakeChildrenOptional<T>]
+  : [props: MakeChildrenOptional<T>]
+) => StcComponentCreator<T>;
+
+export type StcComponentCreator<T> = ComponentCreator<T> & {
+  code(
+    template: TemplateStringsArray,
+    ...substitutions: Children[]
+  ): ComponentCreator<T>;
+  text(
+    template: TemplateStringsArray,
+    ...substitutions: Children[]
+  ): ComponentCreator<T>;
+  children(...children: Children[]): ComponentCreator<T>;
+};
+
+export function stc<T extends {}>(
+  Component: ComponentDefinition<T>,
+): StcSignature<T> {
+  return (...args) => {
+    const fn: StcComponentCreator<T> = () => Component(args[0] as any);
     fn.component = Component;
     fn.props = args[0]!;
-    fn.code = (
-      template: TemplateStringsArray,
-      ...substitutions: Children[]
-    ): ComponentCreator<T> => {
+    fn.code = (template, ...substitutions): ComponentCreator<T> => {
       const propsWithChildren = {
         ...(args[0] ?? {}),
         children: code(template, ...substitutions),
@@ -77,7 +105,17 @@ export function stc<T extends {}>(Component: ComponentDefinition<T>) {
       fn.props = args[0]!;
       return fn;
     };
+    fn.text = (template, ...substitutions) => {
+      const propsWithChildren = {
+        ...(args[0] ?? {}),
+        children: text(template, ...substitutions),
+      };
 
+      const fn = () => Component(propsWithChildren as any);
+      fn.component = Component;
+      fn.props = args[0]!;
+      return fn;
+    };
     fn.children = (...children: Children[]): ComponentCreator<T> => {
       const propsWithChildren = {
         ...(args[0] ?? {}),

--- a/packages/core/src/stc.ts
+++ b/packages/core/src/stc.ts
@@ -2,67 +2,8 @@ import {
   Children,
   ComponentCreator,
   ComponentDefinition,
-  createIntrinsic,
-  IntrinsicElementBase,
-  JSX,
 } from "@alloy-js/core/jsx-runtime";
 import { code, text } from "./code.js";
-
-export type StiSignature<T extends keyof JSX.IntrinsicElements> = (
-  ...args: unknown extends T ? []
-  : {} extends Omit<JSX.IntrinsicElements[T], "children"> ?
-    [props?: JSX.IntrinsicElements[T]]
-  : [props: JSX.IntrinsicElements[T]]
-) => StiComponentCreator<T>;
-
-export type StiComponentCreator<T extends keyof JSX.IntrinsicElements> =
-  (() => IntrinsicElementBase<T>) & {
-    code(
-      template: TemplateStringsArray,
-      ...substitutions: Children[]
-    ): () => IntrinsicElementBase<T>;
-    text(
-      template: TemplateStringsArray,
-      ...substitutions: Children[]
-    ): () => IntrinsicElementBase<T>;
-    children(...children: Children[]): () => IntrinsicElementBase<T>;
-  };
-
-export function sti<T extends keyof JSX.IntrinsicElements>(
-  name: T,
-): StiSignature<T> {
-  return (...args) => {
-    const props: JSX.IntrinsicElements[T] | undefined = args[0];
-    const fn: StiComponentCreator<T> = () => createIntrinsic(name, props!);
-    fn.children = (...children: Children[]) => {
-      const propsWithChildren = {
-        ...(props ?? {}),
-        children,
-      };
-
-      return () => createIntrinsic(name, propsWithChildren as any);
-    };
-
-    fn.code = (template, ...substitutions) => {
-      const propsWithChildren = {
-        ...(args[0] ?? {}),
-        children: code(template, ...substitutions),
-      };
-
-      return () => createIntrinsic(name, propsWithChildren as any);
-    };
-
-    fn.text = (template, ...substitutions) => {
-      const propsWithChildren = {
-        ...(args[0] ?? {}),
-        children: text(template, ...substitutions),
-      };
-
-      return () => createIntrinsic(name, propsWithChildren as any);
-    };
-    return fn;
-  };
-}
 
 export type MakeChildrenOptional<T extends object> =
   T extends { children?: any } ?

--- a/packages/core/src/sti.ts
+++ b/packages/core/src/sti.ts
@@ -1,0 +1,63 @@
+import {
+  Children,
+  createIntrinsic,
+  IntrinsicElementBase,
+  JSX,
+} from "@alloy-js/core/jsx-runtime";
+import { code, text } from "./code.js";
+
+export type StiSignature<T extends keyof JSX.IntrinsicElements> = (
+  ...args: unknown extends T ? []
+  : {} extends Omit<JSX.IntrinsicElements[T], "children"> ?
+    [props?: JSX.IntrinsicElements[T]]
+  : [props: JSX.IntrinsicElements[T]]
+) => StiComponentCreator<T>;
+
+export type StiComponentCreator<T extends keyof JSX.IntrinsicElements> =
+  (() => IntrinsicElementBase<T>) & {
+    code(
+      template: TemplateStringsArray,
+      ...substitutions: Children[]
+    ): () => IntrinsicElementBase<T>;
+    text(
+      template: TemplateStringsArray,
+      ...substitutions: Children[]
+    ): () => IntrinsicElementBase<T>;
+    children(...children: Children[]): () => IntrinsicElementBase<T>;
+  };
+
+export function sti<T extends keyof JSX.IntrinsicElements>(
+  name: T,
+): StiSignature<T> {
+  return (...args) => {
+    const props: JSX.IntrinsicElements[T] | undefined = args[0];
+    const fn: StiComponentCreator<T> = () => createIntrinsic(name, props!);
+    fn.children = (...children: Children[]) => {
+      const propsWithChildren = {
+        ...(props ?? {}),
+        children,
+      };
+
+      return () => createIntrinsic(name, propsWithChildren as any);
+    };
+
+    fn.code = (template, ...substitutions) => {
+      const propsWithChildren = {
+        ...(args[0] ?? {}),
+        children: code(template, ...substitutions),
+      };
+
+      return () => createIntrinsic(name, propsWithChildren as any);
+    };
+
+    fn.text = (template, ...substitutions) => {
+      const propsWithChildren = {
+        ...(args[0] ?? {}),
+        children: text(template, ...substitutions),
+      };
+
+      return () => createIntrinsic(name, propsWithChildren as any);
+    };
+    return fn;
+  };
+}

--- a/packages/core/src/tap.ts
+++ b/packages/core/src/tap.ts
@@ -7,21 +7,72 @@ import { useScope } from "./context/scope.js";
 import { SourceFileContext } from "./context/source-file.js";
 import { ComponentDefinition } from "./jsx-runtime.js";
 
+/**
+ * The return value of {@link createTap}, this holds a reference to the tapped
+ * value. It will be undefined until the tapped value is initialized.
+ */
 export interface Tap<T> extends ComponentDefinition {
+  /** Ref for the tapped value */
   ref: ShallowRef<T | undefined>;
 }
 
+/**
+ * A function called when the Tap is rendered.
+ *
+ * @returns The tapped value.
+ */
 export interface Tapper<T> {
   (): T | undefined;
 }
 
-export interface Handler<T> {
+/**
+ * A function that is called when the tapped value is available.
+ */
+export interface TapHandler<T> {
   (value: T): void;
 }
 
+/**
+ * Create a component that when rendered, initializes the tapped value
+ * with the provided callback. This is useful for accessing context
+ * provided by child components inside a parent component.
+ *
+ * @example
+ * ```tsx
+ * import { type Children, computed, createTap } from "@alloy-js/core";
+ *
+ * // context we will tap into
+ * const SomeContext = createContext<string>();
+ *
+ * // a component which provides some specific context
+ * function MyDeclaration(props: { children: Children }) {
+ *   return <SomeContext.Provider value="Hello World">
+ *     {props.children}
+ *   </SomeContext.Provider>;
+ * }
+ *
+ * // a parent component which wants to know about the context set
+ * // by its children
+ * function MySpecialDeclaration() {
+ *   const SomeContextTap = createTap(() => useContext(SomeContext));
+ *
+ *   return <>
+ *     The declaration context is: {SomeContextTap.ref}
+ *     <MyDeclaration>
+ *       <SomeContextTap />
+ *     </MyDeclaration>
+ *   </>
+ * }
+ *
+ * @see {@link createDeclarationTap} for tapping {@link DeclarationContext}.
+ * @see {@link createMemberTap} for tapping {@link MemberDeclarationContext}.
+ * @see {@link createScopeTap} for tapping {@link OutputScope}.
+ * @see {@link createSourceFileTap} for tapping {@link SourceFileContext}.
+ * ```
+ */
 export function createTap<T = unknown>(
   tapper: Tapper<T>,
-  handler?: Handler<T>,
+  handler?: TapHandler<T>,
 ): Tap<T> {
   const signal = shallowRef<T | undefined>(undefined);
   const fn = () => {
@@ -38,31 +89,43 @@ export function createTap<T = unknown>(
   return fn;
 }
 
+/**
+ * Create a tap for {@link DeclarationContext}.
+ */
 export function createDeclarationTap<
   TSymbol extends OutputSymbol = OutputSymbol,
->(handler?: Handler<TSymbol>) {
+>(handler?: TapHandler<TSymbol>) {
   return createTap<TSymbol>(() => {
     return useContext(DeclarationContext) as any;
   }, handler);
 }
 
+/**
+ * Create a tap for {@link MemberDeclarationContext}.
+ */
 export function createMemberTap<TSymbol extends OutputSymbol = OutputSymbol>(
-  handler?: Handler<TSymbol>,
+  handler?: TapHandler<TSymbol>,
 ) {
   return createTap<TSymbol>(() => {
     return useContext(MemberDeclarationContext) as any;
   }, handler);
 }
 
+/**
+ * Create a tap for {@link OutputScope}.
+ */
 export function createScopeTap<TScope extends OutputScope = OutputScope>(
-  handler?: Handler<TScope>,
+  handler?: TapHandler<TScope>,
 ) {
   return createTap<TScope>(() => {
     return useScope() as any;
   }, handler);
 }
 
-export function createSourceFileTap(handler?: Handler<SourceFileContext>) {
+/**
+ * Create a tap for {@link (SourceFileContext:interface)}.
+ */
+export function createSourceFileTap(handler?: TapHandler<SourceFileContext>) {
   return createTap(() => {
     return useContext(SourceFileContext);
   }, handler);

--- a/packages/core/src/utils.tsx
+++ b/packages/core/src/utils.tsx
@@ -12,6 +12,7 @@ import {
   untrack,
 } from "./jsx-runtime.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { BaseListProps } from "./components/List.jsx";
 import { OutputDirectory, OutputFile, render } from "./render.js";
 
 export interface JoinOptions {
@@ -320,4 +321,43 @@ export function traverseOutput(
       visitor.visitFile(item);
     }
   }
+}
+
+/**
+ * Convert a list of props to a joiner and ender for use in {@link mapJoin}.
+ */
+export function baseListPropsToMapJoinArgs(props: BaseListProps): JoinOptions {
+  let joiner, punctuation;
+  if ("joiner" in props) {
+    joiner = props.joiner;
+  } else {
+    punctuation =
+      props.comma ? ","
+      : props.semicolon ? ";"
+      : "";
+
+    joiner = (
+      <>
+        {punctuation}
+        {props.softline ?
+          <sbr />
+        : props.hardline ?
+          <hbr />
+        : props.literalline ?
+          <lbr />
+        : props.line ?
+          <br />
+        : props.space ?
+          <> </>
+        : <hbr />}
+      </>
+    );
+  }
+
+  const ender =
+    "ender" in props ? props.ender
+    : props.enderPunctuation ? punctuation
+    : undefined;
+
+  return { joiner, ender };
 }

--- a/packages/core/src/utils.tsx
+++ b/packages/core/src/utils.tsx
@@ -324,7 +324,7 @@ export function traverseOutput(
 }
 
 /**
- * Convert a list of props to a joiner and ender for use in {@link mapJoin}.
+ * Convert a list of props to a joiner and ender for use in {@link (mapJoin:1)}.
  */
 export function baseListPropsToMapJoinArgs(props: BaseListProps): JoinOptions {
   let joiner, punctuation;

--- a/packages/docs/scripts/components/Code.ts
+++ b/packages/docs/scripts/components/Code.ts
@@ -1,14 +1,18 @@
-import { code } from "@alloy-js/core";
-import redent from "redent";
+import { text, type Children } from "@alloy-js/core";
+import { dedentToRoot, hbr, indent } from "@alloy-js/core/stc";
 
 export interface CodeProps {
-  code: string;
   language: string;
+  children: Children;
 }
 export function Code(props: CodeProps) {
-  const indentedCode = "\n" + redent(props.code, 2);
-
-  return code`
-    <Code code={\`${indentedCode}\` } lang="${props.language}" />
+  return text`
+    <Code
+      code={\`${dedentToRoot().children(
+        indent().children(props.children),
+        hbr(),
+      )}\`}
+      lang="${props.language}"
+    />
   `;
 }

--- a/packages/docs/scripts/components/Examples.ts
+++ b/packages/docs/scripts/components/Examples.ts
@@ -23,6 +23,5 @@ export function Examples(props: ExamplesProps) {
 
   return MdxSection({
     title: `Example${exampleBlocks.length > 1 ? "s" : ""}`,
-    level: 3,
   }).children(exampleCode);
 }

--- a/packages/docs/scripts/components/InterfaceMembers.ts
+++ b/packages/docs/scripts/components/InterfaceMembers.ts
@@ -7,7 +7,7 @@ import {
   ApiPropertySignature,
   type ApiInterface,
 } from "@microsoft/api-extractor-model";
-import { resolveExcerptReference } from "../utils.js";
+import { flattenedMembers } from "../utils.js";
 import { Excerpt, TsDoc } from "./stc/index.js";
 
 export interface InterfaceMembersProps {
@@ -15,34 +15,11 @@ export interface InterfaceMembersProps {
   flatten?: boolean;
 }
 export function InterfaceMembers(props: InterfaceMembersProps) {
-  let members = props.iface.members as ApiItem[];
+  let members;
   if (props.flatten) {
-    try {
-      for (const extendsType of props.iface.extendsTypes) {
-      }
-    } catch (e) {
-      console.log("Failure to do anything with", props.iface);
-    }
-    for (const extendsType of props.iface.extendsTypes ?? []) {
-      const refType = resolveExcerptReference(
-        extendsType.excerpt.spannedTokens[0],
-        props.iface,
-      );
-      if (!refType) continue;
-      if (refType.kind !== ApiItemKind.Interface) continue;
-
-      members.push(...refType.members);
-    }
-
-    members = members.sort((a, b) => {
-      if (a.displayName < b.displayName) {
-        return -1;
-      }
-      if (a.displayName > b.displayName) {
-        return 1;
-      }
-      return 0;
-    });
+    members = flattenedMembers(props.iface);
+  } else {
+    members = props.iface.members as ApiItem[];
   }
 
   const rows = members.map((member) => {

--- a/packages/docs/scripts/components/MdxSection.ts
+++ b/packages/docs/scripts/components/MdxSection.ts
@@ -1,15 +1,19 @@
 import type { Children } from "@alloy-js/core";
+import { SectionContext, useSectionContext } from "../contexts/section.js";
 import { MdxParagraph } from "./stc/index.js";
 
 export interface MdxSectionProps {
   title: string;
-  level: number;
   children?: Children;
 }
 
 export function MdxSection(props: MdxSectionProps) {
+  const sectionContext = useSectionContext();
+  const level = sectionContext.level + 1;
   return [
-    MdxParagraph().children("#".repeat(props.level) + " " + props.title),
-    MdxParagraph().children(props.children),
+    MdxParagraph().children("#".repeat(level) + " " + props.title),
+    SectionContext.ProviderStc({ value: { level } }).children(
+      MdxParagraph().children(props.children),
+    ),
   ];
 }

--- a/packages/docs/scripts/components/Remarks.ts
+++ b/packages/docs/scripts/components/Remarks.ts
@@ -10,7 +10,7 @@ export function Remarks(props: RemarksProps) {
   if (!props.type.tsdocComment || !props.type.tsdocComment.remarksBlock)
     return "";
 
-  return MdxSection({ title: "Remarks", level: 3 }).children(
+  return MdxSection({ title: "Remarks" }).children(
     TsDoc({ node: props.type.tsdocComment.remarksBlock, context: props.type }),
   );
 }

--- a/packages/docs/scripts/components/SeeAlso.ts
+++ b/packages/docs/scripts/components/SeeAlso.ts
@@ -53,7 +53,7 @@ export function SeeAlso(props: SeeAlsoProps) {
 
   const contextsProvidedList =
     contextsProvided.length > 0 &&
-    MdxSection({ title: "Contexts provided", level: 2 }).children(
+    MdxSection({ title: "Contexts provided" }).children(
       mapJoin(
         () => contextsProvided,
         (seeBlock) => {
@@ -66,7 +66,7 @@ export function SeeAlso(props: SeeAlsoProps) {
 
   const seeAlsoList =
     seeBlocks.length > 0 &&
-    MdxSection({ title: "See also", level: 3 }).children(
+    MdxSection({ title: "See also" }).children(
       mapJoin(
         () => seeBlocks,
         (seeBlock) => {

--- a/packages/docs/scripts/components/component/ComponentDoc.ts
+++ b/packages/docs/scripts/components/component/ComponentDoc.ts
@@ -24,12 +24,21 @@ export function ComponentDoc(props: ComponentDocProps) {
 
   if (componentProps.length === 0) {
     overloadBlocks = [ComponentSignature({ component: props.component })];
+  } else if (componentProps.length === 1) {
+    overloadBlocks = [
+      Summary({ type: componentProps[0] }),
+      ComponentSignature({
+        component: props.component,
+        propsType: componentProps[0],
+      }),
+      ComponentProps({ propType: componentProps[0] }),
+    ];
   } else {
     let index = 1;
     overloadBlocks = mapJoin(
       () => componentProps,
       (iface) => {
-        return MdxSection({ title: "Overload " + index++, level: 2 }).children(
+        return MdxSection({ title: "Overload " + index++ }).children(
           Summary({ type: iface }),
           ComponentSignature({ component: props.component, propsType: iface }),
           ComponentProps({ propType: iface }),

--- a/packages/docs/scripts/components/component/ComponentProps.ts
+++ b/packages/docs/scripts/components/component/ComponentProps.ts
@@ -8,7 +8,7 @@ export interface ComponentPropsProps {
 export function ComponentProps(props: ComponentPropsProps) {
   if (!props.propType) return "";
 
-  return MdxSection({ title: "Props", level: 3 }).children(
+  return MdxSection({ title: "Props" }).children(
     InterfaceMembers({ iface: props.propType, flatten: true }),
   );
 }

--- a/packages/docs/scripts/components/context/ContextAccessor.ts
+++ b/packages/docs/scripts/components/context/ContextAccessor.ts
@@ -1,3 +1,4 @@
+import { code } from "@alloy-js/core";
 import type { ContextApi } from "../../build-json.js";
 import { Code, MdxSection, Summary } from "../stc/index.js";
 
@@ -7,24 +8,24 @@ export interface ContextAccessorProps {
 
 export function ContextAccessor(props: ContextAccessorProps) {
   const { contextAccessor } = props.context;
-  const section = MdxSection({ title: "Accessor", level: 3 });
+  const section = MdxSection({ title: "Accessor" });
 
   if (contextAccessor) {
-    const code = `
+    const c = code`
       import { ${contextAccessor.displayName} } from "@alloy-js/core";
       
       const myContext = ${contextAccessor.displayName}();
     `;
 
     return section.children(
-      Code({ code, language: "ts" }),
+      Code({ language: "ts" }).children(c),
       Summary({ type: contextAccessor }),
     );
   } else {
-    const code = `
+    const c = code`
       const myContext = useContext(${props.context.name}Context);
     `;
 
-    return section.children(Code({ code, language: "ts" }));
+    return section.children(Code({ language: "ts" }).children(c));
   }
 }

--- a/packages/docs/scripts/components/context/ContextDoc.ts
+++ b/packages/docs/scripts/components/context/ContextDoc.ts
@@ -2,6 +2,7 @@ import type { ContextApi } from "../../build-json.js";
 import type { DeclarationDescriptor } from "../DocSourceFile.js";
 import {
   ContextAccessor,
+  ContextFactory,
   ContextInterface,
   ContextSignature,
   DocSourceFile,
@@ -16,7 +17,8 @@ export interface ContextDocProps {
 
 export function ContextDoc(props: ContextDocProps) {
   const title = props.context.name + " context";
-  const { contextVariable, contextAccessor, contextInterface } = props.context;
+  const { contextVariable, contextAccessor, contextInterface, contextFactory } =
+    props.context;
 
   const declares: DeclarationDescriptor[] = [
     { name: title, apiItem: contextVariable },
@@ -35,11 +37,19 @@ export function ContextDoc(props: ContextDocProps) {
     });
   }
 
+  if (contextFactory) {
+    declares.push({
+      name: title + " factory",
+      apiItem: contextFactory,
+    });
+  }
+
   return DocSourceFile({ title, declares }).children(
     Summary({ type: contextVariable }),
     ContextSignature({ context: props.context }),
     ContextAccessor({ context: props.context }),
     ContextInterface({ context: props.context }),
+    ContextFactory({ context: props.context }),
     Remarks({
       type: props.context.contextVariable,
     }),

--- a/packages/docs/scripts/components/context/ContextFactory.ts
+++ b/packages/docs/scripts/components/context/ContextFactory.ts
@@ -1,0 +1,25 @@
+import { code } from "@alloy-js/core";
+import type { ContextApi } from "../../build-json.js";
+import { FunctionSignature, MdxSection, Summary } from "../stc/index.js";
+
+export interface ContextFactoryProps {
+  context: ContextApi;
+}
+
+export function ContextFactory(props: ContextFactoryProps) {
+  const { contextFactory } = props.context;
+  if (!contextFactory) return null;
+
+  const section = MdxSection({ title: "Factory" });
+
+  const c = code`
+      import { ${contextFactory.displayName} } from "@alloy-js/core";
+      
+      const myContext = ${contextFactory.displayName}();
+    `;
+
+  return section.children(
+    FunctionSignature({ fn: contextFactory }),
+    Summary({ type: contextFactory }),
+  );
+}

--- a/packages/docs/scripts/components/context/ContextInterface.ts
+++ b/packages/docs/scripts/components/context/ContextInterface.ts
@@ -7,7 +7,7 @@ export interface ContextInterfaceProps {
 }
 
 export function ContextInterface(props: ContextInterfaceProps) {
-  return MdxSection({ title: "Context interface", level: 3 }).children(
+  return MdxSection({ title: "Context interface" }).children(
     typeof props.context.contextInterface === "string" ?
       props.context.contextInterface
     : InterfaceMembers({

--- a/packages/docs/scripts/components/context/ContextSignature.ts
+++ b/packages/docs/scripts/components/context/ContextSignature.ts
@@ -1,3 +1,4 @@
+import { code } from "@alloy-js/core";
 import type { ContextApi } from "../../build-json.js";
 import { Code, MdxParagraph } from "../stc/index.js";
 
@@ -6,6 +7,6 @@ export interface ContextSignatureProps {
 }
 
 export function ContextSignature(props: ContextSignatureProps) {
-  const code = `const ${props.context.contextVariable.excerpt.text}`;
-  return MdxParagraph().children(Code({ code, language: "ts" }));
+  const c = code`const ${props.context.contextVariable.excerpt.text}`;
+  return MdxParagraph().children(Code({ language: "ts" }).children(c));
 }

--- a/packages/docs/scripts/components/function/FunctionOptions.ts
+++ b/packages/docs/scripts/components/function/FunctionOptions.ts
@@ -15,7 +15,7 @@ export function FunctionOptions(props: FunctionOptionsProps) {
     undefined,
   );
 
-  return MdxSection({ title: "Options", level: 3 }).children(
+  return MdxSection({ title: "Options" }).children(
     InterfaceMembers({ iface: optionsType as ApiInterface, flatten: true }),
   );
 }

--- a/packages/docs/scripts/components/function/FunctionOverloadDoc.ts
+++ b/packages/docs/scripts/components/function/FunctionOverloadDoc.ts
@@ -20,7 +20,7 @@ export interface FunctionOverloadDocProps {
 export function FunctionOverloadDoc(props: FunctionOverloadDocProps) {
   const root =
     props.omitOverloadIndex ? MdxParagraph() : (
-      MdxSection({ title: `Overload ${props.fn.overloadIndex}`, level: 2 })
+      MdxSection({ title: `Overload ${props.fn.overloadIndex}` })
     );
 
   return root.children(

--- a/packages/docs/scripts/components/function/FunctionParameters.ts
+++ b/packages/docs/scripts/components/function/FunctionParameters.ts
@@ -12,7 +12,7 @@ export function FunctionParameters(props: FunctionParametersProps) {
     (param) => code`
       <tr>
         <td style="text-align: right;font-weight: bold;">${param.name}</td>
-        <td>
+        <td>${param.isOptional && `<Badge text="optional" variant="note" size="small" />`}
         
           \`${param.parameterTypeExcerpt.text}\`
           
@@ -22,7 +22,7 @@ export function FunctionParameters(props: FunctionParametersProps) {
     `,
   );
 
-  return MdxSection({ title: "Parameters", level: 3 }).code`
+  return MdxSection({ title: "Parameters" }).code`
     <table>
       ${params}
     </table>

--- a/packages/docs/scripts/components/function/FunctionReturn.ts
+++ b/packages/docs/scripts/components/function/FunctionReturn.ts
@@ -6,7 +6,7 @@ export interface FunctionReturnProps {
 }
 
 export function FunctionReturn(props: FunctionReturnProps) {
-  return MdxSection({ title: "Returns", level: 3 }).children(
+  return MdxSection({ title: "Returns" }).children(
     Excerpt({ excerpt: props.fn.returnTypeExcerpt, context: props.fn }),
     props.fn.tsdocComment &&
       props.fn.tsdocComment.returnsBlock &&

--- a/packages/docs/scripts/components/function/FunctionSignature.ts
+++ b/packages/docs/scripts/components/function/FunctionSignature.ts
@@ -1,3 +1,4 @@
+import { code } from "@alloy-js/core";
 import type { ApiFunction } from "@microsoft/api-extractor-model";
 import { cleanExcerpt } from "../../utils.js";
 import { Code, MdxParagraph } from "../stc/index.js";
@@ -7,11 +8,11 @@ export interface FunctionSignatureProps {
 }
 
 export function FunctionSignature(props: FunctionSignatureProps) {
-  const code = `
+  const c = code`
     import { ${props.fn.name} } from "${props.fn.getAssociatedPackage()?.name}";
 
     ${cleanExcerpt(props.fn.excerpt.text)}
   `;
 
-  return MdxParagraph().children(Code({ code, language: "ts" }));
+  return MdxParagraph().children(Code({ language: "ts" }).children(c));
 }

--- a/packages/docs/scripts/components/stc/index.ts
+++ b/packages/docs/scripts/components/stc/index.ts
@@ -5,6 +5,7 @@ import { ComponentProps as ComponentPropsJsx } from "../component/ComponentProps
 import { ComponentSignature as ComponentSignatureJsx } from "../component/ComponentSignature.js";
 import { ContextAccessor as ContextAccessorJsx } from "../context/ContextAccessor.js";
 import { ContextDoc as ContextDocJsx } from "../context/ContextDoc.js";
+import { ContextFactory as ContextFactoryJsx } from "../context/ContextFactory.js";
 import { ContextInterface as ContextInterfaceJsx } from "../context/ContextInterface.js";
 import { ContextSignature as ContextSignatureJsx } from "../context/ContextSignature.js";
 import { DocDeclaration as DocDeclarationJsx } from "../DocDeclaration.js";
@@ -74,6 +75,7 @@ export const ContextDoc = stc(ContextDocJsx);
 export const ContextSignature = stc(ContextSignatureJsx);
 export const ContextInterface = stc(ContextInterfaceJsx);
 export const ContextAccessor = stc(ContextAccessorJsx);
+export const ContextFactory = stc(ContextFactoryJsx);
 
 export const VariableDoc = stc(VariableDocJsx);
 

--- a/packages/docs/scripts/components/type/TypeMembers.ts
+++ b/packages/docs/scripts/components/type/TypeMembers.ts
@@ -26,7 +26,7 @@ export function TypeMembers(props: TypeMembersProps) {
 
     extendsInfo = code`Extends ${extendsItems}`;
   }
-  return MdxSection({ title: "Members", level: 3 }).children(
+  return MdxSection({ title: "Members" }).children(
     extendsInfo && MdxParagraph().children(extendsInfo),
     InterfaceMembers({ iface: props.type }),
   );

--- a/packages/docs/scripts/contexts/section.ts
+++ b/packages/docs/scripts/contexts/section.ts
@@ -1,0 +1,15 @@
+import {
+  createContext,
+  useContext,
+  type ComponentContext,
+} from "@alloy-js/core";
+
+export interface SectionContext {
+  level: number;
+}
+export const SectionContext: ComponentContext<SectionContext> = createContext({
+  level: 1,
+});
+export function useSectionContext() {
+  return useContext(SectionContext)!;
+}

--- a/packages/docs/scripts/utils.ts
+++ b/packages/docs/scripts/utils.ts
@@ -1,5 +1,10 @@
 import { useContext } from "@alloy-js/core";
-import type { ApiItem, ExcerptToken } from "@microsoft/api-extractor-model";
+import {
+  ApiItemKind,
+  type ApiInterface,
+  type ApiItem,
+  type ExcerptToken,
+} from "@microsoft/api-extractor-model";
 import { ApiModelContext } from "./contexts/api-model.js";
 
 export function resolveExcerptReference(
@@ -17,4 +22,29 @@ export function resolveExcerptReference(
 
 export function cleanExcerpt(excerpt: string) {
   return excerpt.replace(/^(export |declare )*/, "");
+}
+
+export function flattenedMembers(iface: ApiInterface) {
+  const members = [...iface.members];
+
+  for (const extendsType of iface.extendsTypes ?? []) {
+    const refType = resolveExcerptReference(
+      extendsType.excerpt.spannedTokens[0],
+      iface,
+    );
+    if (!refType) continue;
+    if (refType.kind !== ApiItemKind.Interface) continue;
+
+    members.push(...refType.members);
+  }
+
+  return members.sort((a, b) => {
+    if (a.displayName < b.displayName) {
+      return -1;
+    }
+    if (a.displayName > b.displayName) {
+      return 1;
+    }
+    return 0;
+  });
 }

--- a/packages/docs/src/content/docs/guides/basic-concepts.md
+++ b/packages/docs/src/content/docs/guides/basic-concepts.md
@@ -192,35 +192,84 @@ renderString(<MemoExample />);
 // fourTimesValue: 4
 ```
 
-## Whitespace Rules
+## Formatting
 
-Whether using JSX or string templates, whitespace is processed according to the
-following rules:
+Line breaks are ignored within JSX templates and the `text` string template tag,
+and contiguous chunks of whitespace are replaced with a single space. This works
+similarly to HTML. To control the formatting of the emitted output, various
+formatting intrinsic elements are used to format source text according to the
+formatting configuration for a particular output or source file.
+
+Note that, for many situations, you won't need to use these formatting elements
+directly. Components provided by core like `Indent`, `Block`, `List`, and `For`
+generally handle most formatting for you. Additionally, built-in language
+components like `IfStatement`, `Switch`, and so on handle formatting as well. 
+
+The most common formatting intrinsic elements are:
+
+### Line breaks
+
+Alloy has four distinct kinds of line breaks:
+
+* `<hardline />`, `<hbr />` - hard line breaks. Always printed as a line break.
+* `<softline />`, `<sbr />` - soft line breaks. Printed as a line break if the
+  current group exceeds the configured line width, and otherwise printed as
+  nothing.
+* `<literalline />`, `<lbr />` - literal line breaks. Always printed as a
+  linebreak and ignores the indentation level for the next line.
+* `<line />`, `<br />` - regular line breaks. Printed as a line break if the
+  current group exceeds the configured line width, and otherwise is printed as a
+  space.
+
+  Alloy attempts to fit all the text inside a `<group>` on a single line if
+  possible. If the current group cannot fit on a single line, then all line
+  breaks in the group are printed as line breaks. The `<fill>` element behaves
+  similar to `<group>` except only regular line breaks at the end of a line are
+  printed as line breaks, making it useful for formatting text.
+
+### Indentation
+
+* `<indent>` - increase the indent level by one.
+* `<dedent>` - decrease the dedent level by one.
+* `<dedentToRoot>` - decrease the indent level to the root indentation level, which is either no indent or the indent level set by `<markAsRoot />`.
+* `<align width={number} string={string}>` - increase the indent by the given
+  width or with the given string prefix.
+
+### Conditional formatting
+
+* `<indentIfBreak groupId={symbol} negate={boolean}>` - indent the group if a previously printed group is broken (or if it isn't broken when passing `negate`).
+* `<ifBreak groupId={symbol} flatContents={Children}>` - if the current group (or group referenced by the given `groupId`) is broken, print the children. Otherwise, print `flatContents`.
+
+### `code` content
+
+The `code` template tag is akin to the `<code>` HTML element in that it
+preserves linebreaks. It also normalizes indentation. Whitespace is processed
+according to the following rules:
 
 **Any leading and trailing line breaks are ignored**
 
 ```jsx
-renderString(<>
+renderString(code`
 x
-</>); // "x"
+`); // "x"
 ```
 
 **The first significant line sets the base indent**
 
 ```jsx
-renderString(<>
+renderString(code`
   x
   y
-</>); // "x\ny"
+`); // "x\ny"
 ```
 
 **Lines which increase indent set indent level for any contents on that line**
 
 ```jsx
-renderString(<>
+renderString(code`
   base
-    {"a\nb"}
-</>);
+    ${code`a\nb`}
+`);
 // base
 //   a
 //   b

--- a/packages/docs/src/content/docs/guides/getting-started.mdx
+++ b/packages/docs/src/content/docs/guides/getting-started.mdx
@@ -6,10 +6,11 @@ import { Code, Steps, TabItem, Tabs } from '@astrojs/starlight/components';
 
 ## Quick Start
 
-Clone the alloy project template, which is already configured for generating TypeScript code and writing tests in vitest.
+Initialize a new project with npm init:
 
-<Code code="git clone https://github.com/alloy-framework/alloy-project-template my-project
+<Code code="mkdir my-project
 cd my-project
+npm init @alloy-js
 pnpm install
 pnpm build
 " frame="terminal" lang="sh" />

--- a/packages/docs/src/content/docs/guides/typescript-walkthrough.mdx
+++ b/packages/docs/src/content/docs/guides/typescript-walkthrough.mdx
@@ -579,20 +579,20 @@ Finally, we can pull everything together into the method body:
       parameters={parameters}
       returnType={returnType}
     >
-      {code`
-        const response = await ${(
+      \{code\`
+        const response = await $\{(
           <ts.FunctionCallExpression
             target="fetch"
-            args={[endpoint, options]}
+            args=\{[endpoint, options]\}
           />
-        )};
+        )\};
         
-        if (!response.ok) { 
+        if (!response.ok) \{ 
           throw new Error("Request failed: " + response.status);
-        }
+        \}
 
-        return response.json() as ${returnType};
-      `}
+        return response.json() as $\{returnType\};
+      \`\}
     </ts.ClassMethod>
   );
 `} frame="code"lang="tsx" title="src/components/ClientMethod.tsx" />

--- a/packages/docs/src/content/docs/guides/typescript-walkthrough.mdx
+++ b/packages/docs/src/content/docs/guides/typescript-walkthrough.mdx
@@ -68,8 +68,9 @@ First, let's initialize our alloy project. See [the getting started
 guide](../getting-started) for details, but the easiest way is to clone the
 starter template.
 
-<Code code={`git clone https://github.com/alloy-framework/alloy-project-template my-project
+<Code code={`mkdir my-project
 cd my-project
+npm init @alloy-js
 pnpm install
 pnpm build
 `} frame="terminal" lang="sh" />
@@ -143,7 +144,7 @@ Next, let's create the entrypoint for our code generator, and see some output
 so we can start iterating. Create `src/index.tsx` as follows:
 
 <Code code={`
-  import { mapJoin, Output, render, writeOutput } from "@alloy-js/core";
+  import { For, Output, render, writeOutput } from "@alloy-js/core";
   import * as ts from "@alloy-js/typescript";
   import { api } from "./schema.js";
 
@@ -316,7 +317,7 @@ So let's create both `src/components/Model.tsx` and
 ### The Model component
 
 <Code code={`
-  import { mapJoin, refkey } from "@alloy-js/core";
+  import { For, refkey } from "@alloy-js/core";
   import * as ts from "@alloy-js/typescript";
 
   import { RestApiModel } from "../schema.js";
@@ -327,26 +328,28 @@ So let's create both `src/components/Model.tsx` and
   }
 
   export function Model(props: ModelProps) {
-    const members = mapJoin(
-      props.model.properties,
-      prop => <ModelProperty property={prop} />
+    return (
+      <ts.InterfaceDeclaration
+        export
+        name={props.model.name}
+        refkey={refkey(props.model)}
+      >
+        <For each={props.model.properties} comma hardline enderPunctuation>
+          {(prop) => <ModelProperty property={prop} />}
+        </For>
+      </ts.InterfaceDeclaration>
     );
-
-    return <ts.InterfaceDeclaration export name={props.model.name} refkey={refkey(props.model)}>
-      {members}
-    </ts.InterfaceDeclaration>;
   }
 `} frame="code"lang="tsx" title="src/components/Model.ts" />
 
 This creates the model properties using a component we'll cover in the next
 section and adds them into an interface declaration. This component introduces
-two new concepts: `mapJoin` and `refkey`.
+two new concepts: The `For` component and `refkey`.
 
-[mapJoin](../../reference/core/functions/mapjoin/) is a utility that behaves
-similar to a map followed by a join on an Array, except it works in terms of
-`Children` rather than Array elements and strings. Essentially, this means it
-properly handles components (`ModelProperty` in this case). By default,
-`mapJoin` joins with a single line break, but a different joiner can be provided.
+[For](../../reference/core/components/for/) takes an iterable thing and maps it
+using the provided callback. Various props like `comma`, `hardline`, and
+`enderPunctuation` control what content goes between each element and at the end
+of all the elements. This is the main way we format lists of things.
 
 A [refkey](../basic-concepts/#declarations-and-references) is a unique identifier
 for some symbol, and is used to create references to that symbol. Since we are
@@ -403,20 +406,16 @@ component. This is just the schema for the property.
       component from `@alloy-js/typescript`.
 
 With these two components done, we can update our `index.tsx` to make use of these new
-components. First, we need to create a declaration for each of the models in our
-schema, which we can do using `mapJoin`, and then we can update our output once
-again to the following:
+components. Using `For`, we can emit each of our model declarations.
 
 <Code code={`
-  const modelDecls = mapJoin(api.models, (model) => <Model model={model} />);
-
   const output = render(
     <Output>
       <ApiContext.Provider value={createApiContext(api)}>
         <ts.PackageDirectory name={\`\${api.name}-client\`} version="1.0.0">
-          <ts.SourceFile path="models.ts">
-            {modelDecls}
-          </ts.SourceFile>
+        <ts.SourceFile path="models.ts">
+          <For each={api.models}>{(model) => <Model model={model} />}</For>
+        </ts.SourceFile>
           <ts.SourceFile path="client.ts">
           </ts.SourceFile>
           <ts.BarrelFile export="." />
@@ -457,7 +456,7 @@ let's take it step by step.
 #### 1. Imports and setup
 
 <Code code={`
-  import { Children, code, refkey } from "@alloy-js/core";
+  import { Block, For, Children, code, refkey } from "@alloy-js/core";
   import * as ts from "@alloy-js/typescript";
   import { useApi } from "../context/api.js";
   import { RestApiOperation } from "../schema.js";
@@ -550,13 +549,16 @@ step 2.
 #### 5. Determine the parameters to fetch
 
 <Code code={`
-  const options = op.verb ===
-    "post" && <>, 
-      <ts.ObjectExpression>
-        <ts.ObjectProperty name="method" jsValue="POST" />,
-        <ts.ObjectProperty name="body">JSON.stringify({refkey(op, "requestBody")})</ts.ObjectProperty>
-      </ts.ObjectExpression>
-    </>;
+  const options = op.verb === "post" && (
+    <ts.ObjectExpression>
+      <ts.CommaList>
+        <ts.ObjectProperty name="method" jsValue={"POST"} />
+        <ts.ObjectProperty name="body">
+          JSON.stringify({refkey(op, "requestBody")})
+        </ts.ObjectProperty>
+      </ts.CommaList>
+    </ts.ObjectExpression>
+  );
 `} frame="code"lang="tsx" title="src/components/ClientMethod.tsx" />
 
 When we are doing a POST, we need to tell `fetch` to use that verb and provide
@@ -570,20 +572,29 @@ stringifies the `requestBody` parameter, which we defined in step 2.
 Finally, we can pull everything together into the method body:
 
 <Code code={`
-  return <ts.ClassMethod
-    async
-    name={op.name}
-    parameters={parameters}
-    returnType={returnType}
-  >
-    const response = await fetch({endpoint}{options});
-    
-    if (!response.ok) <ts.Block>
-      throw new Error("Request failed: " + response.status);
-    </ts.Block>
+  return (
+    <ts.ClassMethod
+      async
+      name={op.name}
+      parameters={parameters}
+      returnType={returnType}
+    >
+      {code`
+        const response = await ${(
+          <ts.FunctionCallExpression
+            target="fetch"
+            args={[endpoint, options]}
+          />
+        )};
+        
+        if (!response.ok) { 
+          throw new Error("Request failed: " + response.status);
+        }
 
-    return response.json() as {returnType};
-  </ts.ClassMethod>;
+        return response.json() as ${returnType};
+      `}
+    </ts.ClassMethod>
+  );
 `} frame="code"lang="tsx" title="src/components/ClientMethod.tsx" />
 
 The class method is defined as async, given a name based on what's in the API spec,
@@ -594,26 +605,34 @@ and all the parts we assembled previously are slotted into the appropriate place
 The Client component is relatively straight forward:
 
 <Code code={`
-  import { mapJoin, refkey } from "@alloy-js/core";
+  import { refkey } from "@alloy-js/core";
   import * as ts from "@alloy-js/typescript";
   import { useApi } from "../context/api.js";
   import { ClientMethod } from "./ClientMethod.jsx";
 
   export function Client() {
     const schema = useApi().schema;
-    const methods = mapJoin(schema.operations, (op) => <ClientMethod operation={op} />);
     const name = \`\${schema.name}Client\`;
 
     return <ts.ClassDeclaration name={name} export refkey={refkey(schema)}>
-      {methods}
+      <For
+        each={schema.operations}
+        joiner={
+          <>
+            <hbr />
+            <hbr />
+          </>
+        }
+      >
+        {(op) => <ClientMethod operation={op} />}
+      </For>
     </ts.ClassDeclaration>;
   }
 `} frame="code"lang="tsx" title="src/components/Client.tsx" />
 
-We join together using `mapJoin` each of the methods, and add those into a
-ClassDeclaration. The class itself gets a name of the service concatenated with
-`Client`. It is exported from the module. It is also given a refkey for good
-measure, although we don't use it yet.
+We join together each of the methods using `For`. The class itself gets a name
+of the service concatenated with `Client`. It is exported from the module. It is
+also given a refkey for good measure, although we don't use it yet.
 
 With this, we can drop the client into our output by importing the `Client`
 component and updating our output like the following:

--- a/patches/@microsoft__tsdoc@0.15.0.patch
+++ b/patches/@microsoft__tsdoc@0.15.0.patch
@@ -1,0 +1,218 @@
+diff --git a/lib/emitters/TSDocEmitter.js b/lib/emitters/TSDocEmitter.js
+index 8a212a20d2de52283efcf591cee590085b4de2b9..201ee8b414763babfa3cde7894eab377b3cc408d 100644
+--- a/lib/emitters/TSDocEmitter.js
++++ b/lib/emitters/TSDocEmitter.js
+@@ -61,6 +61,10 @@ var TSDocEmitter = /** @class */ (function () {
+             return;
+         }
+         switch (docNode.kind) {
++            case DocNodeKind.SoftBreak:
++                // @ts-ignore
++                this._writeNewline();
++                break;
+             case DocNodeKind.Block:
+                 var docBlock = docNode;
+                 this._ensureLineSkipped();
+diff --git a/lib/transforms/TrimSpacesTransform.js b/lib/transforms/TrimSpacesTransform.js
+index e61af571c3f493f9b7a76690cd7da57c376caf4a..543e86e5b5699cc43cccaabcead66c6b7d47e1c7 100644
+--- a/lib/transforms/TrimSpacesTransform.js
++++ b/lib/transforms/TrimSpacesTransform.js
+@@ -8,80 +8,16 @@ var TrimSpacesTransform = /** @class */ (function () {
+     function TrimSpacesTransform() {
+     }
+     TrimSpacesTransform.transform = function (docParagraph) {
+-        var transformedNodes = [];
+-        // Whether the next nonempty node to be added needs a space before it
+-        var pendingSpace = false;
+-        // The DocPlainText node that we're currently accumulating
+-        var accumulatedTextChunks = [];
+-        var accumulatedNodes = [];
+-        // We always trim leading whitespace for a paragraph.  This flag gets set to true
+-        // as soon as nonempty content is encountered.
+-        var finishedSkippingLeadingSpaces = false;
+-        for (var _i = 0, _a = docParagraph.nodes; _i < _a.length; _i++) {
+-            var node = _a[_i];
+-            switch (node.kind) {
+-                case DocNodeKind.PlainText:
+-                    var docPlainText = node;
+-                    var text = docPlainText.text;
+-                    var startedWithSpace = /^\s/.test(text);
+-                    var endedWithSpace = /\s$/.test(text);
+-                    var collapsedText = text.replace(/\s+/g, ' ').trim();
+-                    if (startedWithSpace && finishedSkippingLeadingSpaces) {
+-                        pendingSpace = true;
+-                    }
+-                    if (collapsedText.length > 0) {
+-                        if (pendingSpace) {
+-                            accumulatedTextChunks.push(' ');
+-                            pendingSpace = false;
+-                        }
+-                        accumulatedTextChunks.push(collapsedText);
+-                        accumulatedNodes.push(node);
+-                        finishedSkippingLeadingSpaces = true;
+-                    }
+-                    if (endedWithSpace && finishedSkippingLeadingSpaces) {
+-                        pendingSpace = true;
+-                    }
+-                    break;
+-                case DocNodeKind.SoftBreak:
+-                    if (finishedSkippingLeadingSpaces) {
+-                        pendingSpace = true;
+-                    }
+-                    accumulatedNodes.push(node);
+-                    break;
+-                default:
+-                    if (pendingSpace) {
+-                        accumulatedTextChunks.push(' ');
+-                        pendingSpace = false;
+-                    }
+-                    // Push the accumulated text
+-                    if (accumulatedTextChunks.length > 0) {
+-                        // TODO: We should probably track the accumulatedNodes somehow, e.g. so we can map them back to the
+-                        // original excerpts.  But we need a developer scenario before we can design this API.
+-                        transformedNodes.push(new DocPlainText({
+-                            configuration: docParagraph.configuration,
+-                            text: accumulatedTextChunks.join('')
+-                        }));
+-                        accumulatedTextChunks.length = 0;
+-                        accumulatedNodes.length = 0;
+-                    }
+-                    transformedNodes.push(node);
+-                    finishedSkippingLeadingSpaces = true;
+-            }
++        if (docParagraph.nodes.length > 0 && 
++            docParagraph.nodes[docParagraph.nodes.length - 1].kind === "SoftBreak") {
++            const transformedNodes = docParagraph.nodes.slice(0, -1);
++            const transformedParagraph = new DocParagraph({
++                configuration: docParagraph.configuration
++            });
++            transformedParagraph.appendNodes(transformedNodes);
++            return transformedParagraph;
+         }
+-        // Push the accumulated text
+-        if (accumulatedTextChunks.length > 0) {
+-            transformedNodes.push(new DocPlainText({
+-                configuration: docParagraph.configuration,
+-                text: accumulatedTextChunks.join('')
+-            }));
+-            accumulatedTextChunks.length = 0;
+-            accumulatedNodes.length = 0;
+-        }
+-        var transformedParagraph = new DocParagraph({
+-            configuration: docParagraph.configuration
+-        });
+-        transformedParagraph.appendNodes(transformedNodes);
+-        return transformedParagraph;
++        return docParagraph;
+     };
+     return TrimSpacesTransform;
+ }());
+diff --git a/lib-commonjs/emitters/TSDocEmitter.js b/lib-commonjs/emitters/TSDocEmitter.js
+index 60535a109e3705baae7cb851e1f7cca6e2b5595b..7d81203310ac78b3ae949f85bee9c4688247596b 100644
+--- a/lib-commonjs/emitters/TSDocEmitter.js
++++ b/lib-commonjs/emitters/TSDocEmitter.js
+@@ -64,6 +64,10 @@ var TSDocEmitter = /** @class */ (function () {
+             return;
+         }
+         switch (docNode.kind) {
++            case DocNode_1.DocNodeKind.SoftBreak:
++                // @ts-ignore
++                this._writeNewline();
++                break;
+             case DocNode_1.DocNodeKind.Block:
+                 var docBlock = docNode;
+                 this._ensureLineSkipped();
+diff --git a/lib-commonjs/transforms/TrimSpacesTransform.js b/lib-commonjs/transforms/TrimSpacesTransform.js
+index b5fe0c49a27a8df5b08e9862541c2449c61c1158..6e54d39581af61241610f1a61d0b1746ac47fb38 100644
+--- a/lib-commonjs/transforms/TrimSpacesTransform.js
++++ b/lib-commonjs/transforms/TrimSpacesTransform.js
+@@ -11,80 +11,16 @@ var TrimSpacesTransform = /** @class */ (function () {
+     function TrimSpacesTransform() {
+     }
+     TrimSpacesTransform.transform = function (docParagraph) {
+-        var transformedNodes = [];
+-        // Whether the next nonempty node to be added needs a space before it
+-        var pendingSpace = false;
+-        // The DocPlainText node that we're currently accumulating
+-        var accumulatedTextChunks = [];
+-        var accumulatedNodes = [];
+-        // We always trim leading whitespace for a paragraph.  This flag gets set to true
+-        // as soon as nonempty content is encountered.
+-        var finishedSkippingLeadingSpaces = false;
+-        for (var _i = 0, _a = docParagraph.nodes; _i < _a.length; _i++) {
+-            var node = _a[_i];
+-            switch (node.kind) {
+-                case nodes_1.DocNodeKind.PlainText:
+-                    var docPlainText = node;
+-                    var text = docPlainText.text;
+-                    var startedWithSpace = /^\s/.test(text);
+-                    var endedWithSpace = /\s$/.test(text);
+-                    var collapsedText = text.replace(/\s+/g, ' ').trim();
+-                    if (startedWithSpace && finishedSkippingLeadingSpaces) {
+-                        pendingSpace = true;
+-                    }
+-                    if (collapsedText.length > 0) {
+-                        if (pendingSpace) {
+-                            accumulatedTextChunks.push(' ');
+-                            pendingSpace = false;
+-                        }
+-                        accumulatedTextChunks.push(collapsedText);
+-                        accumulatedNodes.push(node);
+-                        finishedSkippingLeadingSpaces = true;
+-                    }
+-                    if (endedWithSpace && finishedSkippingLeadingSpaces) {
+-                        pendingSpace = true;
+-                    }
+-                    break;
+-                case nodes_1.DocNodeKind.SoftBreak:
+-                    if (finishedSkippingLeadingSpaces) {
+-                        pendingSpace = true;
+-                    }
+-                    accumulatedNodes.push(node);
+-                    break;
+-                default:
+-                    if (pendingSpace) {
+-                        accumulatedTextChunks.push(' ');
+-                        pendingSpace = false;
+-                    }
+-                    // Push the accumulated text
+-                    if (accumulatedTextChunks.length > 0) {
+-                        // TODO: We should probably track the accumulatedNodes somehow, e.g. so we can map them back to the
+-                        // original excerpts.  But we need a developer scenario before we can design this API.
+-                        transformedNodes.push(new nodes_1.DocPlainText({
+-                            configuration: docParagraph.configuration,
+-                            text: accumulatedTextChunks.join('')
+-                        }));
+-                        accumulatedTextChunks.length = 0;
+-                        accumulatedNodes.length = 0;
+-                    }
+-                    transformedNodes.push(node);
+-                    finishedSkippingLeadingSpaces = true;
+-            }
++        if (docParagraph.nodes.length > 0 && 
++            docParagraph.nodes[docParagraph.nodes.length - 1].kind === "SoftBreak") {
++            const transformedNodes = docParagraph.nodes.slice(0, -1);
++            const transformedParagraph = new nodes_1.DocParagraph({
++                configuration: docParagraph.configuration
++            });
++            transformedParagraph.appendNodes(transformedNodes);
++            return transformedParagraph;
+         }
+-        // Push the accumulated text
+-        if (accumulatedTextChunks.length > 0) {
+-            transformedNodes.push(new nodes_1.DocPlainText({
+-                configuration: docParagraph.configuration,
+-                text: accumulatedTextChunks.join('')
+-            }));
+-            accumulatedTextChunks.length = 0;
+-            accumulatedNodes.length = 0;
+-        }
+-        var transformedParagraph = new nodes_1.DocParagraph({
+-            configuration: docParagraph.configuration
+-        });
+-        transformedParagraph.appendNodes(transformedNodes);
+-        return transformedParagraph;
++        return docParagraph;
+     };
+     return TrimSpacesTransform;
+ }());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,11 @@ catalogs:
       specifier: ^3.0.4
       version: 3.0.4
 
+patchedDependencies:
+  '@microsoft/tsdoc@0.15.0':
+    hash: feqpbbj7jjnlaslm723zbab6bm
+    path: patches/@microsoft__tsdoc@0.15.0.patch
+
 importers:
 
   .:
@@ -146,6 +151,9 @@ importers:
       tsx:
         specifier: ^4.19.1
         version: 4.19.1
+      typedoc:
+        specifier: ^0.28.0
+        version: 0.28.0(typescript@5.7.3)
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.1.0(eslint@9.9.0)(typescript@5.7.3)
@@ -409,7 +417,7 @@ importers:
         version: 7.29.6(@types/node@22.13.10)
       '@microsoft/tsdoc':
         specifier: ^0.15.0
-        version: 0.15.0
+        version: 0.15.0(patch_hash=feqpbbj7jjnlaslm723zbab6bm)
       redent:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1377,6 +1385,9 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
+  '@gerrit0/mini-shiki@3.2.1':
+    resolution: {integrity: sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==}
+
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
@@ -2046,6 +2057,9 @@ packages:
   '@shikijs/engine-oniguruma@1.27.0':
     resolution: {integrity: sha512-x1XMJvQuToX2KhESav2cnaTFDEwpJ1bcczaXy8wlRWhPVVAGR/MxlWnJbhHFe+ETerQgdpLZN8l+EgO0rVfEFQ==}
 
+  '@shikijs/engine-oniguruma@3.2.1':
+    resolution: {integrity: sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==}
+
   '@shikijs/langs@1.27.0':
     resolution: {integrity: sha512-6fBE0OL17XGYlNj8IuHfKtTALLk6+CVAXw8Rj2y/K8NP646/hows9+XwzIFcvFo3wZ0fPAcPKQ9pwG6a1FBevw==}
 
@@ -2055,8 +2069,14 @@ packages:
   '@shikijs/types@1.27.0':
     resolution: {integrity: sha512-oOJdIeOnGo+hbM7MH+Ejpksse2ASex4DVHdvBoKyY3+26GEzG9PwM85BeXNGxUZuVxtVKo43sZl0qtJs/K2Zow==}
 
+  '@shikijs/types@3.2.1':
+    resolution: {integrity: sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==}
+
   '@shikijs/vscode-textmate@10.0.1':
     resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@shikijs/vscode-textmate@9.2.0':
     resolution: {integrity: sha512-5FinaOp6Vdh/dl4/yaOTh0ZeKch+rYS8DUb38V3GMKYVkdqzxw53lViRKUYkVILRiVQT7dcPC7VvAKOR73zVtQ==}
@@ -3481,6 +3501,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   load-yaml-file@0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
@@ -3522,6 +3545,9 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -3539,6 +3565,10 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
 
   markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
@@ -3596,6 +3626,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -4134,6 +4167,10 @@ packages:
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4670,6 +4707,13 @@ packages:
     resolution: {integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==}
     engines: {node: '>=16'}
 
+  typedoc@0.28.0:
+    resolution: {integrity: sha512-UU+xxZXrpnUhEulBYRwY2afoYFC24J2fTFovOs3llj2foGShCoKVQL6cQCfQ+sBAOdiFn2dETpZ9xhah+CL3RQ==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
+
   typesafe-path@0.2.2:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
 
@@ -4699,6 +4743,9 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -5134,11 +5181,6 @@ packages:
     resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
     engines: {node: '>= 14'}
 
-  yaml@2.5.1:
-    resolution: {integrity: sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
   yaml@2.7.0:
     resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
     engines: {node: '>= 14'}
@@ -5344,7 +5386,7 @@ snapshots:
 
   '@astrojs/yaml2ts@0.2.2':
     dependencies:
-      yaml: 2.5.1
+      yaml: 2.7.0
 
   '@babel/cli@7.24.8(@babel/core@7.25.2)':
     dependencies:
@@ -5949,6 +5991,12 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
+  '@gerrit0/mini-shiki@3.2.1':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.2.1
+      '@shikijs/types': 3.2.1
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.3.0': {}
@@ -6090,7 +6138,7 @@ snapshots:
 
   '@microsoft/api-extractor-model@7.29.6(@types/node@22.13.10)':
     dependencies:
-      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc': 0.15.0(patch_hash=feqpbbj7jjnlaslm723zbab6bm)
       '@microsoft/tsdoc-config': 0.17.0
       '@rushstack/node-core-library': 5.7.0(@types/node@22.13.10)
     transitivePeerDependencies:
@@ -6099,7 +6147,7 @@ snapshots:
   '@microsoft/api-extractor@7.47.7(@types/node@22.13.10)':
     dependencies:
       '@microsoft/api-extractor-model': 7.29.6(@types/node@22.13.10)
-      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc': 0.15.0(patch_hash=feqpbbj7jjnlaslm723zbab6bm)
       '@microsoft/tsdoc-config': 0.17.0
       '@rushstack/node-core-library': 5.7.0(@types/node@22.13.10)
       '@rushstack/rig-package': 0.5.3
@@ -6116,12 +6164,12 @@ snapshots:
 
   '@microsoft/tsdoc-config@0.17.0':
     dependencies:
-      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc': 0.15.0(patch_hash=feqpbbj7jjnlaslm723zbab6bm)
       ajv: 8.12.0
       jju: 1.4.0
       resolve: 1.22.8
 
-  '@microsoft/tsdoc@0.15.0': {}
+  '@microsoft/tsdoc@0.15.0(patch_hash=feqpbbj7jjnlaslm723zbab6bm)': {}
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     optional: true
@@ -6646,6 +6694,11 @@ snapshots:
       '@shikijs/types': 1.27.0
       '@shikijs/vscode-textmate': 10.0.1
 
+  '@shikijs/engine-oniguruma@3.2.1':
+    dependencies:
+      '@shikijs/types': 3.2.1
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/langs@1.27.0':
     dependencies:
       '@shikijs/types': 1.27.0
@@ -6659,7 +6712,14 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.1
       '@types/hast': 3.0.4
 
+  '@shikijs/types@3.2.1':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   '@shikijs/vscode-textmate@10.0.1': {}
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@shikijs/vscode-textmate@9.2.0': {}
 
@@ -8435,6 +8495,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   load-yaml-file@0.2.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -8472,6 +8536,8 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  lunr@2.3.9: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -8504,6 +8570,15 @@ snapshots:
       - supports-color
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.3: {}
 
@@ -8687,6 +8762,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -9402,6 +9479,8 @@ snapshots:
       end-of-stream: 1.4.4
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -10107,6 +10186,15 @@ snapshots:
 
   type-fest@4.32.0: {}
 
+  typedoc@0.28.0(typescript@5.7.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.2.1
+      lunr: 2.3.9
+      markdown-it: 14.1.0
+      minimatch: 9.0.5
+      typescript: 5.7.3
+      yaml: 2.7.0
+
   typesafe-path@0.2.2: {}
 
   typescript-auto-import-cache@0.3.3:
@@ -10129,6 +10217,8 @@ snapshots:
   typescript@5.5.4: {}
 
   typescript@5.7.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.5.4: {}
 
@@ -10604,8 +10694,6 @@ snapshots:
       prettier: 2.8.7
 
   yaml@2.2.2: {}
-
-  yaml@2.5.1: {}
 
   yaml@2.7.0: {}
 

--- a/samples/client-emitter/src/components/Client.tsx
+++ b/samples/client-emitter/src/components/Client.tsx
@@ -15,7 +15,15 @@ export function Client(): Children {
 
   return (
     <ts.ClassDeclaration name={name} export refkey={refkey(schema)}>
-      <For each={schema.operations} joiner={doubleBreak}>
+      <For
+        each={schema.operations}
+        joiner={
+          <>
+            <hbr />
+            <hbr />
+          </>
+        }
+      >
         {(op) => <ClientMethod operation={op} />}
       </For>
     </ts.ClassDeclaration>

--- a/samples/client-emitter/src/components/ClientMethod.tsx
+++ b/samples/client-emitter/src/components/ClientMethod.tsx
@@ -1,4 +1,4 @@
-import { Block, Children, code, refkey } from "@alloy-js/core";
+import { Children, code, refkey } from "@alloy-js/core";
 import * as ts from "@alloy-js/typescript";
 import { useApi } from "../context/api.js";
 import { RestApiOperation } from "../schema.js";
@@ -77,15 +77,20 @@ export function ClientMethod(props: ClientMethodProps) {
       parameters={parameters}
       returnType={returnType}
     >
-      const response = await{" "}
-      <ts.FunctionCallExpression target="fetch" args={[endpoint, options]} />;
-      <hbr />
-      <hbr />
-      if (!response.ok){" "}
-      <Block>throw new Error("Request failed: " + response.status);</Block>
-      <hbr />
-      <hbr />
-      return response.json() as {returnType};
+      {code`
+        const response = await ${(
+          <ts.FunctionCallExpression
+            target="fetch"
+            args={[endpoint, options]}
+          />
+        )};
+        
+        if (!response.ok) { 
+          throw new Error("Request failed: " + response.status);
+        }
+
+        return response.json() as ${returnType};
+      `}
     </ts.ClassMethod>
   );
 }


### PR DESCRIPTION
Updates walkthrough, fixes a number of docs bugs, and improves docs rendering of component signatures, contexts, and a few other things.

Also exports more formatting intrinsic elements for string templates, adds a `text` helper, and adds `ProviderStc` for providing context to string template components.