### PR TITLE
[tsp] Adding empty project for the TypeSpec library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ packages/docs/src/content/docs/reference
 packages/docs/dist-build
 
 alloy-output/
+.pnpm-store/

--- a/packages/typespec/api-extractor.json
+++ b/packages/typespec/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "../../api-extractor.base.json"
+}

--- a/packages/typespec/package.json
+++ b/packages/typespec/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@alloy-js/typespec",
+  "version": "0.1.0",
+  "description": "",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./stc": {
+      "development": "./src/components/stc/index.ts",
+      "import": "./dist/src/components/stc/index.js"
+    },
+    "./testing": {
+      "development": "./testing/index.ts",
+      "import": "./dist/testing/index.js"
+    }
+  },
+  "imports": {
+    "#components/*": {
+      "development": "./src/components/*",
+      "default": "./dist/src/components/*"
+    }
+  },
+  "scripts": {
+    "generate-docs": "api-extractor run",
+    "build": "alloy build && pnpm run generate-docs",
+    "clean": "rimraf dist/ .temp/",
+    "test:watch": "vitest -w",
+    "watch": "alloy build --watch",
+    "test": "vitest run",
+    "prepack": "node ../../scripts/strip-dev-exports.js"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "dependencies": {
+    "@alloy-js/core": "workspace:~",
+    "change-case": "catalog:",
+    "pathe": "catalog:"
+  },
+  "devDependencies": {
+    "@alloy-js/cli": "workspace:~",
+    "@alloy-js/rollup-plugin": "workspace:~",
+    "@microsoft/api-extractor": "catalog:",
+    "@rollup/plugin-typescript": "catalog:",
+    "concurrently": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "type": "module"
+}

--- a/packages/typespec/tsconfig.json
+++ b/packages/typespec/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "dist",
+    "types": ["@alloy-js/core/testing/matchers"]
+  },
+  "references": [{ "path": "../core" }],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx",
+    "testing/**/*.ts",
+    "testing/**/*.tsx"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/typespec/vitest.config.ts
+++ b/packages/typespec/vitest.config.ts
@@ -1,0 +1,10 @@
+import alloyPlugin from "@alloy-js/rollup-plugin";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "preserve",
+    sourcemap: "both",
+  },
+  plugins: [alloyPlugin()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -743,6 +743,40 @@ importers:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(tsx@4.20.3)(yaml@2.8.0)
 
+  packages/typespec:
+    dependencies:
+      '@alloy-js/core':
+        specifier: workspace:~
+        version: link:../core
+      change-case:
+        specifier: 'catalog:'
+        version: 5.4.4
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
+    devDependencies:
+      '@alloy-js/cli':
+        specifier: workspace:~
+        version: link:../cli
+      '@alloy-js/rollup-plugin':
+        specifier: workspace:~
+        version: link:../rollup-plugin
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.52.9(@types/node@24.1.0)
+      '@rollup/plugin-typescript':
+        specifier: 'catalog:'
+        version: 12.1.4(rollup@4.46.2)(tslib@2.8.1)(typescript@5.8.3)
+      concurrently:
+        specifier: 'catalog:'
+        version: 9.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(tsx@4.20.3)(yaml@2.8.0)
+
   samples/basic-project:
     dependencies:
       '@alloy-js/core':


### PR DESCRIPTION
This pull request introduces the initial setup for the new `@alloy-js/typespec` package, including its configuration, dependencies, and build/test scripts. The changes ensure the package is ready for development, testing, and documentation generation, and integrate it into the project’s monorepo structure.

**New package setup and configuration:**

* Added `packages/typespec/package.json` to define the package name, exports/imports, scripts, dependencies, and devDependencies for `@alloy-js/typespec`.
* Added `packages/typespec/tsconfig.json` to configure TypeScript compilation settings, declaration output, project references, and file inclusions/exclusions.
* Added `packages/typespec/api-extractor.json` to configure API Extractor for documentation generation.
* Added `packages/typespec/vitest.config.ts` to set up Vitest testing configuration and integrate the Alloy rollup plugin.

**Monorepo integration:**

* Updated `pnpm-lock.yaml` to register `@alloy-js/typespec` and its dependencies in the workspace, ensuring proper package management and linking.