### PR TITLE
[TypeScript] Fix FunctionParameters component adds an extra comma when no params and function name is long

### DIFF
--- a/.chronus/changes/fix-function-params-extra-comma-2025-5-20-16-4-40.md
+++ b/.chronus/changes/fix-function-params-extra-comma-2025-5-20-16-4-40.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: fix
+packages:
+  - "@alloy-js/typescript"
+---
+
+Fix FunctionParameters component adds an extra comma when no params and function name is long

--- a/packages/typescript/src/components/FunctionBase.tsx
+++ b/packages/typescript/src/components/FunctionBase.tsx
@@ -73,6 +73,10 @@ export const FunctionParameters = taggedComponent(
     }
 
     const parameters = normalizeAndDeclareParameters(props.parameters ?? []);
+    if (parameters.length === 0) {
+      return null;
+    }
+
     return (
       <group>
         <Indent softline trailingBreak>
@@ -103,6 +107,10 @@ export const FunctionTypeParameters = taggedComponent(
     }
 
     const parameters = normalizeAndDeclareParameters(props.parameters ?? []);
+    if (parameters.length === 0) {
+      return null;
+    }
+
     return (
       <group>
         <Indent softline trailingBreak>

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -124,6 +124,18 @@ it("supports type parameters by element", () => {
   `);
 });
 
+it("do not add an extra comma when there is no parameters", () => {
+  expect(
+    toSourceText(
+      <FunctionDeclaration name="thisFunctionNameIsTooLongSoTheFormatterWillInsertLineBreakAndIfBreakNodes"></FunctionDeclaration>,
+    ),
+  ).toBe(d`
+    function thisFunctionNameIsTooLongSoTheFormatterWillInsertLineBreakAndIfBreakNodes() {
+
+    }
+  `);
+});
+
 describe("symbols", () => {
   it("creates a nested scope", () => {
     const innerRefkey = refkey();


### PR DESCRIPTION
When the function name is long (and/or deeply indented), the formatter inserts a line break inside the function parameters parens and an extra comma is added by `<ifBreak>,</ifBreak>`. However, when the function have no parameters at all, it produces an invalid code snippet as follows:

```ts
function thisFunctionNameIsTooLongSoTheFormatterWillInsertLineBreakAndIfBreakNodes(
  ,
) {}
```

This pull request fixes the component to return just `null` when no parameters provided, so the extra comma will never be inserted by the formatter.