### PR TITLE
CSharp type parameters support

### DIFF
--- a/.chronus/changes/type-parameters-2025-5-26-20-31-22.md
+++ b/.chronus/changes/type-parameters-2025-5-26-20-31-22.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: breaking, feature, fix, internal
+changeKind: feature
+packages:
+  - "@alloy-js/csharp"
+---
+
+Support for type parameters for interface, class methods, interface methods

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -5,6 +5,7 @@ dictionaries:
   - node
   - typescript
 words:
+  - arrayify
   - cref
 useGitignore: true
 enableGlobDot: true

--- a/packages/csharp/src/components/ClassDeclaration.tsx
+++ b/packages/csharp/src/components/ClassDeclaration.tsx
@@ -40,7 +40,18 @@ export interface ClassDeclarationProps
   doc?: core.Children;
   refkey?: core.Refkey;
 
-  /** Type parameters */
+  /**
+   * Type parameters for the class
+   *
+   * @example
+   * ```tsx
+   * <ClassDeclaration name="MyClass" typeParameters={["T"]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * public class MyClass<T>
+   * ```
+   */
   typeParameters?: (string | TypeParameterProps)[];
 
   /** Base class that this class extends */

--- a/packages/csharp/src/components/ClassDeclaration.tsx
+++ b/packages/csharp/src/components/ClassDeclaration.tsx
@@ -12,6 +12,9 @@ import { CSharpMemberScope, useCSharpScope } from "../symbols/scopes.js";
 import { Name } from "./Name.jsx";
 import { ParameterProps, Parameters } from "./Parameters.jsx";
 import { DocWhen } from "./doc/comment.jsx";
+import { TypeParameterConstraints } from "./type-parameters/type-parameter-constraints.jsx";
+import { TypeParameterProps } from "./type-parameters/type-parameter.jsx";
+import { TypeParameters } from "./type-parameters/type-parameters.jsx";
 
 export interface ClassModifiers {
   readonly abstract?: boolean;
@@ -36,7 +39,9 @@ export interface ClassDeclarationProps
   /** Doc comment */
   doc?: core.Children;
   refkey?: core.Refkey;
-  typeParameters?: Record<string, core.Refkey>;
+
+  /** Type parameters */
+  typeParameters?: (string | TypeParameterProps)[];
 
   /** Base class that this class extends */
   baseType?: core.Children;
@@ -85,29 +90,6 @@ export function ClassDeclaration(props: ClassDeclarationProps) {
   });
 
   let typeParams: core.Children;
