### PR TITLE
Improve outputscope and outputsymbol logging

### DIFF
--- a/packages/core/src/components/Declaration.tsx
+++ b/packages/core/src/components/Declaration.tsx
@@ -79,7 +79,7 @@ export function Declaration(props: DeclarationProps) {
     const scope = useScope();
     if (!(scope instanceof BasicScope)) {
       throw new Error(
-        `Declaration component cannot create a symbol in a non-basic scope: ${scope.constructor.name}`,
+        `Declaration component cannot create a symbol in a non-basic scope: ${scope}`,
       );
     }
 

--- a/packages/core/src/components/MemberDeclaration.tsx
+++ b/packages/core/src/components/MemberDeclaration.tsx
@@ -91,7 +91,7 @@ export function MemberDeclaration(props: MemberDeclarationProps) {
     const scopeContext = useMemberContext()!;
     if (!(scopeContext.ownerSymbol instanceof BasicSymbol)) {
       throw new Error(
-        `MemberDeclaration component cannot create a symbol in a non-basic scope: ${scopeContext.ownerSymbol.constructor.name}`,
+        `MemberDeclaration component cannot create a symbol in a non-basic scope: ${scopeContext.ownerSymbol}`,
       );
     }
     const space =

--- a/packages/core/src/symbols/output-scope.ts
+++ b/packages/core/src/symbols/output-scope.ts
@@ -254,4 +254,11 @@ export abstract class OutputScope {
       () => `${this.constructor.name} ${this.name}[${this.id}]${ownerSymbol}`,
     );
   }
+
+  toString() {
+    const ownerSymbol = this.ownerSymbol ? ` for ${this.ownerSymbol}` : "";
+    return untrack(
+      () => `${this.constructor.name} ${this.name}[${this.id}]${ownerSymbol}`,
+    );
+  }
 }

--- a/packages/core/src/symbols/output-symbol.ts
+++ b/packages/core/src/symbols/output-symbol.ts
@@ -630,6 +630,10 @@ export abstract class OutputSymbol {
   }
 
   [inspect.custom]() {
+    return this.toString();
+  }
+
+  toString() {
     return untrack(() => `${this.constructor.name} "${this.name}"[${this.id}]`);
   }
 }


### PR DESCRIPTION
2nd pass to make use of `toString()`