### PR TITLE
typescript: implement default parameter values

### DIFF
--- a/.chronus/changes/witemple-msft-function-param-defaults-2025-6-7-16-23-58.md
+++ b/.chronus/changes/witemple-msft-function-param-defaults-2025-6-7-16-23-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Implement support for parameter default values.

--- a/packages/typescript/src/components/FunctionBase.tsx
+++ b/packages/typescript/src/components/FunctionBase.tsx
@@ -142,6 +142,10 @@ function parameter(param: DeclaredParameterDescriptor) {
           </SymbolSlot>
         </indent>
       </Show>
+      <Show when={!!param.default}>
+        {" = "}
+        <SymbolSlot>{param.default!}</SymbolSlot>
+      </Show>
     </group>
   );
 }

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -267,6 +267,50 @@ describe("symbols", () => {
     `);
   });
 
+  it("creates parameters with default values", () => {
+    const paramDesc: ParameterDescriptor = {
+      name: "foo",
+      refkey: refkey(),
+      type: "string",
+      default: '"bar"',
+    };
+
+    const decl = (
+      <>
+        <FunctionDeclaration name="foo" parameters={[paramDesc]}>
+          console.log(foo);
+        </FunctionDeclaration>
+      </>
+    );
+
+    expect(toSourceText(decl)).toBe(d`
+      function foo(foo: string = "bar") {
+        console.log(foo);
+      }
+    `);
+  });
+
+  it("correctly renders mixed parameters", () => {
+    const params: ParameterDescriptor[] = [
+      { name: "a", refkey: refkey(), type: "string" },
+      { name: "b", refkey: refkey(), type: "number", optional: true },
+      { name: "c", refkey: refkey(), type: "boolean", default: "false" },
+      { name: "d", refkey: refkey(), type: "any[]", rest: true },
+    ];
+
+    const decl = (
+      <FunctionDeclaration name="foo" parameters={params}>
+        console.log(a, b, c, d);
+      </FunctionDeclaration>
+    );
+
+    expect(toSourceText(decl)).toBe(d`
+      function foo(a: string, b?: number, c: boolean = false, ...d: any[]) {
+        console.log(a, b, c, d);
+      }
+    `);
+  });
+
   it("adds symbols for members of parameters when a type is provided", () => {
     const ifaceRk = refkey();
     const ifaceMemberRk = refkey();


### PR DESCRIPTION
This seems unimplemented in the call signature component, so this PR adds support for this if the `default` is provided in the ParameterDescriptor.