### PR TITLE
Add C# test wrapper with symbol definition utility

### DIFF
--- a/packages/csharp/package.json
+++ b/packages/csharp/package.json
@@ -14,6 +14,10 @@
     "./global/*": {
       "development": "./src/builtins/*/index.ts",
       "import": "./dist/src/builtins/*/index.js"
+    },
+    "./testing/*": {
+      "development": "./testing/index.ts",
+      "import": "./dist/testing/index.js"
     }
   },
   "imports": {

--- a/packages/csharp/src/components/attributes/attributes.test.tsx
+++ b/packages/csharp/src/components/attributes/attributes.test.tsx
@@ -4,7 +4,6 @@ import { TestNamespace } from "#test/utils.jsx";
 import { List, namekey } from "@alloy-js/core";
 import { describe, expect, it } from "vitest";
 import { Attribute, AttributeList } from "./attributes.jsx";
-
 it("define attribute", () => {
   expect(<Attribute name="Test" />).toRenderTo(`
       [Test]

--- a/packages/csharp/testing/create-wrapper.test.tsx
+++ b/packages/csharp/testing/create-wrapper.test.tsx
@@ -1,0 +1,125 @@
+import {
+  ClassDeclaration,
+  Method,
+  Property,
+  StructDeclaration,
+} from "#components/index.js";
+import { List, Refkey } from "@alloy-js/core";
+import { d } from "@alloy-js/core/testing";
+import { expect, it } from "vitest";
+import { createCSharpTestWrapper } from "./create-wrapper.jsx";
+
+it("should render defkey inline", async () => {
+  const { Wrapper, defkey } = createCSharpTestWrapper();
+
+  expect(<Wrapper>return {defkey("myResult")};</Wrapper>).toRenderTo(d`
+
+return myResult;
+`);
+});
+
+it("emits a single declaration per unique name", () => {
+  const { Wrapper, defkey } = createCSharpTestWrapper();
+  const a = defkey("MyType");
+  const b = defkey("MyType");
+  expect(a).toBe(b);
+
+  expect(
+    <Wrapper>
+      return {a} {b};
+    </Wrapper>,
+  ).toRenderTo(d`
+return MyType MyType;
+`); // Ensure only one 'class/struct/interface' (whatever default is) declaration appears above if that's the behavior.
+});
+
+it("reuses declarations across multiple usage sites", () => {
+  const { Wrapper, defkey } = createCSharpTestWrapper();
+  const T = defkey("Thing");
+  const R = defkey("Result");
+
+  expect(
+    <Wrapper>
+      <ClassDeclaration abstract name="A">
+        <List>
+          <Method
+            abstract
+            name="a"
+            returns={R}
+            parameters={[{ name: "x", type: T }]}
+          />
+          <Method
+            abstract
+            name="b"
+            returns={R}
+            parameters={[{ name: "y", type: T }]}
+          />
+        </List>
+      </ClassDeclaration>
+    </Wrapper>,
+  ).toRenderTo(d`
+
+
+abstract class A
+{
+    abstract Result a(Thing x);
+    abstract Result b(Thing y);
+}
+`);
+});
+
+it("should render defkey in nested component", async () => {
+  function TestComponent(props: { returnTypeRef: Refkey }) {
+    return <Method name="foo" returns={props.returnTypeRef} />;
+  }
+
+  const { Wrapper, defkey } = createCSharpTestWrapper();
+
+  expect(
+    <Wrapper>
+      <ClassDeclaration name="MyClass">
+        <TestComponent returnTypeRef={defkey("MyType")} />
+      </ClassDeclaration>
+    </Wrapper>,
+  ).toRenderTo(d`
+
+class MyClass
+{
+    MyType foo() {}
+}
+`);
+});
+
+it("should render defkey in class property", async () => {
+  const { Wrapper, defkey } = createCSharpTestWrapper();
+
+  expect(
+    <Wrapper>
+      <ClassDeclaration name="TestClass">
+        <Property name="MyProperty" type={defkey("MyType")} get set />
+      </ClassDeclaration>
+    </Wrapper>,
+  ).toRenderTo(d`
+ class TestClass
+ {
+     MyType MyProperty { get; set; }
+ }
+`);
+});
+
+it("should render defkey in struct property", async () => {
+  const { Wrapper, defkey } = createCSharpTestWrapper();
+
+  expect(
+    <Wrapper>
+      <StructDeclaration name="TestStruct">
+        <Property name="MyProperty" type={defkey("MyType")} get set />
+      </StructDeclaration>
+    </Wrapper>,
+  ).toRenderTo(d`
+ struct TestStruct
+ {
+     MyType MyProperty { get; set; }
+ }
+`);
+});

--- a/packages/csharp/testing/create-wrapper.tsx
+++ b/packages/csharp/testing/create-wrapper.tsx
@@ -1,0 +1,75 @@
+import { SourceFile } from "#components/index.js";
+import {
+  Children,
+  Declaration,
+  For,
+  namekey,
+  Namekey,
+  Output,
+  shallowReactive,
+} from "@alloy-js/core";
+import { CSharpSymbol, useSourceFileScope } from "../src/index.js";
+
+/**
+ * Higher-order helper for tests which allows referencing symbols by name without
+ * having to manually create declarations for each one ahead of time.
+ *
+ * The returned `Wrapper` component proxies its children
+ * through a root component consisting of Output -> SourceFile -> {children}
+ * while providing a `defkey` function for lazily
+ * declaring unique namekeys by string name.
+ *
+ * If `defkey` is called multiple times with the same name, the same Namekey is
+ * returned (idempotent). New names get a fresh Namekey instance.
+ */
+export function createCSharpTestWrapper() {
+  const seen = shallowReactive(new Map<string, Namekey>());
+  const createdSymbols = new Map<Namekey, CSharpSymbol>();
+
+  function defkey(name: string): Namekey {
+    let existing = seen.get(name);
+    if (existing) {
+      return existing;
+    }
+    const nk = namekey(name, {
+      ignoreNamePolicy: true,
+      ignoreNameConflict: true,
+    });
+
+    seen.set(name, nk);
+
+    return nk;
+  }
+
+  function Wrapper(props: { children: Children }) {
+    return (
+      <Output>
+        <SourceFile path="test.cs">
+          <For each={[...seen.values()]}>
+            {(nk) => <Declaration symbol={createSymbol(nk)} />}
+          </For>
+          {props.children}
+        </SourceFile>
+      </Output>
+    );
+  }
+
+  function createSymbol(nk: Namekey) {
+    const existing = createdSymbols.get(nk);
+    if (existing) {
+      return existing;
+    }
+
+    const scope = useSourceFileScope();
+
+    if (!scope) {
+      throw new Error(`No SourceFile scope when declaring symbol: ${nk.name}`);
+    }
+
+    const sym = new CSharpSymbol(nk, scope.spaces);
+    createdSymbols.set(nk, sym);
+    return sym;
+  }
+
+  return { Wrapper, defkey } as const;
+}

--- a/packages/csharp/testing/index.ts
+++ b/packages/csharp/testing/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-wrapper.jsx";

--- a/packages/csharp/tsconfig.json
+++ b/packages/csharp/tsconfig.json
@@ -17,6 +17,8 @@
     "src/**/*.tsx",
     "test/**/*.ts",
     "test/**/*.tsx",
+    "testing/**/*.ts",
+    "testing/**/*.tsx",
     "scripts/**/*.ts",
     "scripts/**/*.tsx"
   ],


### PR DESCRIPTION
**Summary**  
Introduces a `createCSharpTestWrapper` helper to simplify defining and referencing C# symbols by name in test JSX without manual upfront declarations.

**Key Changes**  
- Added wrapper factory exposing `Wrapper` + `defkey(name)` API.  
- Lazy `Namekey` creation with idempotent caching by string name.  

**Rationale**  
Reduces boilerplate for symbol-based test cases, enforces consistent declaration emission, protects against premature symbol creation outside a valid scope, and improves clarity and maintainability.
