### PR TITLE
[TypeScript] Escape invalid names and handle private symbols properly.

### DIFF
--- a/.chronus/changes/escape-names-2025-3-4-9-48-15.md
+++ b/.chronus/changes/escape-names-2025-3-4-9-48-15.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+No longer validates that instance member symbols are referenced inside the instance member scope. Languages may allow refernecing instance member symbols in a variety of ways (e.g. TypeScript allows referencing private instance symbols in a private instance symbol scope).

--- a/.chronus/changes/escape-names-2025-3-4-9-49-17.md
+++ b/.chronus/changes/escape-names-2025-3-4-9-49-17.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Support declaring and referencing properties with invalid property names. Added a `PropertyName` component to handle escaping property declaration names.

--- a/.chronus/changes/escape-names-2025-3-4-9-50-22.md
+++ b/.chronus/changes/escape-names-2025-3-4-9-50-22.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Properly model private symbols. Private symbols are now stored in separate scopes and will no longer conflict with non-private symbols. Access rules for private symbols are verified (e.g. that static private symbols cannot be referenced outside their scope).

--- a/packages/core/src/binder.ts
+++ b/packages/core/src/binder.ts
@@ -706,12 +706,6 @@ export function createOutputBinder(options: BinderOptions = {}): Binder {
     targetDeclarationBase: TSymbol,
   ): ResolutionResult<TScope, TSymbol> {
     if (targetDeclarationBase.flags & OutputSymbolFlags.InstanceMember) {
-      if (targetDeclarationBase.scope !== currentMemberScope) {
-        throw new Error(
-          "Cannot resolve member symbols from a different member scope",
-        );
-      }
-
       // todo: handle referencing nested objects by refkey
       return {
         pathUp: [],

--- a/packages/core/test/symbols.test.ts
+++ b/packages/core/test/symbols.test.ts
@@ -296,31 +296,6 @@ describe("instance members", () => {
     expect(pathUp).toEqual([]);
     expect(memberPath).toEqual([instance]);
   });
-
-  it("doesn't resolve from outside the member scope", () => {
-    const binder = createOutputBinder();
-    const {
-      scopes: { root },
-      symbols: { instance },
-    } = createScopeTree(binder, {
-      root: {
-        symbols: {
-          root: {
-            flags: OutputSymbolFlags.InstanceMemberContainer,
-            instanceMembers: {
-              instance: {
-                flags: OutputSymbolFlags.InstanceMember,
-              },
-            },
-          },
-        },
-      },
-    });
-
-    expect(() =>
-      binder.resolveDeclarationByKey(root, undefined, instance.refkeys[0]),
-    ).toThrow(/Cannot resolve member symbols/);
-  });
 });
 
 describe("instantiating members", () => {

--- a/packages/typescript/src/components/Declaration.tsx
+++ b/packages/typescript/src/components/Declaration.tsx
@@ -6,11 +6,17 @@ import {
   Refkey,
 } from "@alloy-js/core";
 import { TypeScriptElements, useTSNamePolicy } from "../name-policy.js";
-import { createTSSymbol, TSSymbolFlags } from "../symbols/index.js";
+import {
+  createTSSymbol,
+  TSOutputSymbol,
+  TSSymbolFlags,
+} from "../symbols/index.js";
 
 // imports for documentation
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { TypeDeclaration } from "./TypeDeclaration.jsx";
+
+import { PrivateScopeContext } from "../context/private-scope.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { EnumDeclaration } from "./EnumDeclaration.jsx";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -62,11 +68,21 @@ export interface BaseDeclarationProps {
   doc?: Children;
 }
 
-export interface DeclarationProps extends BaseDeclarationProps {
+export interface DeclarationProps extends Omit<BaseDeclarationProps, "name"> {
+  /**
+   * The name of this declaration.
+   */
+  name?: string;
+
   /**
    * The name policy kind to apply to the declaration.
    */
-  nameKind: TypeScriptElements;
+  nameKind?: TypeScriptElements;
+
+  /**
+   * The symbol to use for this declaration.
+   */
+  symbol?: TSOutputSymbol;
 }
 
 /**
@@ -84,28 +100,53 @@ export interface DeclarationProps extends BaseDeclarationProps {
  *
  */
 export function Declaration(props: DeclarationProps) {
-  const namePolicy = useTSNamePolicy();
+  let sym: TSOutputSymbol;
 
-  let tsFlags: TSSymbolFlags = TSSymbolFlags.None;
-  if (props.kind && props.kind === "type") {
-    tsFlags &= TSSymbolFlags.TypeSymbol;
+  if (props.symbol) {
+    sym = props.symbol;
+  } else {
+    const namePolicy = useTSNamePolicy();
+
+    let tsFlags: TSSymbolFlags = TSSymbolFlags.None;
+    if (props.kind && props.kind === "type") {
+      tsFlags &= TSSymbolFlags.TypeSymbol;
+    }
+
+    sym = createTSSymbol({
+      name: namePolicy.getName(props.name!, props.nameKind!),
+      refkey: props.refkey,
+      export: props.export,
+      default: props.default,
+      flags: props.flags,
+      tsFlags,
+      metadata: props.metadata,
+    });
   }
 
-  const sym = createTSSymbol({
-    name: namePolicy.getName(props.name, props.nameKind),
-    refkey: props.refkey,
-    export: props.export,
-    default: props.default,
-    flags: props.flags,
-    tsFlags,
-    metadata: props.metadata,
-  });
+  function withMemberScope(children: Children) {
+    return <MemberScope owner={sym}>{children}</MemberScope>;
+  }
 
-  let children: Children;
+  function withPrivateMemberScope(children: Children) {
+    const context: PrivateScopeContext = {
+      instanceMembers: sym.privateMemberScope!,
+      staticMembers: sym.privateStaticMemberScope!,
+    };
+    return (
+      <PrivateScopeContext.Provider value={context}>
+        {children}
+      </PrivateScopeContext.Provider>
+    );
+  }
+
+  let children: Children = () => props.children;
+
   if (sym.flags & OutputSymbolFlags.MemberContainer) {
-    children = <MemberScope owner={sym}>{props.children}</MemberScope>;
-  } else {
-    children = () => props.children;
+    children = withMemberScope(children);
+  }
+
+  if (sym.tsFlags & TSSymbolFlags.PrivateMemberContainer) {
+    children = withPrivateMemberScope(children);
   }
 
   return (

--- a/packages/typescript/src/components/EnumMember.tsx
+++ b/packages/typescript/src/components/EnumMember.tsx
@@ -2,6 +2,7 @@ import { Children, OutputSymbolFlags, Refkey, Show } from "@alloy-js/core";
 import { useTSNamePolicy } from "../name-policy.js";
 import { createTSSymbol, TSOutputSymbol } from "../symbols/ts-output-symbol.js";
 import { JSDoc } from "./JSDoc.jsx";
+import { PropertyName } from "./PropertyName.jsx";
 import { ValueExpression } from "./ValueExpression.jsx";
 
 export interface EnumMemberProps {
@@ -55,7 +56,7 @@ export function EnumMember(props: EnumMemberProps) {
       metadata: props.metadata,
     });
   }
-  const nameCode = sym ? sym.name : name;
+  const actualName = sym ? sym.name : name;
   const valueCode =
     props.jsValue !== undefined ?
       <ValueExpression jsValue={props.jsValue} />
@@ -67,7 +68,7 @@ export function EnumMember(props: EnumMemberProps) {
         <JSDoc children={props.doc} />
         <hbr />
       </Show>
-      {nameCode}
+      <PropertyName name={actualName} />
       <Show when={valueCode !== undefined}> = {valueCode}</Show>
     </>
   );

--- a/packages/typescript/src/components/ObjectExpression.tsx
+++ b/packages/typescript/src/components/ObjectExpression.tsx
@@ -13,7 +13,9 @@ import {
   Switch,
   Wrap,
 } from "@alloy-js/core";
+import { useTSNamePolicy } from "../name-policy.js";
 import { createTSSymbol } from "../symbols/index.js";
+import { PropertyName } from "./PropertyName.jsx";
 import { ValueExpression } from "./ValueExpression.js";
 
 export interface ObjectExpressionProps {
@@ -96,7 +98,10 @@ export interface ObjectPropertyProps {
 export function ObjectProperty(props: ObjectPropertyProps) {
   let name;
   if (props.name) {
-    name = props.name;
+    const namer = useTSNamePolicy();
+    name = (
+      <PropertyName name={namer.getName(props.name, "object-member-data")} />
+    );
   } else if (props.nameExpression) {
     name = <>[{props.nameExpression}]</>;
   } else {
@@ -126,7 +131,7 @@ export function ObjectProperty(props: ObjectPropertyProps) {
     sym ? createAssignmentContext(sym) : undefined;
   return (
     <>
-      {sym ? sym.name : name}:{" "}
+      {name}:{" "}
       <AssignmentContext.Provider value={assignmentContext}>
         {value}
       </AssignmentContext.Provider>

--- a/packages/typescript/src/components/PropertyName.tsx
+++ b/packages/typescript/src/components/PropertyName.tsx
@@ -1,0 +1,50 @@
+import { MemberDeclarationContext, useContext } from "@alloy-js/core";
+import { TSOutputSymbol, TSSymbolFlags } from "../symbols/ts-output-symbol.js";
+import { isValidJSIdentifier } from "../utils.js";
+
+export interface PropertyNameProps {
+  /**
+   * The name of the property.
+   */
+  name?: string;
+
+  /**
+   * Whether the property is a private property. If `true`, the property will be
+   * prefixed with `#`.
+   */
+  private?: boolean;
+}
+
+/**
+ * A TypeScript property name for an interface, class, or object member. If the
+ * name is not a valid JavaScript identifier, it will be quoted. If a `name` prop
+ * is provided, it will be used as the property name. Otherwise, the name will be
+ * taken from the {@link (MemberDeclarationContext:variable)}.
+ */
+export function PropertyName(props: PropertyNameProps) {
+  if (props.name) {
+    if (props.private) {
+      return "#" + props.name;
+    }
+    return quoteIfNeeded(props.name);
+  } else {
+    const declSymbol = useContext(MemberDeclarationContext) as TSOutputSymbol;
+    if (!declSymbol) {
+      return "(no member declaration context)";
+    }
+
+    if (declSymbol.tsFlags & TSSymbolFlags.PrivateMember) {
+      return <>#{declSymbol.name}</>;
+    } else {
+      return <>{quoteIfNeeded(declSymbol.name)}</>;
+    }
+  }
+}
+
+function quoteIfNeeded(name: string) {
+  if (isValidJSIdentifier(name)) {
+    return name;
+  } else {
+    return `"${name.replace(/"/g, '\\"')}"`;
+  }
+}

--- a/packages/typescript/src/context/index.ts
+++ b/packages/typescript/src/context/index.ts
@@ -1,0 +1,1 @@
+export * from "./private-scope.js";

--- a/packages/typescript/src/context/private-scope.ts
+++ b/packages/typescript/src/context/private-scope.ts
@@ -1,12 +1,22 @@
-import { createContext, useContext } from "@alloy-js/core";
+import { ComponentContext, createContext, useContext } from "@alloy-js/core";
 import { TSMemberScope } from "../symbols/ts-member-scope.js";
 
 export interface PrivateScopeContext {
+  /**
+   * Scope for private static members.
+   */
   staticMembers: TSMemberScope;
+  /**
+   * Scope for private instance members.
+   */
   instanceMembers: TSMemberScope;
 }
 
-export const PrivateScopeContext = createContext<PrivateScopeContext>();
+/**
+ * Provides scopes for instance and static private members.
+ */
+export const PrivateScopeContext: ComponentContext<PrivateScopeContext> =
+  createContext<PrivateScopeContext>();
 
 export function usePrivateScope() {
   return useContext(PrivateScopeContext);

--- a/packages/typescript/src/context/private-scope.ts
+++ b/packages/typescript/src/context/private-scope.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "@alloy-js/core";
+import { TSMemberScope } from "../symbols/ts-member-scope.js";
+
+export interface PrivateScopeContext {
+  staticMembers: TSMemberScope;
+  instanceMembers: TSMemberScope;
+}
+
+export const PrivateScopeContext = createContext<PrivateScopeContext>();
+
+export function usePrivateScope() {
+  return useContext(PrivateScopeContext);
+}

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./builtins/index.js";
 export * from "./components/index.js";
+export * from "./context/index.js";
 export * from "./create-package.js";
 export * from "./name-conflict-resolver.js";
 export * from "./name-policy.js";

--- a/packages/typescript/src/symbols/ts-member-scope.ts
+++ b/packages/typescript/src/symbols/ts-member-scope.ts
@@ -1,4 +1,4 @@
-import { Binder, OutputScope } from "@alloy-js/core";
+import { Binder, OutputScope, OutputScopeFlags } from "@alloy-js/core";
 import { TSOutputSymbol } from "./ts-output-symbol.js";
 
 export interface TSMemberScope extends OutputScope {
@@ -9,13 +9,17 @@ export interface TSMemberScope extends OutputScope {
 
 export function createTSMemberScope(
   binder: Binder,
-  parent: OutputScope,
+  parent: OutputScope | undefined,
   owner: TSOutputSymbol,
   isStatic: boolean = false,
 ): TSMemberScope {
   return binder.createScope<TSMemberScope>({
     kind: "member",
     name: "members",
+    flags:
+      isStatic ?
+        OutputScopeFlags.StaticMemberScope
+      : OutputScopeFlags.MemberScope,
     owner,
     parent,
     isStatic,

--- a/packages/typescript/src/utils.ts
+++ b/packages/typescript/src/utils.ts
@@ -31,3 +31,10 @@ export function getCallSignatureProps(
 
   return defaultProps(callSignatureProps, defaults);
 }
+
+const identifierRegex =
+  /^(?:[\p{ID_Start}$_])(?:[\p{ID_Continue}$\u200C\u200D])*$/u;
+
+export function isValidJSIdentifier(str: string) {
+  return identifierRegex.test(str);
+}

--- a/packages/typescript/test/enum.test.tsx
+++ b/packages/typescript/test/enum.test.tsx
@@ -152,6 +152,7 @@ it("uses the naming policy", () => {
 describe("symbols", () => {
   it("can reference enum members by refkey", () => {
     const memberOne = refkey();
+    const memberTwo = refkey();
 
     expect(
       <Output>
@@ -159,19 +160,25 @@ describe("symbols", () => {
           <ts.EnumDeclaration name="MyEnum">
             <ts.CommaList>
               <ts.EnumMember name="foo" jsValue="1" refkey={memberOne} />
-              <ts.EnumMember name="bar" jsValue={2} />
+              <ts.EnumMember
+                name="mangled-name"
+                jsValue={2}
+                refkey={memberTwo}
+              />
             </ts.CommaList>
           </ts.EnumDeclaration>
           <hbr />
-          {memberOne};
+          {memberOne};<hbr />
+          {memberTwo};
         </ts.SourceFile>
       </Output>,
     ).toRenderTo(`
       enum MyEnum {
         foo = "1",
-        bar = 2,
+        "mangled-name" = 2,
       }
       MyEnum.foo;
+      MyEnum["mangled-name"];
     `);
   });
 });

--- a/packages/typescript/test/interface.test.tsx
+++ b/packages/typescript/test/interface.test.tsx
@@ -132,3 +132,17 @@ it("supports the naming policy", () => {
     }
   `);
 });
+
+it("handles invalid identifier names", () => {
+  const res = toSourceText(
+    <ts.InterfaceExpression>
+      <ts.InterfaceMember name="invalid-name" type="string" />;
+    </ts.InterfaceExpression>,
+  );
+
+  expect(res).toEqual(d`
+    {
+      "invalid-name": string;
+    }
+  `);
+});

--- a/packages/typescript/test/value-expression.test.tsx
+++ b/packages/typescript/test/value-expression.test.tsx
@@ -28,6 +28,15 @@ it.each([
       }
     `,
   ],
+  [
+    { "mangled-name": 1, "@pagination": 2 },
+    d`
+      {
+        "mangled-name": 1,
+        "@pagination": 2,
+      }
+    `,
+  ],
 ])("works - %o => %s", (jsValue, expectedSource) => {
   expect(toSourceText(<ValueExpression jsValue={jsValue} />)).toBe(
     expectedSource,


### PR DESCRIPTION
* Remove some validation from core that doesn't allow necessary flexibility in language libraries.
* Escape invalid property name declarations via the PropertyName component.
* Properly construct member expressions involving invalid names (e.g. foo["invalid-name"]).