### PR TITLE
createPackage should allow defining static and instance members

### DIFF
--- a/.chronus/changes/static-members-2025-4-7-20-40-48.md
+++ b/.chronus/changes/static-members-2025-4-7-20-40-48.md
@@ -4,4 +4,4 @@ packages:
   - "@alloy-js/typescript"
 ---
 
-Add support to createPackage for providing named members
+Add support to createPackage for defining instance and static members.

--- a/.chronus/changes/static-members-2025-4-7-20-40-48.md
+++ b/.chronus/changes/static-members-2025-4-7-20-40-48.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Add support to createPackage for providing named members

--- a/packages/typescript/src/create-package.ts
+++ b/packages/typescript/src/create-package.ts
@@ -65,7 +65,6 @@ function createStaticMembers(
   for (const member of staticMembers) {
     const memberObj = typeof member === "object" ? member : { name: member };
 
-    console.log("creating static member", memberObj);
     // Create a refkey directly if it doesn't exist yet
     keys[memberObj.name] ??= refkey();
 
@@ -87,11 +86,7 @@ function createStaticMembers(
       default: false,
       flags: memberFlags,
     });
-    memberScope.symbols.forEach((s) => {
-      console.log("member scope", s.name);
-    });
     memberScope.symbols.add(memberSym);
-    console.log("created static member", memberSym);
 
     // Handle static members of the current member
     createStaticMembers(
@@ -124,7 +119,6 @@ function createInstanceMembers(
 
   for (const member of instanceMembers) {
     const memberObj = typeof member === "object" ? member : { name: member };
-    console.log("creating instance member", memberObj);
 
     // Create a refkey directly if it doesn't exist yet
     if (!keys[memberObj.name]) {
@@ -149,7 +143,6 @@ function createInstanceMembers(
     });
 
     ownerSym.instanceMemberScope.symbols.add(memberSym);
-    console.log("created instance member", memberSym);
 
     // Recursively handle nested static members
     createStaticMembers(
@@ -361,6 +354,5 @@ export function createPackage<const T extends PackageDescriptor>(
     }
   }
 
-  console.log("all my refkeys", refkeys);
   return refkeys;
 }

--- a/packages/typescript/src/create-package.ts
+++ b/packages/typescript/src/create-package.ts
@@ -31,7 +31,7 @@ export interface PackageDescriptor {
  * - `instanceMembers`: An optional array of named module descriptors representing
  *  instance members of the module.
  */
-type NamedModuleDescriptor =
+export type NamedModuleDescriptor =
   | string
   | {
       name: string;
@@ -42,7 +42,7 @@ type NamedModuleDescriptor =
 /**
  * Describes the symbols exported by a module.
  */
-interface ModuleSymbolsDescriptor {
+export interface ModuleSymbolsDescriptor {
   default?: string;
   named?: NamedModuleDescriptor[];
 }
@@ -60,7 +60,7 @@ export interface CreatePackageProps<T extends PackageDescriptor> {
 /**
  * Infers the exported members of a module based on its descriptor.
  *
- * @template D - The module descriptor, which may specify a `default` export (as a string)
+ * D - The module descriptor, which may specify a `default` export (as a string)
  *   and/or an array of named exports (`named`).
  *
  * If `D` includes a `default` property of type `string`, the resulting type will include a
@@ -78,7 +78,12 @@ export type PackageRefkeys<
     string,
     { default?: string; named?: NamedModuleDescriptor[] }
   >,
-> = { [P in keyof PD]: ModuleExports<PD[P]> };
+  // “Root” module descriptor at key `"."` becomes the “flat” exports on mcpSdk.*
+> = ModuleExports<PD["."]> & {
+  // Every other module-path (e.g. "./foo/bar.js") lives under its own index:
+  //    mcpSdk["./foo/bar.js"].<exports>
+  [P in keyof PD as P extends "." ? never : P]: ModuleExports<PD[P]>;
+};
 
 // NamedMap is a utility type that maps the named module descriptors
 // to their corresponding Refkey types. It handles both string and object
@@ -88,7 +93,7 @@ export type PackageRefkeys<
 //   • string entries ➜ { [s]: Refkey }
 //   • object entries ➜ { [name]: Refkey & { static: …; instance: … } }
 // ────────────────────────────────────────────────────────────────
-type NamedMap<TDescriptor extends readonly NamedModuleDescriptor[]> =
+export type NamedMap<TDescriptor extends readonly NamedModuleDescriptor[]> =
   // plain-string exports
   {
     [S in Extract<TDescriptor[number], string>]: Refkey;

--- a/packages/typescript/src/create-package.ts
+++ b/packages/typescript/src/create-package.ts
@@ -12,6 +12,8 @@ import {
   createTSModuleScope,
   createTSPackageScope,
   createTSSymbol,
+  TSModuleScope,
+  TSOutputSymbol,
 } from "./symbols/index.js";
 
 export interface PackageDescriptor {
@@ -29,7 +31,7 @@ export interface ModuleSymbolsDescriptor {
 
 function createNamedSymbol(
   binder: Binder,
-  moduleScope: any,
+  moduleScope: TSModuleScope,
   name: string,
   key: Refkey,
   flags?: OutputSymbolFlags,
@@ -48,7 +50,7 @@ function createNamedSymbol(
 
 function createStaticMembers(
   binder: Binder,
-  namespaceSym: any,
+  namespaceSym: TSOutputSymbol,
   staticMembers: NamedModuleDescriptor[],
   keys: any,
   namespaceName: string,
@@ -254,8 +256,8 @@ function createStaticMemberKeys(
   path: string,
   parentName: string,
   staticMembers: NamedModuleDescriptor[],
-): Record<string, any> {
-  const result: Record<string, any> = {};
+): Record<string, Refkey> {
+  const result: Record<string, Refkey> = {};
   for (const member of staticMembers) {
     if (typeof member === "string") {
       result[member] = refkey(descriptor, path, `${parentName}.${member}`);

--- a/packages/typescript/src/create-package.ts
+++ b/packages/typescript/src/create-package.ts
@@ -86,6 +86,10 @@ function createStaticMembers(
       default: false,
       flags: memberFlags,
     });
+    memberScope.symbols.forEach((s) => {
+      console.log("member scope", s.name);
+    });
+    memberScope.symbols.add(memberSym);
     console.log("created static member", memberSym);
 
     // Handle static members of the current member
@@ -138,6 +142,8 @@ function createInstanceMembers(
       default: false,
       flags: memberFlags,
     });
+
+    memberScope.symbols.add(memberSym);
     console.log("created instance member", memberSym);
 
     // Recursively handle nested static members

--- a/packages/typescript/src/create-package.ts
+++ b/packages/typescript/src/create-package.ts
@@ -186,24 +186,6 @@ function assignMembers(
   }
 }
 
-function createStaticMembers(
-  binder: Binder,
-  ownerSym: TSOutputSymbol,
-  staticMembers: NamedModuleDescriptor[],
-  keys: Record<string, any>,
-) {
-  assignMembers(binder, ownerSym, staticMembers, keys, true);
-}
-
-function createInstanceMembers(
-  binder: Binder,
-  ownerSym: TSOutputSymbol,
-  instanceMembers: NamedModuleDescriptor[],
-  keys: Record<string, any>,
-) {
-  assignMembers(binder, ownerSym, instanceMembers, keys, false);
-}
-
 function createSymbols(
   binder: Binder,
   props: CreatePackageProps<PackageDescriptor>,
@@ -261,17 +243,19 @@ function createSymbols(
       });
       moduleScope.exportedSymbols.set(key, ownerSym);
 
-      createStaticMembers(
+      assignMembers(
         binder,
         ownerSym,
         namedRef.staticMembers ?? [],
         keys[namedRef.name],
+        /* isStatic */ true,
       );
-      createInstanceMembers(
+      assignMembers(
         binder,
         ownerSym,
         namedRef.instanceMembers ?? [],
         keys[namedRef.name],
+        /* isStatic */ false,
       );
     }
   }

--- a/packages/typescript/src/create-package.ts
+++ b/packages/typescript/src/create-package.ts
@@ -13,6 +13,7 @@ import {
   createTSPackageScope,
   createTSSymbol,
   TSModuleScope,
+  TSOutputScope,
   TSOutputSymbol,
 } from "./symbols/index.js";
 
@@ -115,7 +116,11 @@ function createInstanceMembers(
   instanceMembers: NamedModuleDescriptor[],
   keys: Record<string, any>,
 ) {
-  const memberScope = createTSMemberScope(binder, ownerSym.scope, ownerSym);
+  ownerSym.instanceMemberScope ??= createTSMemberScope(
+    binder,
+    undefined,
+    ownerSym,
+  );
 
   for (const member of instanceMembers) {
     const memberObj = typeof member === "object" ? member : { name: member };
@@ -136,14 +141,14 @@ function createInstanceMembers(
 
     const memberSym = createTSSymbol({
       name: memberObj.name,
-      scope: memberScope,
+      scope: ownerSym.instanceMemberScope as TSOutputScope,
       refkey: keys[memberObj.name],
       export: false,
       default: false,
       flags: memberFlags,
     });
 
-    memberScope.symbols.add(memberSym);
+    ownerSym.instanceMemberScope.symbols.add(memberSym);
     console.log("created instance member", memberSym);
 
     // Recursively handle nested static members

--- a/packages/typescript/src/create-package.ts
+++ b/packages/typescript/src/create-package.ts
@@ -229,7 +229,7 @@ export function createPackage<const T extends PackageDescriptor>(
     for (const named of symbols.named ?? []) {
       if (typeof named === "object") {
         const { name, staticMembers } = named;
-        keys[name] = refkey(props.descriptor, path, name);
+        keys[name] = refkey();
         if (staticMembers) {
           keys[name] = {
             ...keys[name],
@@ -242,7 +242,7 @@ export function createPackage<const T extends PackageDescriptor>(
           };
         }
       } else {
-        keys[named] = refkey(props.descriptor, path, named);
+        keys[named] = refkey();
       }
     }
   }
@@ -260,13 +260,9 @@ function createStaticMemberKeys(
   const result: Record<string, Refkey> = {};
   for (const member of staticMembers) {
     if (typeof member === "string") {
-      result[member] = refkey(descriptor, path, `${parentName}.${member}`);
+      result[member] = refkey();
     } else {
-      result[member.name] = refkey(
-        descriptor,
-        path,
-        `${parentName}.${member.name}`,
-      );
+      result[member.name] = refkey();
       if (member.staticMembers) {
         result[member.name] = {
           ...result[member.name],

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -136,3 +136,46 @@ it("can import builtins without a package", () => {
     `,
   });
 });
+
+// TODO: better name and location
+it("can import static members", () => {
+  const mcpSdk = createPackage({
+    name: "@modelcontextprotocol/sdk",
+    version: "^3.23.0",
+    descriptor: {
+      "./server/index.js": {
+        named: [
+          { name: "server", staticMembers: ["setRequestHandler"] }, // descriptor form
+          { name: "simple" }, // descriptor form
+          "other", // simple form
+        ],
+      },
+    },
+  });
+
+  const res = render(
+    <Output externals={[mcpSdk, fs]}>
+      <SourceFile path="index.ts">
+        <FunctionDeclaration name="foo">
+          {mcpSdk["./server/index.js"].server.setRequestHandler}();
+          <hbr />
+          await {mcpSdk["./server/index.js"].simple}();
+          <hbr />
+          {mcpSdk["./server/index.js"].other}();
+        </FunctionDeclaration>
+      </SourceFile>
+    </Output>,
+  );
+
+  assertFileContents(res, {
+    "index.ts": `
+      import { other, setRequestHandler, simple } from "@modelcontextprotocol/sdk/server/index.js";
+
+      function foo() {
+        setRequestHandler();
+        await simple();
+        other();
+      }
+    `,
+  });
+});

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -161,7 +161,7 @@ it("can import static members", () => {
   });
 
   const res = render(
-    <Output externals={[mcpSdk, fs]}>
+    <Output externals={[mcpSdk]}>
       <SourceFile path="index.ts">
         <FunctionDeclaration name="foo">
           {mcpSdk["./server/index.js"].server}();
@@ -203,23 +203,17 @@ it("can import instance members", () => {
     version: "^3.23.0",
     descriptor: {
       "./server/index.js": {
-        named: [
-          {
-            name: "Server",
-            instanceMembers: ["instanceHandler"],
-          },
-        ],
+        named: [{ name: "Server", instanceMembers: ["instanceHandler"] }],
       },
     },
   });
 
   function RunTest() {
-    const sym = createTSSymbol({
-      name: "foo",
-    });
+    const sym = createTSSymbol({ name: "foo" });
     const binder = sym.binder;
 
     expect(binder).toBeDefined();
+
     const source = binder.getSymbolForRefkey(
       mcpSdk["./server/index.js"].Server,
     ).value!;
@@ -229,13 +223,9 @@ it("can import instance members", () => {
     binder.instantiateSymbolInto(source, sym);
 
     expect(sym.staticMemberScope?.symbols.size).toBe(1);
-    expect(sym.staticMemberScope?.symbols.values().next().value?.name).toBe(
-      "instanceHandler",
-    );
+    expect([...sym.staticMemberScope!.symbols][0].name).toBe("instanceHandler");
   }
 
-  // TODO:
-  // 2. Update types to namespace instance vs static properties (thing.Server.instance.instanceHandler, thing.Server.static.create)
   render(
     <Output externals={[mcpSdk]}>
       <SourceFile path="index.ts">

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -169,10 +169,10 @@ it("can import static members", () => {
 
   assertFileContents(res, {
     "index.ts": `
-      import { other, setRequestHandler, simple } from "@modelcontextprotocol/sdk/server/index.js";
+      import { other, server, simple } from "@modelcontextprotocol/sdk/server/index.js";
 
       function foo() {
-        setRequestHandler();
+        server.setRequestHandler();
         await simple();
         other();
       }

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -137,8 +137,6 @@ it("can import builtins without a package", () => {
   });
 });
 
-// TODO: better name and location
-
 it("can import static members", () => {
   const mcpSdk = createPackage({
     name: "@modelcontextprotocol/sdk",

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -1,4 +1,4 @@
-import { Output, refkey, render, useBinder } from "@alloy-js/core";
+import { Output, refkey, render } from "@alloy-js/core";
 import { it } from "vitest";
 import { fs } from "../src/builtins/node.js";
 import {
@@ -6,6 +6,7 @@ import {
   ClassMethod,
   createPackage,
   FunctionDeclaration,
+  MemberExpression,
   PackageDirectory,
   SourceFile,
 } from "../src/index.js";
@@ -222,10 +223,12 @@ it.only("can import instance members", () => {
             Static: {mcpSdk["./server/index.js"].Server.create}();
             <hbr />
             Instance:{" "}
-            {refkey([
-              mcpSdk["./server/index.js"].Server.instanceHandler,
-              "MyServer",
-            ])}
+            <MemberExpression>
+              <MemberExpression.Part id="this" />
+              <MemberExpression.Part
+                refkey={mcpSdk["./server/index.js"].Server.instanceHandler}
+              />
+            </MemberExpression>
             ();
           </ClassMethod>
         </ClassDeclaration>

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -151,8 +151,8 @@ it("can import static members", () => {
               { name: "nested", staticMembers: ["nestedHandler"] },
             ],
           },
-          { name: "simple" },
-          "other",
+          { name: "noMembers" },
+          "simpleName",
         ],
       },
     },
@@ -162,15 +162,15 @@ it("can import static members", () => {
     <Output externals={[mcpSdk, fs]}>
       <SourceFile path="index.ts">
         <FunctionDeclaration name="foo">
+          {mcpSdk["./server/index.js"].server}();
+          <hbr />
           {mcpSdk["./server/index.js"].server.setRequestHandler}();
           <hbr />
           {mcpSdk["./server/index.js"].server.nested.nestedHandler}();
           <hbr />
-          await {mcpSdk["./server/index.js"].server}();
+          {mcpSdk["./server/index.js"].noMembers}();
           <hbr />
-          {mcpSdk["./server/index.js"].other}();
-          <hbr />
-          {mcpSdk["./server/index.js"].simple}();
+          {mcpSdk["./server/index.js"].simpleName}();
         </FunctionDeclaration>
       </SourceFile>
     </Output>,
@@ -178,14 +178,14 @@ it("can import static members", () => {
 
   assertFileContents(res, {
     "index.ts": `
-      import { other, server, simple } from "@modelcontextprotocol/sdk/server/index.js";
+      import { noMembers, server, simpleName } from "@modelcontextprotocol/sdk/server/index.js";
 
       function foo() {
+        server();
         server.setRequestHandler();
         server.nested.nestedHandler();
-        await server();
-        other();
-        simple();
+        noMembers();
+        simpleName();
       }
     `,
   });

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -138,6 +138,7 @@ it("can import builtins without a package", () => {
 });
 
 // TODO: better name and location
+
 it("can import static members", () => {
   const mcpSdk = createPackage({
     name: "@modelcontextprotocol/sdk",
@@ -145,9 +146,15 @@ it("can import static members", () => {
     descriptor: {
       "./server/index.js": {
         named: [
-          { name: "server", staticMembers: ["setRequestHandler"] }, // descriptor form
-          { name: "simple" }, // descriptor form
-          "other", // simple form
+          {
+            name: "server",
+            staticMembers: [
+              "setRequestHandler",
+              { name: "nested", staticMembers: ["nestedHandler"] },
+            ],
+          },
+          { name: "simple" },
+          "other",
         ],
       },
     },
@@ -158,6 +165,8 @@ it("can import static members", () => {
       <SourceFile path="index.ts">
         <FunctionDeclaration name="foo">
           {mcpSdk["./server/index.js"].server.setRequestHandler}();
+          <hbr />
+          {mcpSdk["./server/index.js"].server.nested.nestedHandler}();
           <hbr />
           await {mcpSdk["./server/index.js"].simple}();
           <hbr />
@@ -173,6 +182,7 @@ it("can import static members", () => {
 
       function foo() {
         server.setRequestHandler();
+        server.nested.nestedHandler();
         await simple();
         other();
       }

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -203,13 +203,8 @@ it.only("can import instance members", () => {
           {
             name: "Server",
             instanceMembers: ["instanceHandler"],
-            staticMembers: [
-              "setRequestHandler",
-              { name: "nested", staticMembers: ["nestedHandler"] },
-            ],
+            staticMembers: ["create"],
           },
-          //{ name: "noMembers" },
-          //"simpleName",
         ],
       },
     },
@@ -224,66 +219,13 @@ it.only("can import instance members", () => {
           extends={mcpSdk["./server/index.js"].Server}
         >
           <ClassMethod name="handleRequest">
-            {(function () {
-              console.log("instantiatingInto");
-              const binder = useBinder();
-              // TODO: param ordering is misleading in doc comment...
-              const source = binder.getSymbolForRefkey(
-                mcpSdk["./server/index.js"].Server,
-              ).value!;
-
-              const target = binder.getSymbolForRefkey(
-                refkey("MyServer"),
-              ).value!;
-
-              if (source === undefined || target === undefined) {
-                throw new Error("Source or target is undefined");
-              }
-              // console.log({
-              //   source: {
-              //     name: source.name,
-              //     staticMembers: source.staticMemberScope?.getSymbolNames(),
-              //     instanceMembers: source.instanceMemberScope?.getSymbolNames(),
-              //   },
-              //   target: {
-              //     name: target.name,
-              //     staticMembers: target.staticMemberScope?.getSymbolNames(),
-              //     instanceMembers: target.instanceMemberScope?.getSymbolNames(),
-              //   },
-              // });
-
-              binder.instantiateSymbolInto(source, target);
-
-              console.log({
-                source: {
-                  name: source.name,
-                  staticMembers: source.staticMemberScope?.getSymbolNames(),
-                  instanceMembers: source.instanceMemberScope?.getSymbolNames(),
-                },
-                target: {
-                  name: target.name,
-                  staticMembers: target.staticMemberScope?.getSymbolNames(),
-                  instanceMembers: target.instanceMemberScope?.getSymbolNames(),
-                },
-              });
-            })()}
-            Static: {mcpSdk["./server/index.js"].Server.setRequestHandler}();
-            <hbr />
-            Static Nested:{" "}
-            {mcpSdk["./server/index.js"].Server.nested.nestedHandler}();
+            Static: {mcpSdk["./server/index.js"].Server.create}();
             <hbr />
             Instance:{" "}
             {refkey([
               mcpSdk["./server/index.js"].Server.instanceHandler,
               "MyServer",
             ])}
-            ();
-            <hbr />
-            Instance single:{" "}
-            {refkey(
-              mcpSdk["./server/index.js"].Server.instanceHandler,
-              "MyServer",
-            )}
             ();
           </ClassMethod>
         </ClassDeclaration>
@@ -298,10 +240,8 @@ it.only("can import instance members", () => {
 
       class MyServer extends Server {
         handleRequest() {
-          Static: Server.setRequestHandler();
-          Static Nested: Server.nested.nestedHandler();
+          Static: Server.create();
           Instance: this.instanceHandler();
-          Instance single: this.instanceHandler();
         }
       }
     `,

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -151,6 +151,7 @@ it("can import static members", () => {
               "setRequestHandler",
               { name: "nested", staticMembers: ["nestedHandler"] },
             ],
+            instanceMembers: ["instanceHandler"],
           },
           { name: "noMembers" },
           "simpleName",
@@ -165,9 +166,13 @@ it("can import static members", () => {
         <FunctionDeclaration name="foo">
           {mcpSdk["./server/index.js"].server}();
           <hbr />
-          {mcpSdk["./server/index.js"].server.setRequestHandler}();
+          {mcpSdk["./server/index.js"].server.static.setRequestHandler}();
           <hbr />
-          {mcpSdk["./server/index.js"].server.nested.nestedHandler}();
+          {
+            mcpSdk["./server/index.js"].server.static.nested.static
+              .nestedHandler
+          }
+          ();
           <hbr />
           {mcpSdk["./server/index.js"].noMembers}();
           <hbr />
@@ -177,6 +182,7 @@ it("can import static members", () => {
     </Output>,
   );
 
+  console.log(res.contents[0].contents);
   assertFileContents(res, {
     "index.ts": `
       import { noMembers, server, simpleName } from "@modelcontextprotocol/sdk/server/index.js";

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -1,4 +1,4 @@
-import { Output, render } from "@alloy-js/core";
+import { Output, refkey, render } from "@alloy-js/core";
 import { it } from "vitest";
 import { fs } from "../src/builtins/node.js";
 import {
@@ -193,7 +193,7 @@ it("can import static members", () => {
   });
 });
 
-it("can import instance members", () => {
+it.only("can import instance members", () => {
   const mcpSdk = createPackage({
     name: "@modelcontextprotocol/sdk",
     version: "^3.23.0",
@@ -202,10 +202,8 @@ it("can import instance members", () => {
         named: [
           {
             name: "Server",
-            instanceMembers: [
-              "setRequestHandler",
-              //{ name: "nested", staticMembers: ["nestedHandler"] },
-            ],
+            instanceMembers: ["instanceHandler"],
+            staticMembers: ["setRequestHandler"],
           },
           //{ name: "noMembers" },
           //"simpleName",
@@ -219,9 +217,10 @@ it("can import instance members", () => {
       <SourceFile path="index.ts">
         <ClassDeclaration
           name="MyServer"
+          refkey={refkey("MyServer")}
           extends={mcpSdk["./server/index.js"].Server}
         >
-          <ClassMethod name="handleRequest">TODO</ClassMethod>
+          <ClassMethod name="handleRequest"></ClassMethod>
         </ClassDeclaration>
       </SourceFile>
     </Output>,
@@ -233,7 +232,7 @@ it("can import instance members", () => {
 
       class MyServer extends Server {
         handleRequest() {
-          TODO
+          this.setRequestHandler();
         }
       }
     `,

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -166,9 +166,11 @@ it("can import static members", () => {
           <hbr />
           {mcpSdk["./server/index.js"].server.nested.nestedHandler}();
           <hbr />
-          await {mcpSdk["./server/index.js"].simple}();
+          await {mcpSdk["./server/index.js"].server}();
           <hbr />
           {mcpSdk["./server/index.js"].other}();
+          <hbr />
+          {mcpSdk["./server/index.js"].simple}();
         </FunctionDeclaration>
       </SourceFile>
     </Output>,
@@ -181,8 +183,9 @@ it("can import static members", () => {
       function foo() {
         server.setRequestHandler();
         server.nested.nestedHandler();
-        await simple();
+        await server();
         other();
+        simple();
       }
     `,
   });

--- a/packages/typescript/test/externals.test.tsx
+++ b/packages/typescript/test/externals.test.tsx
@@ -182,7 +182,6 @@ it("can import static members", () => {
     </Output>,
   );
 
-  console.log(res.contents[0].contents);
   assertFileContents(res, {
     "index.ts": `
       import { noMembers, server, simpleName } from "@modelcontextprotocol/sdk/server/index.js";
@@ -208,7 +207,6 @@ it("can import instance members", () => {
           {
             name: "Server",
             instanceMembers: ["instanceHandler"],
-            staticMembers: ["create"],
           },
         ],
       },


### PR DESCRIPTION
This pull request introduces a new feature to the `@alloy-js/typescript` package, enabling support for named static and instance members in module descriptors. The changes include updates to the `createPackage` API, new utility types, and additional test cases to ensure the functionality works as intended.

This supports scenarios such as:

```typescript
  const mcpSdk = createPackage({
    name: "@modelcontextprotocol/sdk",
    version: "^3.23.0",
    descriptor: {
      "./server/index.js": {
        named: [
          {
            name: "server",
            staticMembers: [
              "setRequestHandler",
              { name: "nested", staticMembers: ["nestedHandler"] },
            ],
            instanceMembers: ["instanceHandler"],
          },
          { name: "noMembers" },
          "simpleName",
        ],
      },
    },
  });
```

With namespacing and type inference providing the correct mappings.

Resolves #87