### PR TITLE
typescript: don't insert a space when rendering a default case arm

### DIFF
--- a/.chronus/changes/witemple-msft-no-space-case-default-2025-6-8-20-51-40.md
+++ b/.chronus/changes/witemple-msft-no-space-case-default-2025-6-8-20-51-40.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/typescript"
+---
+
+Removed an errant space when using a `default` CaseClause.

--- a/packages/typescript/src/components/SwitchStatement.tsx
+++ b/packages/typescript/src/components/SwitchStatement.tsx
@@ -51,7 +51,7 @@ export function CaseClause(props: CaseClauseProps) {
   return (
     <>
       <Switch>
-        <Match when={"default" in props && props.default}>default </Match>
+        <Match when={"default" in props && props.default}>default</Match>
         <Match else>
           case{" "}
           {"expression" in props ?

--- a/packages/typescript/test/switch-statement.test.tsx
+++ b/packages/typescript/test/switch-statement.test.tsx
@@ -43,7 +43,7 @@ it("handles various cases", () => {
         // block
         break;
       }
-      default :
+      default:
         // default
     }
   `);


### PR DESCRIPTION
PR removes an extra space that is inserted when rendering a `default` case of a switch statement.