-  if (props.typeParameters) {
-    const typeParamNames = new Array<string>();
-    for (const entry of Object.entries(props.typeParameters)) {
-      typeParamNames.push(
-        useCSharpNamePolicy().getName(entry[0], "type-parameter"),
-      );
-      // create a symbol for each type param so its
-      // refkey resolves to the type param's name
-      new CSharpOutputSymbol(entry[0], {
-        scope: thisClassScope,
-        refkeys: entry[1],
-      });
-    }
-    typeParams = (
-      <group>
-        {"<"}
-        <core.For each={typeParamNames} comma line>
-          {(name) => name}
-        </core.For>
-        {">"}
-      </group>
-    );
-  }
 
   const bases = [
     ...(props.baseType ? [props.baseType] : []),
@@ -123,8 +105,13 @@ export function ClassDeclaration(props: ClassDeclarationProps) {
     <core.Declaration symbol={thisClassSymbol}>
       <DocWhen doc={props.doc} />
       {modifiers}class <Name />
-      {typeParams}
+      {props.typeParameters && (
+        <TypeParameters parameters={props.typeParameters} />
+      )}
       {base}
+      {props.typeParameters && (
+        <TypeParameterConstraints parameters={props.typeParameters} />
+      )}
       {!props.children && ";"}
       {props.children && (
         <core.Block newline>

--- a/packages/csharp/src/components/ClassDeclaration.tsx
+++ b/packages/csharp/src/components/ClassDeclaration.tsx
@@ -89,8 +89,6 @@ export function ClassDeclaration(props: ClassDeclarationProps) {
     owner: thisClassSymbol,
   });
 
-  let typeParams: core.Children;
-
   const bases = [
     ...(props.baseType ? [props.baseType] : []),
     ...(props.interfaceTypes || []),

--- a/packages/csharp/src/components/ClassMethod.tsx
+++ b/packages/csharp/src/components/ClassMethod.tsx
@@ -18,6 +18,9 @@ import { CSharpOutputSymbol } from "../symbols/csharp-output-symbol.js";
 import { CSharpMemberScope, useCSharpScope } from "../symbols/scopes.js";
 import { ParameterProps, Parameters } from "./Parameters.jsx";
 import { DocWhen } from "./doc/comment.jsx";
+import { TypeParameterConstraints } from "./type-parameters/type-parameter-constraints.jsx";
+import { TypeParameterProps } from "./type-parameters/type-parameter.jsx";
+import { TypeParameters } from "./type-parameters/type-parameters.jsx";
 
 /** Method modifiers. Can only be one. */
 export interface ClassMethodModifiers {
@@ -51,6 +54,20 @@ export interface ClassMethodProps
 
   /** Doc comment */
   doc?: Children;
+
+  /**
+   * Type parameters for the method
+   *
+   * @example
+   * ```tsx
+   * <InterfaceMethod name="Test" typeParameters={["T"]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * public void Test<T>()
+   * ```
+   */
+  typeParameters?: (TypeParameterProps | string)[];
 }
 
 // a C# class method
@@ -86,7 +103,14 @@ export function ClassMethod(props: ClassMethodProps) {
       <Scope value={methodScope}>
         <DocWhen doc={props.doc} />
         {modifiers}
-        {returns} {name}({params})
+        {returns}{" "}
+        {props.typeParameters && (
+          <TypeParameters parameters={props.typeParameters} />
+        )}
+        {name}({params})
+        {props.typeParameters && (
+          <TypeParameterConstraints parameters={props.typeParameters} />
+        )}
         {props.abstract ? ";" : <Block newline>{props.children}</Block>}
       </Scope>
     </MemberDeclaration>

--- a/packages/csharp/src/components/index.ts
+++ b/packages/csharp/src/components/index.ts
@@ -15,5 +15,6 @@ export * from "./property/property.jsx";
 export * from "./record/declaration.js";
 export * from "./Reference.js";
 export * from "./SourceFile.js";
+export type { TypeParameterProps } from "./type-parameters/type-parameter.jsx";
 export * from "./UsingDirective.js";
 export * from "./var/declaration.jsx";

--- a/packages/csharp/src/components/interface/declaration.test.tsx
+++ b/packages/csharp/src/components/interface/declaration.test.tsx
@@ -1,10 +1,10 @@
 import { List, refkey } from "@alloy-js/core";
 import { describe, expect, it } from "vitest";
 import { TestNamespace } from "../../../test/utils.jsx";
-import { Property } from "../property/property.jsx";
 import { SourceFile } from "../SourceFile.jsx";
 import { TypeParameterProps } from "../type-parameters/type-parameter.jsx";
 import { InterfaceDeclaration } from "./declaration.jsx";
+import { InterfaceProperty } from "./property.jsx";
 
 it("declares class with no members", () => {
   expect(
@@ -77,12 +77,22 @@ describe("with type parameters", () => {
         <SourceFile path="Test.cs">
           <InterfaceDeclaration
             public
-            name="TestClass"
+            name="Test"
             typeParameters={typeParameters}
           >
             <List>
-              <Property name="PropA" type={typeParameters[0].refkey} />
-              <Property name="PropB" type={typeParameters[1].refkey} />
+              <InterfaceProperty
+                name="PropA"
+                type={typeParameters[0].refkey}
+                get
+                set
+              />
+              <InterfaceProperty
+                name="PropB"
+                type={typeParameters[1].refkey}
+                get
+                set
+              />
             </List>
           </InterfaceDeclaration>
         </SourceFile>
@@ -90,10 +100,10 @@ describe("with type parameters", () => {
     ).toRenderTo(`
       namespace TestCode
       {
-        public class TestClass<T, U>
+        public interface Test<T, U>
         {
-          public T MemberOne;
-          private U memberTwo;
+          T PropA { get; set; }
+          U PropB { get; set; }
         }
       }
     `);
@@ -115,14 +125,14 @@ describe("with type parameters", () => {
       <TestNamespace>
         <InterfaceDeclaration
           public
-          name="TestClass"
+          name="Test"
           typeParameters={typeParameters}
         >
           // Body
         </InterfaceDeclaration>
       </TestNamespace>,
     ).toRenderTo(`
-      public class TestClass<T, U>
+      public interface Test<T, U>
         where T : IFoo
         where U : IBar
       {

--- a/packages/csharp/src/components/interface/declaration.test.tsx
+++ b/packages/csharp/src/components/interface/declaration.test.tsx
@@ -1,5 +1,9 @@
+import { List, refkey } from "@alloy-js/core";
 import { describe, expect, it } from "vitest";
 import { TestNamespace } from "../../../test/utils.jsx";
+import { Property } from "../property/property.jsx";
+import { SourceFile } from "../SourceFile.jsx";
+import { TypeParameterProps } from "../type-parameters/type-parameter.jsx";
 import { InterfaceDeclaration } from "./declaration.jsx";
 
 it("declares class with no members", () => {
@@ -53,4 +57,77 @@ it("specify doc comment", () => {
     /// This is a test
     interface TestInterface;
   `);
+});
+
+describe("with type parameters", () => {
+  it("reference parameters", () => {
+    const typeParameters: TypeParameterProps[] = [
+      {
+        name: "T",
+        refkey: refkey(),
+      },
+      {
+        name: "U",
+        refkey: refkey(),
+      },
+    ];
+
+    expect(
+      <TestNamespace>
+        <SourceFile path="Test.cs">
+          <InterfaceDeclaration
+            public
+            name="TestClass"
+            typeParameters={typeParameters}
+          >
+            <List>
+              <Property name="PropA" type={typeParameters[0].refkey} />
+              <Property name="PropB" type={typeParameters[1].refkey} />
+            </List>
+          </InterfaceDeclaration>
+        </SourceFile>
+      </TestNamespace>,
+    ).toRenderTo(`
+      namespace TestCode
+      {
+        public class TestClass<T, U>
+        {
+          public T MemberOne;
+          private U memberTwo;
+        }
+      }
+    `);
+  });
+
+  it("defines with constraints", () => {
+    const typeParameters: TypeParameterProps[] = [
+      {
+        name: "T",
+        constraints: "IFoo",
+      },
+      {
+        name: "U",
+        constraints: "IBar",
+      },
+    ];
+
+    expect(
+      <TestNamespace>
+        <InterfaceDeclaration
+          public
+          name="TestClass"
+          typeParameters={typeParameters}
+        >
+          // Body
+        </InterfaceDeclaration>
+      </TestNamespace>,
+    ).toRenderTo(`
+      public class TestClass<T, U>
+        where T : IFoo
+        where U : IBar
+      {
+        // Body
+      }
+    `);
+  });
 });

--- a/packages/csharp/src/components/interface/method.test.tsx
+++ b/packages/csharp/src/components/interface/method.test.tsx
@@ -2,7 +2,7 @@ import { refkey } from "@alloy-js/core";
 import { Children } from "@alloy-js/core/jsx-runtime";
 import { describe, expect, it } from "vitest";
 import { TestNamespace } from "../../../test/utils.jsx";
-import { ClassDeclaration, ClassMember } from "../ClassDeclaration.jsx";
+import { SourceFile } from "../SourceFile.jsx";
 import { TypeParameterProps } from "../type-parameters/type-parameter.jsx";
 import { InterfaceDeclaration } from "./declaration.jsx";
 import { InterfaceMethod } from "./method.jsx";
@@ -188,22 +188,33 @@ describe("with type parameters", () => {
     ];
 
     expect(
-      <ClassDeclaration public name="TestClass" typeParameters={typeParameters}>
-        <ClassMember public name="memberOne" type={typeParameters[0].refkey} />
-        ;<hbr />
-        <ClassMember private name="memberTwo" type={typeParameters[1].refkey} />
-        ;
-      </ClassDeclaration>,
+      <TestNamespace>
+        <SourceFile path="TestFile.cs">
+          <InterfaceDeclaration public name="TestInterface">
+            <InterfaceMethod
+              name="Test"
+              public
+              typeParameters={typeParameters}
+              parameters={[
+                {
+                  name: "paramA",
+                  type: typeParameters[0].refkey,
+                },
+              ]}
+              returns={typeParameters[0].refkey}
+            />
+          </InterfaceDeclaration>
+        </SourceFile>
+      </TestNamespace>,
     ).toRenderTo(`
-    namespace TestCode
-    {
-        public class TestClass<T, U>
+      namespace TestCode
+      {
+        public interface TestInterface
         {
-            public T MemberOne;
-            private U memberTwo;
+          public T <T, U>Test(T paramA);
         }
-    }
-  `);
+      }
+    `);
   });
 
   it("defines with constraints", () => {
@@ -219,18 +230,20 @@ describe("with type parameters", () => {
     ];
 
     expect(
-      <ClassDeclaration public name="TestClass" typeParameters={typeParameters}>
-        // Body
-      </ClassDeclaration>,
+      <Wrapper>
+        <InterfaceMethod public name="Test" typeParameters={typeParameters}>
+          // Body
+        </InterfaceMethod>
+      </Wrapper>,
     ).toRenderTo(`
-      namespace TestCode
+      public interface TestInterface
       {
-          public class TestClass<T, U>
-              where T : IFoo
-              where U : IBar
-          {
-              // Body
-          }
+        public void <T, U>Test()
+          where T : IFoo
+          where U : IBar
+        {
+          // Body
+        }
       }
     `);
   });

--- a/packages/csharp/src/components/interface/method.test.tsx
+++ b/packages/csharp/src/components/interface/method.test.tsx
@@ -1,6 +1,9 @@
+import { refkey } from "@alloy-js/core";
 import { Children } from "@alloy-js/core/jsx-runtime";
 import { describe, expect, it } from "vitest";
 import { TestNamespace } from "../../../test/utils.jsx";
+import { ClassDeclaration, ClassMember } from "../ClassDeclaration.jsx";
+import { TypeParameterProps } from "../type-parameters/type-parameter.jsx";
 import { InterfaceDeclaration } from "./declaration.jsx";
 import { InterfaceMethod } from "./method.jsx";
 
@@ -169,4 +172,66 @@ it("specify doc comment", () => {
       void Method();
     }
   `);
+});
+
+describe("with type parameters", () => {
+  it("reference parameters", () => {
+    const typeParameters: TypeParameterProps[] = [
+      {
+        name: "T",
+        refkey: refkey(),
+      },
+      {
+        name: "U",
+        refkey: refkey(),
+      },
+    ];
+
+    expect(
+      <ClassDeclaration public name="TestClass" typeParameters={typeParameters}>
+        <ClassMember public name="memberOne" type={typeParameters[0].refkey} />
+        ;<hbr />
+        <ClassMember private name="memberTwo" type={typeParameters[1].refkey} />
+        ;
+      </ClassDeclaration>,
+    ).toRenderTo(`
+    namespace TestCode
+    {
+        public class TestClass<T, U>
+        {
+            public T MemberOne;
+            private U memberTwo;
+        }
+    }
+  `);
+  });
+
+  it("defines with constraints", () => {
+    const typeParameters: TypeParameterProps[] = [
+      {
+        name: "T",
+        constraints: "IFoo",
+      },
+      {
+        name: "U",
+        constraints: "IBar",
+      },
+    ];
+
+    expect(
+      <ClassDeclaration public name="TestClass" typeParameters={typeParameters}>
+        // Body
+      </ClassDeclaration>,
+    ).toRenderTo(`
+      namespace TestCode
+      {
+          public class TestClass<T, U>
+              where T : IFoo
+              where U : IBar
+          {
+              // Body
+          }
+      }
+    `);
+  });
 });

--- a/packages/csharp/src/components/interface/method.tsx
+++ b/packages/csharp/src/components/interface/method.tsx
@@ -17,6 +17,9 @@ import { CSharpOutputSymbol } from "../../symbols/csharp-output-symbol.js";
 import { CSharpMemberScope, useCSharpScope } from "../../symbols/scopes.js";
 import { ParameterProps, Parameters } from "../Parameters.jsx";
 import { DocWhen } from "../doc/comment.jsx";
+import { TypeParameterConstraints } from "../type-parameters/type-parameter-constraints.jsx";
+import { TypeParameterProps } from "../type-parameters/type-parameter.jsx";
+import { TypeParameters } from "../type-parameters/type-parameters.jsx";
 
 /** Method modifiers. Can only be one. */
 export interface InterfaceMethodModifiers {
@@ -33,6 +36,19 @@ export interface InterfaceMethodProps
   refkey?: Refkey;
   children?: Children;
   parameters?: Array<ParameterProps>;
+  /**
+   * Type parameters for the method
+   *
+   * @example
+   * ```tsx
+   * <InterfaceMethod name="Test" typeParameters={["T"]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * public void Test<T>()
+   * ```
+   */
+  typeParameters?: (TypeParameterProps | string)[];
   returns?: Children;
 
   /** Doc comment */
@@ -72,7 +88,14 @@ export function InterfaceMethod(props: InterfaceMethodProps) {
       <Scope value={methodScope}>
         <DocWhen doc={props.doc} />
         {modifiers}
-        {props.returns ?? "void"} {name}({params})
+        {props.returns ?? "void"}{" "}
+        {props.typeParameters && (
+          <TypeParameters parameters={props.typeParameters} />
+        )}
+        {name}({params})
+        {props.typeParameters && (
+          <TypeParameterConstraints parameters={props.typeParameters} />
+        )}
         {props.children ?
           <Block newline>{props.children}</Block>
         : ";"}

--- a/packages/csharp/src/components/type-parameters/type-parameter-constraints.test.tsx
+++ b/packages/csharp/src/components/type-parameters/type-parameter-constraints.test.tsx
@@ -1,0 +1,93 @@
+import { expect, it } from "vitest";
+import { TypeParameterConstraints } from "./type-parameter-constraints.jsx";
+
+it("renders nothing if there is no constraints", () => {
+  expect(<TypeParameterConstraints parameters={["A", "B"]} />).toRenderTo(``);
+});
+
+it("renders inline if there is only one", () => {
+  expect(
+    <>
+      {"code()"}
+      <TypeParameterConstraints
+        parameters={[{ name: "A", constraints: "string" }]}
+      />
+    </>,
+  ).toRenderTo(`
+    code() where A : string
+  `);
+});
+
+it("renders multiple constraints", () => {
+  expect(
+    <>
+      {"code()"}
+      <TypeParameterConstraints
+        parameters={[{ name: "A", constraints: ["string", "int"] }]}
+      />
+    </>,
+  ).toRenderTo(`
+    code() where A : string, int
+  `);
+});
+
+it("renders newline if constraint is very long", () => {
+  expect(
+    <>
+      {"code()"}
+      <TypeParameterConstraints
+        parameters={[
+          {
+            name: "ThisIsQuiteALongName",
+            constraints: "VeryLongBuilderFactorySingletonThatShouldBeSplit",
+          },
+        ]}
+      />
+    </>,
+  ).toRenderTo(`
+    code()
+      where ThisIsQuiteALongName : VeryLongBuilderFactorySingletonThatShouldBeSplit
+  `);
+});
+
+it("renders multiple constraints on new lines if they are very long", () => {
+  expect(
+    <>
+      {"code()"}
+      <TypeParameterConstraints
+        parameters={[
+          {
+            name: "A",
+            constraints: [
+              "IVeryLongBuilderFactorySingletonThatShouldBeSplitA",
+              "IVeryLongBuilderFactorySingletonThatShouldBeSplitB",
+            ],
+          },
+        ]}
+      />
+    </>,
+  ).toRenderTo(`
+    code()
+      where A :
+        IVeryLongBuilderFactorySingletonThatShouldBeSplitA,
+        IVeryLongBuilderFactorySingletonThatShouldBeSplitB
+  `);
+});
+
+it("declare type parameters using parameters", () => {
+  expect(
+    <>
+      {"code()"}
+      <TypeParameterConstraints
+        parameters={[
+          { name: "A", constraints: "string" },
+          { name: "B", constraints: "string" },
+        ]}
+      />
+    </>,
+  ).toRenderTo(`
+    code()
+      where A : string
+      where B : string
+  `);
+});

--- a/packages/csharp/src/components/type-parameters/type-parameter-constraints.tsx
+++ b/packages/csharp/src/components/type-parameters/type-parameter-constraints.tsx
@@ -1,0 +1,46 @@
+import { Children, code, For, Indent } from "@alloy-js/core";
+import { TypeParameterProps } from "./type-parameter.jsx";
+import { normalizeParameters } from "./type-parameters.jsx";
+
+export interface TypeParameterConstraintsProps {
+  /** Parameters */
+  parameters: (TypeParameterProps | string)[];
+}
+
+export function TypeParameterConstraints(
+  props: TypeParameterConstraintsProps,
+): Children {
+  const parameters = normalizeParameters(props.parameters);
+  if (!parameters.some((x) => x.constraints)) {
+    return null;
+  }
+  return (
+    <group>
+      <Indent line>
+        <For each={parameters} hardline>
+          {(param) => <TypeParameterConstraint {...param} />}
+        </For>
+      </Indent>
+    </group>
+  );
+}
+
+function TypeParameterConstraint(props: TypeParameterProps): Children {
+  const constraints = arrayify(props.constraints);
+  return (
+    <>
+      where {code`${props.name} : `}
+      <group>
+        <Indent softline>
+          <For each={constraints} comma line>
+            {(constraint) => code`${constraint}`}
+          </For>
+        </Indent>
+      </group>
+    </>
+  );
+}
+
+function arrayify<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value];
+}

--- a/packages/csharp/src/components/type-parameters/type-parameter.tsx
+++ b/packages/csharp/src/components/type-parameters/type-parameter.tsx
@@ -1,0 +1,35 @@
+import { Children, MemberDeclaration, refkey, Refkey } from "@alloy-js/core";
+import { useCSharpNamePolicy } from "../../name-policy.js";
+import { CSharpOutputSymbol } from "../../symbols/csharp-output-symbol.js";
+import { useCSharpScope } from "../../symbols/scopes.js";
+
+/**
+ * Information for a TypeScript generic type parameter.
+ */
+export interface TypeParameterProps {
+  /**
+   * The name of the type parameter.
+   */
+  readonly name: string;
+
+  /**
+   * The parameter constraint
+   */
+  readonly constraints?: Children | Children[];
+
+  /**
+   * A refkey or array of refkeys for this type parameter.
+   */
+  readonly refkey?: Refkey | Refkey[];
+}
+
+export function TypeParameter(props: TypeParameterProps) {
+  const name = useCSharpNamePolicy().getName(props.name, "type-parameter");
+  const scope = useCSharpScope();
+  const symbol = new CSharpOutputSymbol(name, {
+    scope,
+    refkeys: props.refkey ?? refkey(props.name),
+  });
+
+  return <MemberDeclaration symbol={symbol}>{name}</MemberDeclaration>;
+}

--- a/packages/csharp/src/components/type-parameters/type-parameters.test.tsx
+++ b/packages/csharp/src/components/type-parameters/type-parameters.test.tsx
@@ -1,0 +1,19 @@
+import { expect, it } from "vitest";
+import { TestNamespace } from "../../../test/utils.jsx";
+import { TypeParameters } from "./type-parameters.jsx";
+
+it("declare type parameters using parameters names", () => {
+  expect(
+    <TestNamespace>
+      <TypeParameters parameters={["A", "B"]} />
+    </TestNamespace>,
+  ).toRenderTo(`<A, B>`);
+});
+
+it("declare type parameters using parameters", () => {
+  expect(
+    <TestNamespace>
+      <TypeParameters parameters={[{ name: "A" }, { name: "B" }]} />
+    </TestNamespace>,
+  ).toRenderTo(`<A, B>`);
+});

--- a/packages/csharp/src/components/type-parameters/type-parameters.tsx
+++ b/packages/csharp/src/components/type-parameters/type-parameters.tsx
@@ -1,0 +1,72 @@
+import { For, Indent, taggedComponent } from "@alloy-js/core";
+import { TypeParameter, TypeParameterProps } from "./type-parameter.jsx";
+
+export const typeParametersTag = Symbol.for("csharp.type-parameters");
+
+export interface TypeParametersProps {
+  /** Parameters */
+  parameters: (TypeParameterProps | string)[];
+}
+
+/**
+ * Represent type parameters
+ *
+ * @example
+ * ```ts
+ * <A, B extends string>
+ * ```
+ */
+export const TypeParameters = taggedComponent(
+  typeParametersTag,
+  function TypeParameters(props: TypeParametersProps) {
+    const typeParameters = normalizeParameters(props.parameters);
+
+    // const typeParameters = normalizeAndDeclareParameters(props.parameters);
+
+    // onCleanup(() => {
+    //   for (const param of typeParameters) {
+    //     param.symbol.delete();
+    //   }
+    // });
+
+    return (
+      <>
+        {"<"}
+        <group>
+          <Indent softline>
+            <For each={typeParameters} comma line>
+              {(param) => <TypeParameter {...param} />}
+            </For>
+            <ifBreak>,</ifBreak>
+          </Indent>
+        </group>
+        {">"}
+      </>
+    );
+  },
+);
+
+export function normalizeParameters(
+  parameters: (TypeParameterProps | string)[],
+): TypeParameterProps[] {
+  return parameters.map((param) => {
+    if (typeof param === "string") {
+      return { name: param };
+    }
+    return param;
+  });
+}
+
+// export function declareParameter(
+//   parameters: TypeParameterProps[],
+// ): TypeParameterProps[] {
+//   return parameters.map((param) => {
+//     return {
+//       ...param,
+//       symbol: new CSharpOutputSymbol(entry[0], {
+//         scope: thisClassScope,
+//         refkeys: entry[1],
+//       }),
+//     };
+//   });
+// }


### PR DESCRIPTION
Add support for type parmaeters for methods and rethink how it was done for class/interface to align more with the typescript way.
Provide nice formatting in case of overflow as well