### PR TITLE
Fix JS Doc comment close with `*/` instead of `**/`

### DIFF
--- a/.chronus/changes/fix-doc-comment-extra-star-2025-3-18-10-21-41.md
+++ b/.chronus/changes/fix-doc-comment-extra-star-2025-3-18-10-21-41.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/typescript"
+---
+
+JS Doc comment close with `*/` instead of `**/`

--- a/packages/typescript/src/components/JSDocComment.tsx
+++ b/packages/typescript/src/components/JSDocComment.tsx
@@ -17,7 +17,7 @@ export function JSDocComment(props: JSDocCommentProps) {
         <hbr />
         {props.children}
       </align>
-      <hbr /> **/
+      <hbr /> */
     </>
   );
 }

--- a/packages/typescript/test/class.test.tsx
+++ b/packages/typescript/test/class.test.tsx
@@ -309,15 +309,15 @@ it("renders a class with docs for the class and its members", () => {
   expect(res).toEqual(d`
     /**
      * This is a class documentation
-     **/
+     */
     class Foo {
       /**
        * This is a field documentation
-       **/
+       */
       bar = 123;
       /**
        * This is a method documentation
-       **/
+       */
       baz() {
         return 123;
       }
@@ -353,7 +353,7 @@ it("renders a method with parameter docs", () => {
        * @param {string} b - Line 1 for b.
        *   This is a long description that
        *   should continue in the next line.
-       **/
+       */
       bar(a: number, b: string): void {}
     }
   `);

--- a/packages/typescript/test/enum-jsdoc.test.tsx
+++ b/packages/typescript/test/enum-jsdoc.test.tsx
@@ -19,7 +19,7 @@ it("renders an enum declaration with documentation", () => {
   expect(res).toEqual(d`
     /**
      * Color enumeration for the application
-     **/
+     */
     enum Color {
       Red,
       Green,
@@ -49,25 +49,25 @@ it("renders an enum declaration with documented members", () => {
   expect(res).toEqual(d`
     /**
      * Represents cardinal directions. Used for navigation purposes
-     **/
+     */
     enum Direction {
       /**
        * Bound to the north
-       **/
+       */
       North = 0,
       /**
        * Bound to the East
        *
        * A second doc paragraph
-       **/
+       */
       East = 1,
       /**
        * Opposite to North
-       **/
+       */
       South = 2,
       /**
        * Going west!
-       **/
+       */
       West = 3,
     }
   `);

--- a/packages/typescript/test/function-declaration-jsdoc.test.tsx
+++ b/packages/typescript/test/function-declaration-jsdoc.test.tsx
@@ -18,7 +18,7 @@ it("renders a function declaration with documentation", () => {
      * A function that greets a person
      *
      * @param {string} name
-     **/
+     */
     function greet(name: string): string {}
   `);
 });
@@ -42,7 +42,7 @@ it("With documented parameters", () => {
      *
      * @param {number} price
      * @param {number} [taxRate]
-     **/
+     */
     export function calculateTotal(price: number, taxRate?: number): number {}
   `);
 });
@@ -84,6 +84,6 @@ it("renders a function with a reference", () => {
      * Creates a new user
      *
      * @param {User} user - The user object to create
-     **/
+     */
     function createUser(user: User): void {}`);
 });

--- a/packages/typescript/test/interface-jsdoc.test.tsx
+++ b/packages/typescript/test/interface-jsdoc.test.tsx
@@ -19,7 +19,7 @@ it("renders an interface declaration with documentation", () => {
   expect(res).toEqual(d`
     /**
      * Interface representing a person
-     **/
+     */
     interface Person {
       name: string;
       age: number;
@@ -42,7 +42,7 @@ it("renders an interface declaration with docs from a string array with single e
   expect(res).toEqual(d`
     /**
      * Interface representing a person
-     **/
+     */
     interface Person {
       name: string;
       age: number;
@@ -70,7 +70,7 @@ it("renders an interface declaration with docs from a string array", () => {
      * Interface representing a person
      *
      * This should be another paragraph
-     **/
+     */
     interface Person {
       name: string;
       age: number;
@@ -103,15 +103,15 @@ it("renders an interface declaration with documented properties", () => {
   expect(res).toEqual(d`
     /**
      * Standard API response format
-     **/
+     */
     export interface APIResponse {
       /**
        * Wether or not the request completed successfully
-       **/
+       */
       success: boolean;
       /**
        * the response payload
-       **/
+       */
       data: unknown;
       error?: string;
     }
@@ -146,17 +146,17 @@ it("renders an interface declaration with array documented properties ", () => {
   expect(res).toEqual(d`
     /**
      * Standard API response format
-     **/
+     */
     export interface APIResponse {
       /**
        * Wether or not the request completed successfully
        *
        * This is another paragraph
-       **/
+       */
       success: boolean;
       /**
        * the response payload
-       **/
+       */
       data: unknown;
       error?: string;
     }

--- a/packages/typescript/test/jsdoc.test.tsx
+++ b/packages/typescript/test/jsdoc.test.tsx
@@ -24,7 +24,7 @@ describe("JSDoc", () => {
        * Hello!
        *
        * This is another line
-       **/
+       */
     `,
       { printWidth: 40 },
     );
@@ -59,7 +59,7 @@ describe("Prose", () => {
          * This is another paragraph. There
          * should be a couple breaks in front of
          * it.
-         **/
+         */
       `,
       { printWidth: 40 },
     );
@@ -83,7 +83,7 @@ describe("JSDocExample", () => {
        *
        * @example
        * console.log("Hello world!")
-       **/
+       */
       `,
       { printWidth: 40 },
     );
@@ -109,7 +109,7 @@ describe("JSDocExample", () => {
        * \`\`\`ts
        * console.log("Hello world!")
        * \`\`\`
-       **/
+       */
       `,
       { printWidth: 40 },
     );
@@ -140,7 +140,7 @@ describe("JSDocExample", () => {
        * @example
        * // make a function call.
        * console.log(arg1, arg2);
-       **/
+       */
       `,
       { printWidth: 40 },
     );

--- a/packages/typescript/test/jsdocparam.test.tsx
+++ b/packages/typescript/test/jsdocparam.test.tsx
@@ -14,7 +14,7 @@ it("name only", () => {
     d`
           /**
            * @param somebody
-           **/
+           */
         `,
   );
 });
@@ -30,7 +30,7 @@ it("name and type", () => {
     d`
           /**
            * @param {string} somebody
-           **/
+           */
         `,
   );
 });
@@ -48,7 +48,7 @@ it("name, type and description", () => {
     d`
           /**
            * @param {string} somebody Somebody's name.
-           **/
+           */
         `,
   );
 });
@@ -66,7 +66,7 @@ it("name, type and description with hyphen", () => {
     d`
           /**
            * @param {string} somebody - Somebody's name.
-           **/
+           */
         `,
   );
 });
@@ -84,7 +84,7 @@ it("name, type, description, hyphen and optional", () => {
     d`
         /**
          * @param {string} [somebody] - Somebody's name.
-         **/
+         */
         `,
   );
 });
@@ -108,7 +108,7 @@ it("name, type, description, hyphen and optional with default value", () => {
     d`
             /**
              * @param {string} [somebody=John Doe] - Somebody's name.
-             **/
+             */
             `,
   );
 });
@@ -153,7 +153,7 @@ it("name, type, description, hyphen and optional with default value with a very 
            *   even a codename (e.g., "Agent X"). It's used primarily for display
            *   purposes, logging, or greeting messages and is not required to be unique or
            *   validated unless specified by the caller.
-           **/
+           */
           `,
     { printWidth: 80 },
   );
@@ -181,7 +181,7 @@ it("name, type, description, hyphen and optional with default value with a descr
           /**
            * @param {string} [somebody=John Doe] - Somebody's name. This is one line
            *   This is another line
-           **/
+           */
           `,
     { printWidth: 80 },
   );

--- a/packages/typescript/test/var-declaration-jsdoc.test.tsx
+++ b/packages/typescript/test/var-declaration-jsdoc.test.tsx
@@ -19,7 +19,7 @@ it("renders a variable declaration with documentation", () => {
   expect(res).toEqual(d`
     /**
      * This is a variable documentation
-     **/
+     */
     const myVar = 123;
   `);
 });
@@ -41,7 +41,7 @@ it("renders a let declaration with documentation", () => {
   expect(res).toEqual(d`
     /**
      * A counter variable that can be changed
-     **/
+     */
     let counter: number = 0;
   `);
 });
@@ -64,7 +64,7 @@ it("renders an exported variable declaration with documentation", () => {
   expect(res).toEqual(d`
     /**
      * The base URL for API calls
-     **/
+     */
     export const API_URL: string = "https://api.example.com";
   `);
 });


### PR DESCRIPTION
fix #122