### PR TITLE
typescript: implement type parameters for interfaces, type parameter defaults

### DIFF
--- a/.chronus/changes/witemple-msft-interface-type-params-2025-6-7-19-18-6.md
+++ b/.chronus/changes/witemple-msft-interface-type-params-2025-6-7-19-18-6.md
@@ -1,0 +1,9 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Implemented type parameters for InterfaceDeclaration components.
+
+Implemented type parameter defaults.

--- a/packages/typescript/src/components/Declaration.tsx
+++ b/packages/typescript/src/components/Declaration.tsx
@@ -16,7 +16,6 @@ import { PrivateScopeContext } from "../context/private-scope.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { EnumDeclaration } from "./EnumDeclaration.jsx";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { InterfaceDeclaration } from "./Interface.jsx";
 
 export interface BaseDeclarationProps {
   /**
@@ -84,7 +83,7 @@ export interface DeclarationProps extends Omit<BaseDeclarationProps, "name"> {
 /**
  * Create a TypeScript declaration. Generally, this component shouldn't be used
  * directly, and instead prefer components for specific declarations, e.g.
- * {@link EnumDeclaration}, {@link InterfaceDeclaration},
+ * {@link EnumDeclaration}, {@link (InterfaceDeclaration:function)},
  * {@link TypeDeclaration}, etc.
  *
  * @remarks

--- a/packages/typescript/src/components/Declaration.tsx
+++ b/packages/typescript/src/components/Declaration.tsx
@@ -15,7 +15,6 @@ import { TypeDeclaration } from "./TypeDeclaration.jsx";
 import { PrivateScopeContext } from "../context/private-scope.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { EnumDeclaration } from "./EnumDeclaration.jsx";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 export interface BaseDeclarationProps {
   /**

--- a/packages/typescript/src/components/FunctionBase.tsx
+++ b/packages/typescript/src/components/FunctionBase.tsx
@@ -288,6 +288,10 @@ function typeParameter(param: DeclaredTypeParameterDescriptor) {
           <TypeRefContext>{param.extends}</TypeRefContext>
         </indent>
       </Show>
+      <Show when={!!param.default}>
+        {" = "}
+        <TypeRefContext>{param.default}</TypeRefContext>
+      </Show>
     </group>
   );
 }

--- a/packages/typescript/src/components/Interface.tsx
+++ b/packages/typescript/src/components/Interface.tsx
@@ -32,15 +32,6 @@ export interface InterfaceDeclarationProps extends BaseDeclarationProps {
   typeParameters?: TypeParameterDescriptor[] | string[];
 }
 
-/**
- * Create a TypeScript interface declaration.
- *
- * @remarks
- *
- * This component will declare a symbol for this interface. The `export` and
- * `default` boolean props determine whether and how this symbol is exported
- * from the package.
- */
 const _InterfaceDeclaration = ensureTypeRefContext(
   (props: InterfaceDeclarationProps) => {
     const children = childrenArray(() => props.children);
@@ -79,6 +70,15 @@ const _InterfaceDeclaration = ensureTypeRefContext(
   },
 );
 
+/**
+ * Create a TypeScript interface declaration.
+ *
+ * @remarks
+ *
+ * This component will declare a symbol for this interface. The `export` and
+ * `default` boolean props determine whether and how this symbol is exported
+ * from the package.
+ */
 export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
   return _InterfaceDeclaration(props);
 }

--- a/packages/typescript/test/interface.test.tsx
+++ b/packages/typescript/test/interface.test.tsx
@@ -229,6 +229,76 @@ it("handles invalid identifier names", () => {
   `);
 });
 
+it("accepts type parameters by descriptors", () => {
+  const typeParams: ts.TypeParameterDescriptor[] = [
+    { name: "T", refkey: refkey() },
+    { name: "U", extends: "number", refkey: refkey() },
+    { name: "V", default: "object", refkey: refkey() },
+    { name: "W", extends: "string", default: '"test"', refkey: refkey() },
+  ];
+
+  const res = toSourceText(
+    <ts.InterfaceDeclaration name="Foo" typeParameters={typeParams}>
+      <ts.InterfaceMember name="member" type={typeParams[0].refkey} />;
+      <hbr />
+      <ts.InterfaceMember name="member2" type={typeParams[1].refkey} />;
+      <hbr />
+      <ts.InterfaceMember name="member3" type={typeParams[2].refkey} />;
+      <hbr />
+      <ts.InterfaceMember name="member4" type={typeParams[3].refkey} />;
+    </ts.InterfaceDeclaration>,
+  );
+
+  expect(res).toEqual(d`
+    interface Foo<T, U extends number, V = object, W extends string = "test"> {
+      member: T;
+      member2: U;
+      member3: V;
+      member4: W;
+    }
+  `);
+});
+
+it("accepts type parameters with extends", () => {
+  const res = toSourceText(
+    <ts.InterfaceDeclaration name="Foo" typeParameters={["T"]} extends="Bar">
+      <ts.InterfaceMember name="member" type="T" />;
+    </ts.InterfaceDeclaration>,
+  );
+
+  expect(res).toEqual(d`
+    interface Foo<T> extends Bar {
+      member: T;
+    }
+  `);
+});
+
+it("accepts type parameters children", () => {
+  const res = toSourceText(
+    <ts.InterfaceDeclaration name="Foo">
+      <ts.InterfaceDeclaration.TypeParameters>
+        T, U extends number, V = object, W extends string = "test"
+      </ts.InterfaceDeclaration.TypeParameters>
+      <ts.InterfaceMember name="member" type={"T"} />;
+      <hbr />
+      <ts.InterfaceMember name="member2" type="U" />;
+      <hbr />
+      <ts.InterfaceMember name="member3" type="V" />;
+      <hbr />
+      <ts.InterfaceMember name="member4" type="W" />;
+    </ts.InterfaceDeclaration>,
+  );
+
+  expect(res).toEqual(d`
+    interface Foo<T, U extends number, V = object, W extends string = "test"> {
+      member: T;
+      member2: U;
+      member3: V;
+      member4: W;
+    }
+  `);
+});
+
 describe("method members", () => {
   it("render basic", () => {
     expect(


### PR DESCRIPTION
Like parameter defaults, type parameter defaults were unimplemented, so this PR implements them.

This PR implements support for type parameters in interface declarations.