### PR TITLE
Make writeOutput synchronous

### DIFF
--- a/.chronus/changes/sync-write-2025-7-20-11-46-49.md
+++ b/.chronus/changes/sync-write-2025-7-20-11-46-49.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+writeOutput will write files sequentially instead of in parallel to avoid race conditions where directories aren't created before files are attempted to be written to them.

--- a/packages/core/src/utils.tsx
+++ b/packages/core/src/utils.tsx
@@ -311,16 +311,16 @@ export interface OutputVisitor {
  * @param sourceDirectory - The root directory to traverse.
  * @param visitor - The visitor to call for each file and directory.
  */
-export function traverseOutput(
+export async function traverseOutput(
   sourceDirectory: OutputDirectory,
   visitor: OutputVisitor,
 ) {
-  visitor.visitDirectory(sourceDirectory);
+  await visitor.visitDirectory(sourceDirectory);
   for (const item of sourceDirectory.contents) {
     if (item.kind === "directory") {
-      traverseOutput(item, visitor);
+      await traverseOutput(item, visitor);
     } else {
-      visitor.visitFile(item);
+      await visitor.visitFile(item);
     }
   }
 }

--- a/packages/core/src/write-output.ts
+++ b/packages/core/src/write-output.ts
@@ -10,54 +10,42 @@ export async function writeOutput(
   output: OutputDirectory,
   basePath: string = "",
 ) {
-  const ops: Promise<void>[] = [];
-
-  traverseOutput(output, {
-    visitDirectory(directory) {
-      ops.push(
-        (async () => {
-          const path = resolve(basePath, directory.path);
-          if (await AlloyHost.exists(path)) {
-            return;
-          }
+  return await traverseOutput(output, {
+    async visitDirectory(directory) {
+      const path = resolve(basePath, directory.path);
+      if (await AlloyHost.exists(path)) {
+        return;
+      }
+      // eslint-disable-next-line no-console
+      console.log("create", relative(process.cwd(), path));
+      await AlloyHost.mkdir(path);
+    },
+    async visitFile(file) {
+      if ("contents" in file) {
+        const path = resolve(basePath, file.path);
+        if (await AlloyHost.exists(path)) {
+          // eslint-disable-next-line no-console
+          console.log("overwrite", relative(process.cwd(), path));
+        } else {
           // eslint-disable-next-line no-console
           console.log("create", relative(process.cwd(), path));
-          await AlloyHost.mkdir(path);
-        })(),
-      );
-    },
-    visitFile(file) {
-      ops.push(
-        (async () => {
-          if ("contents" in file) {
-            const path = resolve(basePath, file.path);
-            if (await AlloyHost.exists(path)) {
-              // eslint-disable-next-line no-console
-              console.log("overwrite", relative(process.cwd(), path));
-            } else {
-              // eslint-disable-next-line no-console
-              console.log("create", relative(process.cwd(), path));
-            }
+        }
 
-            await AlloyHost.write(path, file.contents);
-          } else {
-            // copy file
-            const source = resolve(basePath, file.sourcePath);
-            const target = resolve(basePath, file.path);
-            if (await AlloyHost.exists(target)) {
-              // eslint-disable-next-line no-console
-              console.log("copy over", relative(process.cwd(), target));
-            } else {
-              // eslint-disable-next-line no-console
-              console.log("copy", relative(process.cwd(), target));
-            }
-            await AlloyHost.mkdir(dirname(target));
-            await AlloyHost.write(target, AlloyHost.read(source).stream());
-          }
-        })(),
-      );
+        await AlloyHost.write(path, file.contents);
+      } else {
+        // copy file
+        const source = resolve(basePath, file.sourcePath);
+        const target = resolve(basePath, file.path);
+        if (await AlloyHost.exists(target)) {
+          // eslint-disable-next-line no-console
+          console.log("copy over", relative(process.cwd(), target));
+        } else {
+          // eslint-disable-next-line no-console
+          console.log("copy", relative(process.cwd(), target));
+        }
+        await AlloyHost.mkdir(dirname(target));
+        await AlloyHost.write(target, AlloyHost.read(source).stream());
+      }
     },
   });
-
-  return Promise.all(ops);
 }


### PR DESCRIPTION
The async stuff was nice but unfortunately introduces race conditions where a directory might not be created by the time we're trying to write a file into it.