### PR TITLE
Upgrade api extractor

### DIFF
--- a/.chronus/changes/upgrade-api-extractor-2025-4-15-2-1-12.md
+++ b/.chronus/changes/upgrade-api-extractor-2025-4-15-2-1-12.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: internal
+packages:
+  - "@alloy-js/core"
+---
+
+Upgrade api extractor

--- a/packages/core/src/components/Block.tsx
+++ b/packages/core/src/components/Block.tsx
@@ -1,4 +1,7 @@
-import { Children, childrenArray, computed, Indent } from "@alloy-js/core";
+import { computed } from "@vue/reactivity";
+import { Children } from "../jsx-runtime.js";
+import { childrenArray } from "../utils.jsx";
+import { Indent } from "./Indent.jsx";
 
 export interface BlockProps {
   /**

--- a/packages/core/src/components/For.tsx
+++ b/packages/core/src/components/For.tsx
@@ -1,5 +1,5 @@
-import { Children, memo } from "@alloy-js/core/jsx-runtime";
 import { isRef, Ref } from "@vue/reactivity";
+import { type Children, memo } from "../jsx-runtime.js";
 import { baseListPropsToMapJoinArgs, mapJoin } from "../utils.js";
 import { BaseListProps } from "./List.jsx";
 
@@ -75,7 +75,7 @@ export function For<
     | (() => ForSupportedCollections)
     | Ref<ForSupportedCollections>,
   U extends Children,
->(props: ForProps<T, U>) {
+>(props: ForProps<T, U>): Children {
   const cb = props.children;
   const options = baseListPropsToMapJoinArgs(props);
   options.skipFalsy = props.skipFalsy;

--- a/packages/core/src/components/Indent.tsx
+++ b/packages/core/src/components/Indent.tsx
@@ -1,4 +1,4 @@
-import { Children } from "@alloy-js/core/jsx-runtime";
+import { Children } from "../jsx-runtime.js";
 
 export interface IndentProps {
   children: Children;

--- a/packages/core/src/components/List.tsx
+++ b/packages/core/src/components/List.tsx
@@ -1,4 +1,4 @@
-import { Children, memo, splitProps } from "@alloy-js/core/jsx-runtime";
+import { Children, memo, splitProps } from "../jsx-runtime.js";
 import { childrenArray } from "../utils.js";
 import { For } from "./For.jsx";
 

--- a/packages/core/src/components/MemberName.tsx
+++ b/packages/core/src/components/MemberName.tsx
@@ -1,7 +1,8 @@
 import { useContext } from "../context.js";
 import { MemberDeclarationContext } from "../context/member-declaration.js";
+import { Children } from "../jsx-runtime.js";
 
-export function MemberName() {
+export function MemberName(): Children {
   const declSymbol = useContext(MemberDeclarationContext);
   if (!declSymbol) {
     return "(no member declaration context)";

--- a/packages/core/src/components/Name.tsx
+++ b/packages/core/src/components/Name.tsx
@@ -1,7 +1,8 @@
 import { useContext } from "../context.js";
 import { DeclarationContext } from "../context/declaration.js";
+import { Children } from "../jsx-runtime.js";
 
-export function Name() {
+export function Name(): Children {
   const declSymbol = useContext(DeclarationContext);
   if (!declSymbol) {
     return "";

--- a/packages/core/src/components/Prose.tsx
+++ b/packages/core/src/components/Prose.tsx
@@ -1,5 +1,6 @@
-import { childrenArray, computed } from "@alloy-js/core";
-import { Children } from "@alloy-js/core/jsx-runtime";
+import { computed } from "@vue/reactivity";
+import { Children } from "../jsx-runtime.js";
+import { childrenArray } from "../utils.jsx";
 
 export interface Prose {
   children: Children;

--- a/packages/core/src/components/ReferenceOrContent.tsx
+++ b/packages/core/src/components/ReferenceOrContent.tsx
@@ -1,7 +1,7 @@
-import { Children } from "@alloy-js/core/jsx-runtime";
 import { computed } from "@vue/reactivity";
 import { useContext } from "../context.js";
 import { BinderContext } from "../context/binder.js";
+import { Children } from "../jsx-runtime.js";
 import type { Refkey } from "../refkey.js";
 
 export interface ReferenceOrContentProps {

--- a/packages/core/src/components/Show.tsx
+++ b/packages/core/src/components/Show.tsx
@@ -1,4 +1,4 @@
-import { Children } from "@alloy-js/core/jsx-runtime";
+import { Children } from "../jsx-runtime.js";
 
 export interface ShowProps {
   children: Children;

--- a/packages/core/src/components/StatementList.tsx
+++ b/packages/core/src/components/StatementList.tsx
@@ -1,4 +1,5 @@
-import { Children, List } from "@alloy-js/core";
+import { Children } from "../jsx-runtime.js";
+import { List } from "./List.jsx";
 
 export interface StatementListProps {
   children: Children;

--- a/packages/core/src/components/Switch.tsx
+++ b/packages/core/src/components/Switch.tsx
@@ -1,4 +1,9 @@
-import { Children, memo, taggedComponent } from "@alloy-js/core/jsx-runtime";
+import {
+  Children,
+  memo,
+  TaggedComponent,
+  taggedComponent,
+} from "../jsx-runtime.js";
 import { childrenArray, findKeyedChildren } from "../utils.js";
 
 export interface SwitchProps {
@@ -57,6 +62,9 @@ export const matchTag = Symbol();
  * The Match component is used inside of a {@link Switch} component to
  * define conditionally rendered blocks of content.
  */
-export const Match = taggedComponent(matchTag, (props: MatchProps) => {
-  return () => (props.when ? props.children : undefined);
-});
+export const Match: TaggedComponent<MatchProps> = taggedComponent(
+  matchTag,
+  (props: MatchProps) => {
+    return () => (props.when ? props.children : undefined);
+  },
+);

--- a/packages/core/src/components/Wrap.tsx
+++ b/packages/core/src/components/Wrap.tsx
@@ -1,4 +1,4 @@
-import { Children, ComponentDefinition } from "@alloy-js/core/jsx-runtime";
+import { Children, ComponentDefinition } from "../jsx-runtime.js";
 
 export interface WrapProps<TProps> {
   /**

--- a/packages/core/src/jsx-runtime.ts
+++ b/packages/core/src/jsx-runtime.ts
@@ -469,10 +469,13 @@ export function createComponent<TProps extends Props = Props>(
   return creator;
 }
 
+export type TaggedComponent<TProps> = Component<TProps> &
+  Required<Pick<Component<TProps>, "tag">>;
+
 export function taggedComponent<TProps = Props>(
   tag: symbol,
   component: Component<TProps>,
-): Component<TProps> & Required<Pick<Component<TProps>, "tag">> {
+): TaggedComponent<TProps> {
   component.tag = tag;
   return component as any;
 }

--- a/packages/core/src/stc.ts
+++ b/packages/core/src/stc.ts
@@ -1,9 +1,9 @@
+import { code, text } from "./code.js";
 import {
   Children,
   ComponentCreator,
   ComponentDefinition,
-} from "@alloy-js/core/jsx-runtime";
-import { code, text } from "./code.js";
+} from "./jsx-runtime.js";
 
 export type MakeChildrenOptional<T extends object> =
   T extends { children?: any } ?

--- a/packages/core/src/sti.ts
+++ b/packages/core/src/sti.ts
@@ -1,10 +1,10 @@
+import { code, text } from "./code.js";
 import {
   Children,
   createIntrinsic,
   IntrinsicElementBase,
   JSX,
-} from "@alloy-js/core/jsx-runtime";
-import { code, text } from "./code.js";
+} from "./jsx-runtime.js";
 
 export type StiSignature<T extends keyof JSX.IntrinsicElements> = (
   ...args: unknown extends T ? []

--- a/packages/core/src/utils.tsx
+++ b/packages/core/src/utils.tsx
@@ -1,6 +1,6 @@
 import { toRaw } from "@vue/reactivity";
 import {
-  Children,
+  type Children,
   ComponentCreator,
   createCustomContext,
   CustomContext,
@@ -265,7 +265,10 @@ export function childrenArray(
   }
 }
 
-export function findKeyedChild(children: Children[], tag: symbol) {
+export function findKeyedChild(
+  children: Children[],
+  tag: symbol,
+): ComponentCreator | null {
   for (const child of children) {
     if (isKeyedChild(child) && child.tag === tag) {
       return child;
@@ -275,7 +278,10 @@ export function findKeyedChild(children: Children[], tag: symbol) {
   return null;
 }
 
-export function findKeyedChildren(children: Children[], tag: symbol) {
+export function findKeyedChildren(
+  children: Children[],
+  tag: symbol,
+): ComponentCreator[] {
   const keyedChildren: ComponentCreator[] = [];
   for (const child of children) {
     if (isKeyedChild(child) && child.tag === tag) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,11 +25,11 @@ catalogs:
       specifier: ^7.27.0
       version: 7.27.0
     '@microsoft/api-extractor':
-      specifier: ~7.47.7
-      version: 7.47.12
+      specifier: ~7.52.8
+      version: 7.52.8
     '@microsoft/api-extractor-model':
-      specifier: ~7.29.6
-      version: 7.29.9
+      specifier: ~7.30.6
+      version: 7.30.6
     '@microsoft/tsdoc':
       specifier: 0.15.1
       version: 0.15.1
@@ -304,7 +304,7 @@ importers:
         version: link:../rollup-plugin
       '@microsoft/api-extractor':
         specifier: 'catalog:'
-        version: 7.47.12(@types/node@20.17.30)
+        version: 7.52.8(@types/node@20.17.30)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
@@ -387,7 +387,7 @@ importers:
         version: link:../rollup-plugin
       '@microsoft/api-extractor':
         specifier: 'catalog:'
-        version: 7.47.12(@types/node@20.17.30)
+        version: 7.52.8(@types/node@20.17.30)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
@@ -439,10 +439,10 @@ importers:
         version: link:../typescript
       '@microsoft/api-extractor':
         specifier: 'catalog:'
-        version: 7.47.12(@types/node@20.17.30)
+        version: 7.52.8(@types/node@20.17.30)
       '@microsoft/api-extractor-model':
         specifier: 'catalog:'
-        version: 7.29.9(@types/node@20.17.30)
+        version: 7.30.6(@types/node@20.17.30)
       '@microsoft/tsdoc':
         specifier: 'catalog:'
         version: 0.15.1(patch_hash=feqpbbj7jjnlaslm723zbab6bm)
@@ -470,7 +470,7 @@ importers:
         version: link:../rollup-plugin
       '@microsoft/api-extractor':
         specifier: 'catalog:'
-        version: 7.47.12(@types/node@20.17.30)
+        version: 7.52.8(@types/node@20.17.30)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
@@ -501,7 +501,7 @@ importers:
         version: link:../rollup-plugin
       '@microsoft/api-extractor':
         specifier: 'catalog:'
-        version: 7.47.12(@types/node@20.17.30)
+        version: 7.52.8(@types/node@20.17.30)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
@@ -532,7 +532,7 @@ importers:
         version: link:../rollup-plugin
       '@microsoft/api-extractor':
         specifier: 'catalog:'
-        version: 7.47.12(@types/node@20.17.30)
+        version: 7.52.8(@types/node@20.17.30)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -591,7 +591,7 @@ importers:
         version: link:../rollup-plugin
       '@microsoft/api-extractor':
         specifier: 'catalog:'
-        version: 7.47.12(@types/node@20.17.30)
+        version: 7.52.8(@types/node@20.17.30)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
         version: 12.1.2(rollup@4.39.0)(tslib@2.8.1)(typescript@5.8.3)
@@ -1391,11 +1391,11 @@ packages:
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
 
-  '@microsoft/api-extractor-model@7.29.9':
-    resolution: {integrity: sha512-/DaMfUjiswmrnLjHCorVzWGbW5rmeTGDo+H0QcvcarJ14SjNVmFWiRKzscN4B2y9AyllqeXMPgwbtSFAdAkpMQ==}
+  '@microsoft/api-extractor-model@7.30.6':
+    resolution: {integrity: sha512-znmFn69wf/AIrwHya3fxX6uB5etSIn6vg4Q4RB/tb5VDDs1rqREc+AvMC/p19MUN13CZ7+V/8pkYPTj7q8tftg==}
 
-  '@microsoft/api-extractor@7.47.12':
-    resolution: {integrity: sha512-YE/h4vE9T1i3oGtgEZC7pHupH/drtGAuQ36iJ1Ua0gQ8NXmPXNKNilkCqzWnX/QvMnr1xSgEjHppWMXEi5YZKQ==}
+  '@microsoft/api-extractor@7.52.8':
+    resolution: {integrity: sha512-cszYIcjiNscDoMB1CIKZ3My61+JOhpERGlGr54i6bocvGLrcL/wo9o+RNXMBrb7XgLtKaizZWUpqRduQuHQLdg==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.17.1':
@@ -1809,8 +1809,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rushstack/node-core-library@5.10.0':
-    resolution: {integrity: sha512-2pPLCuS/3x7DCd7liZkqOewGM0OzLyCacdvOe8j6Yrx9LkETGnxul1t7603bIaB8nUAooORcct9fFDOQMbWAgw==}
+  '@rushstack/node-core-library@5.13.1':
+    resolution: {integrity: sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -1820,16 +1820,16 @@ packages:
   '@rushstack/rig-package@0.5.3':
     resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
-  '@rushstack/terminal@0.14.3':
-    resolution: {integrity: sha512-csXbZsAdab/v8DbU1sz7WC2aNaKArcdS/FPmXMOXEj/JBBZMvDK0+1b4Qao0kkG0ciB1Qe86/Mb68GjH6/TnMw==}
+  '@rushstack/terminal@0.15.3':
+    resolution: {integrity: sha512-DGJ0B2Vm69468kZCJkPj3AH5nN+nR9SPmC0rFHtzsS4lBQ7/dgOwtwVxYP7W9JPDMuRBkJ4KHmWKr036eJsj9g==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/ts-command-line@4.23.1':
-    resolution: {integrity: sha512-40jTmYoiu/xlIpkkRsVfENtBq4CW3R4azbL0Vmda+fMwHWqss6wwf/Cy/UJmMqIzpfYc2OTnjYP1ZLD3CmyeCA==}
+  '@rushstack/ts-command-line@5.0.1':
+    resolution: {integrity: sha512-bsbUucn41UXrQK7wgM8CNM/jagBytEyJqXw/umtI8d68vFm1Jwxh1OtLrlW7uGZgjCWiiPH6ooUNa1aVsuVr3Q==}
 
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
@@ -2668,9 +2668,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
+  fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
 
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -3010,8 +3010,8 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -4067,8 +4067,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@5.4.2:
-    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4150,9 +4150,9 @@ packages:
   universal-user-agent@7.0.2:
     resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
 
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unstorage@1.15.0:
     resolution: {integrity: sha512-m40eHdGY/gA6xAPqo8eaxqXgBuzQTlAKfmB1iF7oCKXE1HfwHwzDJBywK+qQGn52dta+bPlZluPF7++yR3p/bg==}
@@ -5351,29 +5351,29 @@ snapshots:
       - acorn
       - supports-color
 
-  '@microsoft/api-extractor-model@7.29.9(@types/node@20.17.30)':
+  '@microsoft/api-extractor-model@7.30.6(@types/node@20.17.30)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1(patch_hash=feqpbbj7jjnlaslm723zbab6bm)
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.0(@types/node@20.17.30)
+      '@rushstack/node-core-library': 5.13.1(@types/node@20.17.30)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.47.12(@types/node@20.17.30)':
+  '@microsoft/api-extractor@7.52.8(@types/node@20.17.30)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.9(@types/node@20.17.30)
+      '@microsoft/api-extractor-model': 7.30.6(@types/node@20.17.30)
       '@microsoft/tsdoc': 0.15.1(patch_hash=feqpbbj7jjnlaslm723zbab6bm)
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.0(@types/node@20.17.30)
+      '@rushstack/node-core-library': 5.13.1(@types/node@20.17.30)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.3(@types/node@20.17.30)
-      '@rushstack/ts-command-line': 4.23.1(@types/node@20.17.30)
+      '@rushstack/terminal': 0.15.3(@types/node@20.17.30)
+      '@rushstack/ts-command-line': 5.0.1(@types/node@20.17.30)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.4.2
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -5803,12 +5803,12 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.39.0':
     optional: true
 
-  '@rushstack/node-core-library@5.10.0(@types/node@20.17.30)':
+  '@rushstack/node-core-library@5.13.1(@types/node@20.17.30)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
       ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 7.0.1
+      fs-extra: 11.3.0
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.10
@@ -5821,16 +5821,16 @@ snapshots:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.14.3(@types/node@20.17.30)':
+  '@rushstack/terminal@0.15.3(@types/node@20.17.30)':
     dependencies:
-      '@rushstack/node-core-library': 5.10.0(@types/node@20.17.30)
+      '@rushstack/node-core-library': 5.13.1(@types/node@20.17.30)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.17.30
 
-  '@rushstack/ts-command-line@4.23.1(@types/node@20.17.30)':
+  '@rushstack/ts-command-line@5.0.1(@types/node@20.17.30)':
     dependencies:
-      '@rushstack/terminal': 0.14.3(@types/node@20.17.30)
+      '@rushstack/terminal': 0.15.3(@types/node@20.17.30)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -6876,11 +6876,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fs-extra@7.0.1:
+  fs-extra@11.3.0:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
+      jsonfile: 6.1.0
+      universalify: 2.0.1
 
   fs-minipass@2.1.0:
     dependencies:
@@ -7311,7 +7311,9 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  jsonfile@4.0.0:
+  jsonfile@6.1.0:
+    dependencies:
+      universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
 
@@ -8831,7 +8833,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.4.2: {}
+  typescript@5.8.2: {}
 
   typescript@5.8.3: {}
 
@@ -8921,7 +8923,7 @@ snapshots:
 
   universal-user-agent@7.0.2: {}
 
-  universalify@0.1.2: {}
+  universalify@2.0.1: {}
 
   unstorage@1.15.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,8 @@ catalog:
   "@babel/plugin-syntax-jsx": ^7.18.6
   "@babel/preset-typescript": ^7.27.0
   "@babel/types": ^7.27.0
-  "@microsoft/api-extractor-model": ~7.29.6
-  "@microsoft/api-extractor": ~7.47.7
+  "@microsoft/api-extractor-model": ~7.30.6
+  "@microsoft/api-extractor": ~7.52.8
   "@rollup/plugin-babel": ^6.0.4
   "@rollup/plugin-node-resolve": ^16.0.1
   "@rollup/plugin-typescript": ^12.1.2

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "lib": ["es2023", "DOM"],
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
     "target": "es2022",
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Tentative pr. Api extractor just doesn't handle self imports at all well with this new version so have to make sure `@alloy-js/jsx-runtime` is never included