### PR TITLE
Sort import statements and named imports

### DIFF
--- a/.chronus/changes/sort-import-2025-4-2-3-24-42.md
+++ b/.chronus/changes/sort-import-2025-4-2-3-24-42.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Sort import statements and named imports

--- a/packages/typescript/src/components/ImportStatement.tsx
+++ b/packages/typescript/src/components/ImportStatement.tsx
@@ -21,9 +21,14 @@ export interface ImportStatementsProps {
 export function ImportStatements(props: ImportStatementsProps) {
   const pkg = usePackage();
 
+  const imports = [...props.records];
+  imports.sort(([a], [b]) => {
+    return a.name.localeCompare(b.name);
+  });
+
   return mapJoin(
-    () => props.records,
-    (module, importedSymbols) => {
+    () => imports,
+    ([module, importedSymbols]) => {
       let targetPath: string;
 
       if (

--- a/packages/typescript/src/components/ImportStatement.tsx
+++ b/packages/typescript/src/components/ImportStatement.tsx
@@ -91,6 +91,9 @@ export function ImportStatement(props: ImportStatementProps) {
     }
 
     if (namedImportSymbols.length > 0) {
+      namedImportSymbols.sort((a, b) => {
+        return a.local.name.localeCompare(b.local.name);
+      });
       const allNamedImportsAreTypes = namedImportSymbols.every(
         (nis) => nis.local.tsFlags & TSSymbolFlags.TypeSymbol,
       );

--- a/packages/typescript/src/components/ImportStatement.tsx
+++ b/packages/typescript/src/components/ImportStatement.tsx
@@ -1,4 +1,5 @@
 import {
+  computed,
   mapJoin,
   memo,
   SourceDirectoryContext,
@@ -21,13 +22,14 @@ export interface ImportStatementsProps {
 export function ImportStatements(props: ImportStatementsProps) {
   const pkg = usePackage();
 
-  const imports = [...props.records];
-  imports.sort(([a], [b]) => {
-    return a.name.localeCompare(b.name);
-  });
+  const imports = computed(() =>
+    [...props.records].sort(([a], [b]) => {
+      return a.name.localeCompare(b.name);
+    }),
+  );
 
   return mapJoin(
-    () => imports,
+    () => imports.value,
     ([module, importedSymbols]) => {
       let targetPath: string;
 

--- a/packages/typescript/test/basic.test.tsx
+++ b/packages/typescript/test/basic.test.tsx
@@ -75,7 +75,7 @@ it("works", () => {
   `);
 
   expect(findFile(res, "test2.ts").contents).toEqual(d`
-    import { sayHello, sayGoodbye } from "./test1.js";
+    import { sayGoodbye, sayHello } from "./test1.js";
     
     console.log(sayHello("world"));
     console.log(sayGoodbye("world"));

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -50,8 +50,8 @@ it("can import builtins", () => {
       }
     `,
     "index.ts": `
-      import { nice } from "testLib/subpath";
       import { readFile } from "node:fs/promises";
+      import { nice } from "testLib/subpath";
 
       nice;
       await readFile();
@@ -85,8 +85,8 @@ it("can import builtins without a package", () => {
 
   assertFileContents(res, {
     "index.ts": `
-      import { nice } from "testLib/subpath";
       import { readFile } from "node:fs/promises";
+      import { nice } from "testLib/subpath";
 
       nice;
       await readFile();
@@ -124,8 +124,8 @@ it("can import builtins without a package", () => {
 
   assertFileContents(res, {
     "index.ts": `
-      import { nice } from "testLib/subpath";
       import { readFile } from "node:fs/promises";
+      import { nice } from "testLib/subpath";
 
       function foo() {
         function bar() {

--- a/packages/typescript/test/imports.test.tsx
+++ b/packages/typescript/test/imports.test.tsx
@@ -214,9 +214,9 @@ it("works with importing the same name many times from different files with the 
 
   assertFileContents(res, {
     "test-import.ts": `
-      import { type MyInterface, conflict } from "./test1.js";
-      import { type MyInterface as MyInterface_2, conflict as conflict_2 } from "./test2.js";
-      import { type MyInterface as MyInterface_3, conflict as conflict_3 } from "./test3.js";
+      import { conflict, type MyInterface } from "./test1.js";
+      import { conflict as conflict_2, type MyInterface as MyInterface_2 } from "./test2.js";
+      import { conflict as conflict_3, type MyInterface as MyInterface_3 } from "./test3.js";
 
       const one: MyInterface = conflict;
       const two: MyInterface_2 = conflict_2;
@@ -402,7 +402,7 @@ describe("type imports", () => {
 
     assertFileContents(res, {
       "test2.ts": `
-      import { type TypeA, ClassA } from "./test1.js";
+      import { ClassA, type TypeA } from "./test1.js";
 
       type A = TypeA
       class B extends ClassA {}

--- a/packages/typescript/test/imports.test.tsx
+++ b/packages/typescript/test/imports.test.tsx
@@ -70,6 +70,77 @@ it("works with named imports", () => {
   });
 });
 
+it("sort named imports", () => {
+  const res = render(
+    <Output>
+      <ts.SourceFile path="test1.ts">
+        <List>
+          <>
+            <ts.ClassDeclaration export name="B" refkey={refkey("B")} />
+          </>
+          <>
+            <ts.FunctionDeclaration export name="a" refkey={refkey("a")} />
+          </>
+        </List>
+      </ts.SourceFile>
+
+      <ts.SourceFile path="test2.ts">
+        <List>
+          <>
+            const b = <Reference refkey={refkey("B")} />;
+          </>
+          <>
+            const a = <Reference refkey={refkey("a")} />;
+          </>
+        </List>
+      </ts.SourceFile>
+    </Output>,
+  );
+
+  assertFileContents(res, {
+    "test2.ts": `
+      import { a, B } from "./test1.js";
+
+      const b = B;
+      const a = a;
+    `,
+  });
+});
+
+it("sort statements by import paths", () => {
+  const res = render(
+    <Output>
+      <ts.SourceFile path="a.ts">
+        <ts.ClassDeclaration export default name="A" refkey={refkey("A")} />
+      </ts.SourceFile>
+      <ts.SourceFile path="b.ts">
+        <ts.ClassDeclaration export default name="B" refkey={refkey("B")} />
+      </ts.SourceFile>
+
+      <ts.SourceFile path="test2.ts">
+        <List>
+          <>
+            const b = <Reference refkey={refkey("B")} />;
+          </>
+          <>
+            const a = <Reference refkey={refkey("A")} />;
+          </>
+        </List>
+      </ts.SourceFile>
+    </Output>,
+  );
+
+  assertFileContents(res, {
+    "test2.ts": `
+      import A from "./a.js";
+      import B from "./b.js";
+
+      const b = B;
+      const a = A;
+    `,
+  });
+});
+
 it("works with default and named imports", () => {
   const res = render(
     <Output>


### PR DESCRIPTION
1. Sorting the statements by path
2. Sorting the named import by local path(Seems to be the same as prettier does though by target path would maybe make more sense)