### PR TITLE
Improve formatting of CSharp components

### DIFF
--- a/packages/csharp/src/components/method/method.test.tsx
+++ b/packages/csharp/src/components/method/method.test.tsx
@@ -158,3 +158,52 @@ it("use expression body form", () => {
     }
   `);
 });
+
+describe("format", () => {
+  it("split expression after => if too long", () => {
+    expect(
+      <TestNamespace printWidth={60}>
+        <ClassDeclaration name="Test">
+          <Method public override name="ThisIsAVeryLongMethodName" expression>
+            this.WithAVeryLongPropertyName.AndAnEvenLongerMemberName
+          </Method>
+        </ClassDeclaration>
+      </TestNamespace>,
+    ).toRenderTo(`
+      class Test
+      {
+          public override void ThisIsAVeryLongMethodName() =>
+              this.WithAVeryLongPropertyName.AndAnEvenLongerMemberName;
+      }
+  `);
+  });
+
+  it("split parameters first if too long", () => {
+    expect(
+      <TestNamespace printWidth={60}>
+        <ClassDeclaration name="Test">
+          <Method
+            public
+            override
+            name="ThisIsAVeryLongMethodName"
+            expression
+            parameters={[
+              { name: "firstParameter", type: "int" },
+              { name: "secondParameter", type: "string" },
+            ]}
+          >
+            this.Short
+          </Method>
+        </ClassDeclaration>
+      </TestNamespace>,
+    ).toRenderTo(`
+      class Test
+      {
+          public override void ThisIsAVeryLongMethodName(
+              int firstParameter,
+              string secondParameter
+          ) => this.Short;
+      }
+  `);
+  });
+});

--- a/packages/csharp/src/components/method/method.tsx
+++ b/packages/csharp/src/components/method/method.tsx
@@ -154,9 +154,12 @@ export function Method(props: MethodProps) {
 
 const ExpressionBody = (props: { children?: Children }) => {
   return (
-    <>
-      {" => "}
-      {props.children};
-    </>
+    <group>
+      {" =>"}
+      <indent>
+        <line />
+        {props.children};
+      </indent>
+    </group>
   );
 };

--- a/packages/csharp/src/components/parameters/parameters.tsx
+++ b/packages/csharp/src/components/parameters/parameters.tsx
@@ -51,9 +51,14 @@ export function Parameters(props: ParametersProps) {
     <group>
       {"("}
       {props.parameters && (
-        <Indent softline>
+        <Indent nobreak>
           <For each={props.parameters} joiner={", "}>
-            {(param) => <Parameter {...param} />}
+            {(param) => (
+              <>
+                <softline />
+                <Parameter {...param} />
+              </>
+            )}
           </For>
         </Indent>
       )}

--- a/packages/csharp/test/utils.tsx
+++ b/packages/csharp/test/utils.tsx
@@ -3,12 +3,15 @@ import * as coretest from "@alloy-js/core/testing";
 import { expect } from "vitest";
 import * as csharp from "../src/index.js";
 
-export function TestNamespace(props: {
+export interface TestNamespaceProps extends csharp.CSharpFormatOptions {
   children: core.Children;
-}): core.Children {
+}
+export function TestNamespace(props: TestNamespaceProps): core.Children {
   return (
     <core.Output namePolicy={csharp.createCSharpNamePolicy()}>
-      <csharp.SourceFile path="Test.cs">{props.children}</csharp.SourceFile>
+      <csharp.SourceFile path="Test.cs" {...props}>
+        {props.children}
+      </csharp.SourceFile>
     </core.Output>
   );
 }


### PR DESCRIPTION
- Method and parameters are printed better whne they need to be split 