### PR TITLE
Update ForCallbackArgs to handle arrays early, before unions of arrays are distributed

### DIFF
--- a/.chronus/changes/patch-1-2025-3-10-20-45-44.md
+++ b/.chronus/changes/patch-1-2025-3-10-20-45-44.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+Update `ForCallbackArgs` to handle arrays early, before unions of arrays are distributed. This mitigates a nasty typechecking bug that appears when the type of elements passed to `For` are a union of arrays.

--- a/packages/core/src/components/For.tsx
+++ b/packages/core/src/components/For.tsx
@@ -4,9 +4,9 @@ import { baseListPropsToMapJoinArgs, mapJoin } from "../utils.js";
 import { BaseListProps } from "./List.jsx";
 
 export type ForCallbackArgs<T> =
-  T extends Ref<infer U> ? ForCallbackArgs<U>
+  number extends keyof T ? [value: T[number]]
+  : T extends Ref<infer U> ? ForCallbackArgs<U>
   : T extends () => infer U ? ForCallbackArgs<U>
-  : T extends (infer U)[] ? [value: U]
   : T extends Map<infer U, infer V> ? [key: U, value: V]
   : T extends Set<infer U> ? [value: U]
   : T extends IterableIterator<infer U> ? [value: U]


### PR DESCRIPTION
This treats everything that has `number` as a key as being array-like and treats it as an array. This works for unions of arrays without distributing the union over the conditional type.

Closes https://github.com/alloy-framework/alloy/issues/95