### PR TITLE
Type references

### DIFF
--- a/.chronus/changes/type-ref-2025-3-18-22-0-49.md
+++ b/.chronus/changes/type-ref-2025-3-18-22-0-49.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Add `type` prop on `Reference` component to mark this reference as a type only reference allowing imports to be specialized in type import

--- a/packages/docs/scripts/build-json.ts
+++ b/packages/docs/scripts/build-json.ts
@@ -238,11 +238,17 @@ function queryApis(apiModel: ApiModel): DocumentationStructure {
             if ((member as ApiFunction).parameters.length > 0) {
               const propsTypeRef = (member as ApiFunction).parameters[0]
                 .parameterTypeExcerpt.spannedTokens[0].canonicalReference;
-              const resolvedPropType = apiModel.resolveDeclarationReference(
+              const model = apiModel.resolveDeclarationReference(
                 propsTypeRef!,
                 undefined,
-              ).resolvedApiItem!;
+              );
 
+              const resolvedPropType = model.resolvedApiItem;
+              if (!resolvedPropType) {
+                throw new Error(
+                  `Cannot resolve prop type for ${member.displayName}: ${model.errorMessage}`,
+                );
+              }
               if (resolvedPropType.kind === ApiItemKind.Interface) {
                 componentPropTypes.push(resolvedPropType as ApiInterface);
                 propTypes.add(resolvedPropType as ApiInterface);

--- a/packages/typescript/src/components/ImportStatement.tsx
+++ b/packages/typescript/src/components/ImportStatement.tsx
@@ -67,7 +67,7 @@ export interface ImportStatementProps {
   symbols: Set<ImportedSymbol>;
 }
 
-export function ImportStatement(props: Readonly<ImportStatementProps>) {
+export function ImportStatement(props: ImportStatementProps) {
   return memo(() => {
     let defaultImportSymbol: ImportedSymbol | undefined = undefined;
     const namedImportSymbols: ImportedSymbol[] = [];

--- a/packages/typescript/src/components/ImportStatement.tsx
+++ b/packages/typescript/src/components/ImportStatement.tsx
@@ -9,6 +9,7 @@ import {
   ImportedSymbol,
   ImportRecords,
   TSPackageScope,
+  TSSymbolFlags,
 } from "../symbols/index.js";
 import { modulePath } from "../utils.js";
 import { usePackage } from "./PackageDirectory.js";
@@ -66,7 +67,7 @@ export interface ImportStatementProps {
   symbols: Set<ImportedSymbol>;
 }
 
-export function ImportStatement(props: ImportStatementProps) {
+export function ImportStatement(props: Readonly<ImportStatementProps>) {
   return memo(() => {
     let defaultImportSymbol: ImportedSymbol | undefined = undefined;
     const namedImportSymbols: ImportedSymbol[] = [];
@@ -90,11 +91,23 @@ export function ImportStatement(props: ImportStatementProps) {
     }
 
     if (namedImportSymbols.length > 0) {
+      const allNamedImportsAreTypes = namedImportSymbols.every(
+        (nis) => nis.target.tsFlags & TSSymbolFlags.TypeSymbol,
+      );
+
+      if (allNamedImportsAreTypes) {
+        parts.push("type ");
+      }
       parts.push("{ ");
       parts.push(
         mapJoin(
           () => namedImportSymbols,
-          (nis) => <ImportBinding importedSymbol={nis} />,
+          (nis) => (
+            <ImportBinding
+              importedSymbol={nis}
+              inTypeImport={allNamedImportsAreTypes}
+            />
+          ),
           { joiner: ", " },
         ),
       );
@@ -109,9 +122,10 @@ export function ImportStatement(props: ImportStatementProps) {
 interface ImportBindingProps {
   importedSymbol: ImportedSymbol;
   default?: boolean;
+  inTypeImport?: boolean;
 }
 
-function ImportBinding(props: ImportBindingProps) {
+function ImportBinding(props: Readonly<ImportBindingProps>) {
   const text = memo(() => {
     const localName = props.importedSymbol.local.name;
     const targetName = props.importedSymbol.target.name;
@@ -124,5 +138,18 @@ function ImportBinding(props: ImportBindingProps) {
     }
   });
 
-  return text;
+  const prefix = memo(() =>
+    (
+      !props.inTypeImport &&
+      props.importedSymbol.local.tsFlags & TSSymbolFlags.TypeSymbol
+    ) ?
+      "type "
+    : "",
+  );
+  return (
+    <>
+      {prefix}
+      {text}
+    </>
+  );
 }

--- a/packages/typescript/src/components/Reference.tsx
+++ b/packages/typescript/src/components/Reference.tsx
@@ -3,10 +3,16 @@ import { ref } from "../symbols/index.js";
 
 export interface ReferenceProps {
   refkey: Refkey;
+
+  /**
+   * If the reference is a type.
+   * This affect things like import where `type` keyword might be used.
+   */
+  type?: boolean;
 }
 
-export function Reference({ refkey }: ReferenceProps) {
-  const reference = ref(refkey);
+export function Reference({ refkey, type }: Readonly<ReferenceProps>) {
+  const reference = ref(refkey, type);
 
   return <>{reference}</>;
 }

--- a/packages/typescript/src/components/Reference.tsx
+++ b/packages/typescript/src/components/Reference.tsx
@@ -6,13 +6,15 @@ export interface ReferenceProps {
 
   /**
    * Whether this is a reference to a type.
+   *
+   * @remarks
    * This affect things like import where `type` keyword might be used.
    */
   type?: boolean;
 }
 
 export function Reference({ refkey, type }: Readonly<ReferenceProps>) {
-  const reference = ref(refkey, type);
+  const reference = ref(refkey, { type });
 
   return <>{reference}</>;
 }

--- a/packages/typescript/src/components/Reference.tsx
+++ b/packages/typescript/src/components/Reference.tsx
@@ -5,7 +5,7 @@ export interface ReferenceProps {
   refkey: Refkey;
 
   /**
-   * If the reference is a type.
+   * Whether this is a reference to a type.
    * This affect things like import where `type` keyword might be used.
    */
   type?: boolean;

--- a/packages/typescript/src/components/Reference.tsx
+++ b/packages/typescript/src/components/Reference.tsx
@@ -13,7 +13,7 @@ export interface ReferenceProps {
   type?: boolean;
 }
 
-export function Reference({ refkey, type }: Readonly<ReferenceProps>) {
+export function Reference({ refkey, type }: ReferenceProps) {
   const reference = ref(refkey, { type });
 
   return <>{reference}</>;

--- a/packages/typescript/src/symbols/reference.ts
+++ b/packages/typescript/src/symbols/reference.ts
@@ -20,7 +20,10 @@ import { TSModuleScope } from "./ts-module-scope.js";
 import { TSOutputSymbol, TSSymbolFlags } from "./ts-output-symbol.js";
 import { TSPackageScope } from "./ts-package-scope.js";
 
-export function ref(refkey: Refkey, type?: boolean): () => string {
+export interface RefOptions {
+  type?: boolean;
+}
+export function ref(refkey: Refkey, options?: RefOptions): () => string {
   const sourceFile = useContext(SourceFileContext);
   const resolveResult = resolve<TSOutputScope, TSOutputSymbol>(
     refkey as Refkey,
@@ -108,7 +111,7 @@ export function ref(refkey: Refkey, type?: boolean): () => string {
         sourceFile!.scope.addImport(
           importSymbol,
           pathDown[0] as TSModuleScope,
-          type,
+          { type: options?.type },
         ),
       );
     }

--- a/packages/typescript/src/symbols/reference.ts
+++ b/packages/typescript/src/symbols/reference.ts
@@ -20,7 +20,7 @@ import { TSModuleScope } from "./ts-module-scope.js";
 import { TSOutputSymbol, TSSymbolFlags } from "./ts-output-symbol.js";
 import { TSPackageScope } from "./ts-package-scope.js";
 
-export function ref(refkey: Refkey): () => string {
+export function ref(refkey: Refkey, type?: boolean): () => string {
   const sourceFile = useContext(SourceFileContext);
   const resolveResult = resolve<TSOutputScope, TSOutputSymbol>(
     refkey as Refkey,
@@ -103,8 +103,13 @@ export function ref(refkey: Refkey): () => string {
       ];
 
       const importSymbol = symbolPath[0];
+
       localSymbol = untrack(() =>
-        sourceFile!.scope.addImport(importSymbol, pathDown[0] as TSModuleScope),
+        sourceFile!.scope.addImport(
+          importSymbol,
+          pathDown[0] as TSModuleScope,
+          type,
+        ),
       );
     }
 

--- a/packages/typescript/src/symbols/ts-module-scope.ts
+++ b/packages/typescript/src/symbols/ts-module-scope.ts
@@ -11,6 +11,10 @@ export interface ImportedSymbol {
 }
 export type ImportRecords = Map<TSModuleScope, Set<ImportedSymbol>>;
 
+export interface AddImportOptions {
+  type?: boolean;
+}
+
 export interface TSModuleScope extends OutputScope {
   kind: "module";
   exportedSymbols: Map<Refkey, TSOutputSymbol>;
@@ -22,7 +26,7 @@ export interface TSModuleScope extends OutputScope {
   addImport(
     symbol: TSOutputSymbol,
     module: TSModuleScope,
-    type?: boolean,
+    options?: AddImportOptions,
   ): TSOutputSymbol;
 }
 
@@ -38,10 +42,10 @@ export function createTSModuleScope(
     exportedSymbols: new Map(),
     importedSymbols: new Map(),
     importedModules: new Map(),
-    addImport(this: TSModuleScope, targetSymbol, targetModule, type) {
+    addImport(this: TSModuleScope, targetSymbol, targetModule, options) {
       const existing = this.importedSymbols.get(targetSymbol);
       if (existing) {
-        if (!type && existing.tsFlags & TSSymbolFlags.TypeSymbol) {
+        if (!options?.type && existing.tsFlags & TSSymbolFlags.TypeSymbol) {
           existing.tsFlags &= ~TSSymbolFlags.TypeSymbol;
         }
         return existing;
@@ -62,7 +66,7 @@ export function createTSModuleScope(
         refkey: refkey({}),
         tsFlags: TSSymbolFlags.LocalImportSymbol,
       });
-      if (type) {
+      if (options?.type) {
         localSymbol.tsFlags |= TSSymbolFlags.TypeSymbol;
       }
 

--- a/packages/typescript/test/imports.test.tsx
+++ b/packages/typescript/test/imports.test.tsx
@@ -1,4 +1,5 @@
 import {
+  List,
   Output,
   SourceDirectory,
   StatementList,
@@ -6,7 +7,7 @@ import {
   render,
 } from "@alloy-js/core";
 import "@alloy-js/core/testing";
-import { it } from "vitest";
+import { describe, it } from "vitest";
 import * as ts from "../src/components/index.js";
 import { Reference } from "../src/components/Reference.js";
 import { tsNameConflictResolver } from "../src/name-conflict-resolver.js";
@@ -306,5 +307,137 @@ it("handles conflicts with local declarations", () => {
       const v = test_1;
       export function test() {}
     `,
+  });
+});
+
+describe("type imports", () => {
+  function mkTestFile(name: string) {
+    const TypeA = refkey("TypeA");
+    const TypeB = refkey("TypeB");
+    const ClassA = refkey("ClassA");
+
+    return {
+      component: (
+        <ts.SourceFile path="test1.ts">
+          <ts.InterfaceDeclaration export name="TypeA" refkey={TypeA} />
+          <ts.InterfaceDeclaration export name="TypeB" refkey={TypeB} />
+          <ts.ClassDeclaration export name="ClassA" refkey={ClassA} />
+        </ts.SourceFile>
+      ),
+      TypeA,
+      TypeB,
+      ClassA,
+    };
+  }
+
+  it("adds type keyword only to type imports", () => {
+    const { component, TypeA, ClassA } = mkTestFile("test1.ts");
+    const res = render(
+      <Output>
+        {component}
+        <ts.SourceFile path="test2.ts">
+          <List>
+            <>
+              type A = <Reference refkey={TypeA} type />
+            </>
+            <>
+              class B extends <Reference refkey={ClassA} /> {"{}"}
+            </>
+          </List>
+        </ts.SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(res, {
+      "test2.ts": `
+      import { type TypeA, ClassA } from "./test1.js";
+
+      type A = TypeA
+      class B extends ClassA {}
+    `,
+    });
+  });
+
+  it("add type keyword for whole import if all are types", () => {
+    const { component, TypeA, TypeB } = mkTestFile("test1.ts");
+    const res = render(
+      <Output>
+        {component}
+        <ts.SourceFile path="test2.ts">
+          <List>
+            <>
+              type A = <Reference refkey={TypeA} type />
+            </>
+            <>
+              type B = <Reference refkey={TypeB} type />
+            </>
+          </List>
+        </ts.SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(res, {
+      "test2.ts": `
+      import type { TypeA, TypeB } from "./test1.js";
+
+      type A = TypeA
+      type B = TypeB
+    `,
+    });
+  });
+  it("reference same type multiple times", () => {
+    const { component, TypeA, ClassA } = mkTestFile("test1.ts");
+    const res = render(
+      <Output>
+        {component}
+        <ts.SourceFile path="test2.ts">
+          <List>
+            <>
+              type A = <Reference refkey={TypeA} type />
+            </>
+            <>
+              type B = <Reference refkey={TypeA} type />
+            </>
+          </List>
+        </ts.SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(res, {
+      "test2.ts": `
+      import type { TypeA } from "./test1.js";
+
+      type A = TypeA
+      type B = TypeA
+    `,
+    });
+  });
+
+  it("same reference used as both type and non type doesn't include type", () => {
+    const { component, ClassA } = mkTestFile("test1.ts");
+    const res = render(
+      <Output>
+        {component}
+        <ts.SourceFile path="test2.ts">
+          <List>
+            <>
+              type A = <Reference refkey={ClassA} type />
+            </>
+            <>
+              class B extends <Reference refkey={ClassA} /> {"{}"}
+            </>
+          </List>
+        </ts.SourceFile>
+      </Output>,
+    );
+
+    assertFileContents(res, {
+      "test2.ts": `
+      import { ClassA } from "./test1.js";
+
+      type A = ClassA
+      class B extends ClassA {}
+    `,
+    });
   });
 });

--- a/packages/typescript/test/imports.test.tsx
+++ b/packages/typescript/test/imports.test.tsx
@@ -386,7 +386,7 @@ describe("type imports", () => {
     });
   });
   it("reference same type multiple times", () => {
-    const { component, TypeA, ClassA } = mkTestFile("test1.ts");
+    const { component, TypeA } = mkTestFile("test1.ts");
     const res = render(
       <Output>
         {component}


### PR DESCRIPTION
fix #120

when using a typescript reference can specify it is used in a type context which updates the imports to include `type` keyword. 

If a symbol is used both as type and non type the keyword will be omitted.
If all symbols from an import are types it uses this syntax `import type {A, B, C} from "..."` otherwise it use `import {type A, B, type C} from "..."`