### PR TITLE
feat(typescript): add internal prop to exclude declarations from barrel exports

### DIFF
--- a/.chronus/changes/fix-barrel-export-name-conflicts-2026-3-8.md
+++ b/.chronus/changes/fix-barrel-export-name-conflicts-2026-3-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/typescript"
+---
+
+Resolve name conflicts in barrel file exports. When multiple source files export symbols with the same name, the barrel now falls back to named re-exports with deterministic aliases (e.g. `export { helper as helper_2 } from "./b.js"`) instead of emitting conflicting `export *` statements that produce TypeScript build errors.

--- a/.chronus/changes/internal-export-visibility-2026-3-8.md
+++ b/.chronus/changes/internal-export-visibility-2026-3-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/typescript"
+---
+
+Add `internal` prop to declaration components. Internal declarations are exported from their source module but excluded from barrel file re-exports and public package resolution.

--- a/packages/typescript/src/components/BarrelFile.tsx
+++ b/packages/typescript/src/components/BarrelFile.tsx
@@ -82,9 +82,47 @@ export function BarrelFile(props: BarrelFileProps) {
     return [...sourceFiles, ...nestedBarrels];
   });
 
+  const exportNameConflicts = memo(() => {
+    const modules = exports();
+    const nameOwners = new Map<string, TSModuleScope[]>();
+
+    for (const mod of modules) {
+      const publicSymbols = mod.getPublicSymbols();
+      for (const sym of publicSymbols) {
+        if (!nameOwners.has(sym.name)) {
+          nameOwners.set(sym.name, []);
+        }
+        const owners = nameOwners.get(sym.name)!;
+        if (!owners.includes(mod)) {
+          owners.push(mod);
+        }
+      }
+    }
+
+    const moduleConflicts = new Map<TSModuleScope, Map<string, string>>();
+
+    for (const [name, owners] of nameOwners) {
+      if (owners.length <= 1) continue;
+
+      for (let i = 1; i < owners.length; i++) {
+        if (!moduleConflicts.has(owners[i])) {
+          moduleConflicts.set(owners[i], new Map());
+        }
+        moduleConflicts.get(owners[i])!.set(name, `${name}_${i}`);
+      }
+    }
+
+    return moduleConflicts;
+  });
+
   return (
     <SourceFile path={path} export={props.export}>
-      <For each={exports}>{(mod) => <ExportStatement star from={mod} />}</For>
+      <For each={exports}>
+        {(mod) => {
+          const conflicts = exportNameConflicts().get(mod);
+          return <ExportStatement star from={mod} nameConflicts={conflicts} />;
+        }}
+      </For>
     </SourceFile>
   );
 }

--- a/packages/typescript/src/components/BarrelFile.tsx
+++ b/packages/typescript/src/components/BarrelFile.tsx
@@ -82,47 +82,9 @@ export function BarrelFile(props: BarrelFileProps) {
     return [...sourceFiles, ...nestedBarrels];
   });
 
-  const exportNameConflicts = memo(() => {
-    const modules = exports();
-    const nameOwners = new Map<string, TSModuleScope[]>();
-
-    for (const mod of modules) {
-      const publicSymbols = mod.getPublicSymbols();
-      for (const sym of publicSymbols) {
-        if (!nameOwners.has(sym.name)) {
-          nameOwners.set(sym.name, []);
-        }
-        const owners = nameOwners.get(sym.name)!;
-        if (!owners.includes(mod)) {
-          owners.push(mod);
-        }
-      }
-    }
-
-    const moduleConflicts = new Map<TSModuleScope, Map<string, string>>();
-
-    for (const [name, owners] of nameOwners) {
-      if (owners.length <= 1) continue;
-
-      for (let i = 1; i < owners.length; i++) {
-        if (!moduleConflicts.has(owners[i])) {
-          moduleConflicts.set(owners[i], new Map());
-        }
-        moduleConflicts.get(owners[i])!.set(name, `${name}_${i}`);
-      }
-    }
-
-    return moduleConflicts;
-  });
-
   return (
     <SourceFile path={path} export={props.export}>
-      <For each={exports}>
-        {(mod) => {
-          const conflicts = exportNameConflicts().get(mod);
-          return <ExportStatement star from={mod} nameConflicts={conflicts} />;
-        }}
-      </For>
+      <For each={exports}>{(mod) => <ExportStatement star from={mod} />}</For>
     </SourceFile>
   );
 }

--- a/packages/typescript/src/components/ClassDeclaration.tsx
+++ b/packages/typescript/src/components/ClassDeclaration.tsx
@@ -80,6 +80,7 @@ export function ClassDeclaration(props: ClassDeclarationProps) {
     refkeys: props.refkey,
     export: props.export,
     default: props.default,
+    internal: props.internal,
     metadata: props.metadata,
     hasInstanceMembers: true,
     namePolicy: useTSNamePolicy().for("class"),

--- a/packages/typescript/src/components/Declaration.tsx
+++ b/packages/typescript/src/components/Declaration.tsx
@@ -68,6 +68,13 @@ export interface DeclarationPropsWithInfo extends DeclarationPropsBase {
   export?: boolean;
 
   /**
+   * Whether this is an internal export. Internal declarations are exported from
+   * their source module but are not re-exported through barrel files or the
+   * public package surface.
+   */
+  internal?: boolean;
+
+  /**
    * Whether this is the default export of the module.
    */
   default?: boolean;
@@ -104,6 +111,7 @@ export function Declaration(props: DeclarationProps) {
         refkeys: props.refkey,
         export: props.export,
         default: props.default,
+        internal: props.internal,
         metadata: props.metadata,
         namePolicy: useTSNamePolicy().for(props.nameKind!),
       });
@@ -112,6 +120,7 @@ export function Declaration(props: DeclarationProps) {
         refkeys: props.refkey,
         export: props.export,
         default: props.default,
+        internal: props.internal,
         metadata: props.metadata,
         namePolicy: useTSNamePolicy().for(props.nameKind!),
       });

--- a/packages/typescript/src/components/EnumDeclaration.tsx
+++ b/packages/typescript/src/components/EnumDeclaration.tsx
@@ -27,6 +27,7 @@ export function EnumDeclaration(props: EnumDeclarationProps) {
     refkeys: props.refkey,
     default: props.default,
     export: props.export,
+    internal: props.internal,
     metadata: props.metadata,
     namePolicy: useTSNamePolicy().for("enum"),
   });

--- a/packages/typescript/src/components/ExportStatement.tsx
+++ b/packages/typescript/src/components/ExportStatement.tsx
@@ -11,16 +11,44 @@ export interface ExportStatementProps {
 export function ExportStatement(props: ExportStatementProps) {
   if (props.star) {
     const module = useSourceFile();
+    const fromPath = modulePath(
+      relative(dirname(module.scope.name), props.from!.name),
+    );
+
     const allSymbols = props.from!.getAllSymbols();
+    const hasInternalExports = Array.from(allSymbols).some(
+      (s) => s.export && s.internal,
+    );
+
+    // Propagate non-internal symbols to the barrel module's exported symbols
+    // for cross-package reference resolution.
     for (const symbol of allSymbols) {
+      if (symbol.internal) continue;
       for (const refkey of symbol.refkeys) {
         module.scope.exportedSymbols.set(refkey, symbol as TSOutputSymbol);
       }
     }
+
+    if (!hasInternalExports) {
+      // No internal exports in this module, use export *
+      return <>export * from "{fromPath}";</>;
+    }
+
+    // Module has internal exports — use named re-exports for public symbols only
+    const publicSymbols = props.from!.getPublicSymbols();
+
+    if (publicSymbols.size === 0) {
+      return "";
+    }
+
+    const names = Array.from(publicSymbols)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((s) => s.name)
+      .join(", ");
+
     return (
       <>
-        export * from "
-        {modulePath(relative(dirname(module.scope.name), props.from!.name))}";
+        export {"{"} {names} {"}"} from "{fromPath}";
       </>
     );
   }

--- a/packages/typescript/src/components/ExportStatement.tsx
+++ b/packages/typescript/src/components/ExportStatement.tsx
@@ -1,3 +1,4 @@
+import { createSymbol } from "@alloy-js/core";
 import { dirname, relative } from "pathe";
 import { TSModuleScope, TSOutputSymbol } from "../symbols/index.js";
 import { modulePath } from "../utils.js";
@@ -6,6 +7,7 @@ import { useSourceFile } from "./SourceFile.js";
 export interface ExportStatementProps {
   star?: boolean;
   from?: TSModuleScope;
+  nameConflicts?: Map<string, string>;
 }
 
 export function ExportStatement(props: ExportStatementProps) {
@@ -20,21 +22,34 @@ export function ExportStatement(props: ExportStatementProps) {
       (s) => s.export && s.internal,
     );
 
+    const hasConflicts =
+      props.nameConflicts !== undefined && props.nameConflicts.size > 0;
+
     // Propagate non-internal symbols to the barrel module's exported symbols
     // for cross-package reference resolution.
     for (const symbol of allSymbols) {
       if (symbol.internal) continue;
-      for (const refkey of symbol.refkeys) {
-        module.scope.exportedSymbols.set(refkey, symbol as TSOutputSymbol);
+
+      const alias = props.nameConflicts?.get(symbol.name);
+      if (alias) {
+        // Create an aliased symbol so consumers import using the aliased name.
+        const aliased = createSymbol(TSOutputSymbol, alias, undefined, {});
+        for (const refkey of symbol.refkeys) {
+          module.scope.exportedSymbols.set(refkey, aliased);
+        }
+      } else {
+        for (const refkey of symbol.refkeys) {
+          module.scope.exportedSymbols.set(refkey, symbol as TSOutputSymbol);
+        }
       }
     }
 
-    if (!hasInternalExports) {
-      // No internal exports in this module, use export *
+    if (!hasInternalExports && !hasConflicts) {
+      // No internal exports or name conflicts, use export *
       return <>export * from "{fromPath}";</>;
     }
 
-    // Module has internal exports — use named re-exports for public symbols only
+    // Module has internal exports or name conflicts — use named re-exports
     const publicSymbols = props.from!.getPublicSymbols();
 
     if (publicSymbols.size === 0) {
@@ -43,7 +58,10 @@ export function ExportStatement(props: ExportStatementProps) {
 
     const names = Array.from(publicSymbols)
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((s) => s.name)
+      .map((s) => {
+        const alias = props.nameConflicts?.get(s.name);
+        return alias ? `${s.name} as ${alias}` : s.name;
+      })
       .join(", ");
 
     return (

--- a/packages/typescript/src/components/ExportStatement.tsx
+++ b/packages/typescript/src/components/ExportStatement.tsx
@@ -7,7 +7,6 @@ import { useSourceFile } from "./SourceFile.js";
 export interface ExportStatementProps {
   star?: boolean;
   from?: TSModuleScope;
-  nameConflicts?: Map<string, string>;
 }
 
 export function ExportStatement(props: ExportStatementProps) {
@@ -22,51 +21,85 @@ export function ExportStatement(props: ExportStatementProps) {
       (s) => s.export && s.internal,
     );
 
-    const hasConflicts =
-      props.nameConflicts !== undefined && props.nameConflicts.size > 0;
+    const publicSymbols = props.from!.getPublicSymbols();
 
-    // Propagate non-internal symbols to the barrel module's exported symbols
-    // for cross-package reference resolution.
+    // Propagate all non-internal symbols to the barrel module's exportedSymbols
+    // for cross-package refkey resolution. Public symbols will be overwritten
+    // below with their deconflicted aliases.
     for (const symbol of allSymbols) {
       if (symbol.internal) continue;
+      for (const refkey of symbol.refkeys) {
+        module.scope.exportedSymbols.set(refkey, symbol as TSOutputSymbol);
+      }
+    }
 
-      const alias = props.nameConflicts?.get(symbol.name);
-      if (alias) {
-        // Create an aliased symbol so consumers import using the aliased name.
-        const aliased = createSymbol(TSOutputSymbol, alias, undefined, {});
-        for (const refkey of symbol.refkeys) {
-          module.scope.exportedSymbols.set(refkey, aliased);
-        }
-      } else {
-        for (const refkey of symbol.refkeys) {
-          module.scope.exportedSymbols.set(refkey, symbol as TSOutputSymbol);
+    // If the source module has internal exports but nothing public, skip it.
+    if (hasInternalExports && publicSymbols.size === 0) {
+      return "";
+    }
+
+    // Empty source files (no symbols at all) still get export *.
+    if (publicSymbols.size === 0) {
+      return <>export * from "{fromPath}";</>;
+    }
+
+    // Deduplicate by name within the source module (e.g. a class creates
+    // symbols in both values and types spaces with the same name).
+    const symbolsByName = new Map<string, TSOutputSymbol[]>();
+    for (const sym of publicSymbols) {
+      if (!symbolsByName.has(sym.name)) {
+        symbolsByName.set(sym.name, []);
+      }
+      symbolsByName.get(sym.name)!.push(sym);
+    }
+
+    // Create re-export alias symbols in the barrel module's values SymbolTable.
+    // The SymbolTable's built-in deconfliction handles cross-module name
+    // conflicts automatically.
+    const aliases: TSOutputSymbol[] = [];
+    for (const [, syms] of symbolsByName) {
+      const alias = createSymbol(
+        TSOutputSymbol,
+        syms[0].name,
+        module.scope.values,
+        {
+          binder: module.scope.binder,
+          aliasTarget: syms[0],
+        },
+      );
+      aliases.push(alias);
+
+      // Overwrite the direct propagation above with the alias for public
+      // symbols so consumers get the deconflicted name.
+      for (const sym of syms) {
+        for (const refkey of sym.refkeys) {
+          module.scope.exportedSymbols.set(refkey, alias);
         }
       }
     }
 
-    if (!hasInternalExports && !hasConflicts) {
-      // No internal exports or name conflicts, use export *
-      return <>export * from "{fromPath}";</>;
-    }
-
-    // Module has internal exports or name conflicts — use named re-exports
-    const publicSymbols = props.from!.getPublicSymbols();
-
-    if (publicSymbols.size === 0) {
-      return "";
-    }
-
-    const names = Array.from(publicSymbols)
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((s) => {
-        const alias = props.nameConflicts?.get(s.name);
-        return alias ? `${s.name} as ${alias}` : s.name;
-      })
-      .join(", ");
-
+    // Rendering is reactive: when the SymbolTable deconflicts names, the alias
+    // name properties update and this expression re-evaluates.
     return (
       <>
-        export {"{"} {names} {"}"} from "{fromPath}";
+        {() => {
+          const hasConflicts = aliases.some((a) => a.name !== a.originalName);
+
+          if (!hasInternalExports && !hasConflicts) {
+            return `export * from "${fromPath}";`;
+          }
+
+          const names = aliases
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((a) =>
+              a.name !== a.originalName ?
+                `${a.originalName} as ${a.name}`
+              : a.name,
+            )
+            .join(", ");
+
+          return `export { ${names} } from "${fromPath}";`;
+        }}
       </>
     );
   }

--- a/packages/typescript/src/components/Interface.tsx
+++ b/packages/typescript/src/components/Interface.tsx
@@ -83,6 +83,7 @@ const _InterfaceDeclaration = ensureTypeRefContext(
       refkeys: props.refkey,
       default: props.default,
       export: props.export,
+      internal: props.internal,
       metadata: props.metadata,
       tsFlags: TSSymbolFlags.TypeSymbol,
       namePolicy: useTSNamePolicy().for("interface"),

--- a/packages/typescript/src/components/VarDeclaration.tsx
+++ b/packages/typescript/src/components/VarDeclaration.tsx
@@ -28,6 +28,7 @@ export function VarDeclaration(props: VarDeclarationProps) {
     refkeys: props.refkey,
     default: props.default,
     export: props.export,
+    internal: props.internal,
     metadata: props.metadata,
     tsFlags: props.nullish ? TSSymbolFlags.Nullish : TSSymbolFlags.None,
     type: props.type ? TypeSymbolSlot.firstSymbol : undefined,

--- a/packages/typescript/src/symbols/reference.tsx
+++ b/packages/typescript/src/symbols/reference.tsx
@@ -67,7 +67,7 @@ export function ref(
           const sym = module.exportedSymbols.get(refkey);
           if (sym && !sym.internal) {
             localSymbol = untrack(() =>
-              sourceFile!.scope.addImport(lexicalDeclaration, module, {
+              sourceFile!.scope.addImport(sym, module, {
                 type: options?.type,
               }),
             );

--- a/packages/typescript/src/symbols/reference.tsx
+++ b/packages/typescript/src/symbols/reference.tsx
@@ -64,7 +64,8 @@ export function ref(
       // find public dependency
       for (const module of sourcePackage.exportedSymbols.values()) {
         for (const refkey of lexicalDeclaration.refkeys) {
-          if (module.exportedSymbols.has(refkey)) {
+          const sym = module.exportedSymbols.get(refkey);
+          if (sym && !sym.internal) {
             localSymbol = untrack(() =>
               sourceFile!.scope.addImport(lexicalDeclaration, module, {
                 type: options?.type,
@@ -73,6 +74,7 @@ export function ref(
             break;
           }
         }
+        if (localSymbol) break;
       }
 
       if (!localSymbol) {

--- a/packages/typescript/src/symbols/ts-module-scope.ts
+++ b/packages/typescript/src/symbols/ts-module-scope.ts
@@ -104,6 +104,33 @@ export class TSModuleScope extends TSLexicalScope {
     return allSymbols;
   }
 
+  /**
+   * Get symbols that are exported from this module (i.e. have `export: true`).
+   */
+  getExportedSymbols() {
+    const exported = new Set<TSOutputSymbol>();
+    for (const symbol of this.getAllSymbols()) {
+      if (symbol.export) {
+        exported.add(symbol);
+      }
+    }
+    return exported;
+  }
+
+  /**
+   * Get symbols that are public exports from this module. These are symbols
+   * that are exported and not marked as internal.
+   */
+  getPublicSymbols() {
+    const publicSymbols = new Set<TSOutputSymbol>();
+    for (const symbol of this.getAllSymbols()) {
+      if (symbol.export && !symbol.internal) {
+        publicSymbols.add(symbol);
+      }
+    }
+    return publicSymbols;
+  }
+
   override get debugInfo(): Record<string, unknown> {
     return {
       ...super.debugInfo,

--- a/packages/typescript/src/symbols/ts-output-symbol.ts
+++ b/packages/typescript/src/symbols/ts-output-symbol.ts
@@ -25,6 +25,13 @@ export enum TSSymbolFlags {
 export interface CreateTsSymbolOptions extends OutputSymbolOptions {
   export?: boolean;
   default?: boolean;
+
+  /**
+   * Whether this symbol is internal. Internal symbols are exported from their
+   * source module but are not re-exported through barrel files or the public
+   * package surface.
+   */
+  internal?: boolean;
   tsFlags?: TSSymbolFlags;
   hasInstanceMembers?: boolean;
 }
@@ -45,6 +52,7 @@ export class TSOutputSymbol extends OutputSymbol {
     super(name, spaces, options);
     this.#export = !!options.export;
     this.#default = !!options.default;
+    this.#internal = !!options.internal;
     this.#tsFlags = options.tsFlags ?? TSSymbolFlags.None;
     this.#hasInstanceMembers = !!options.hasInstanceMembers;
     if (
@@ -75,6 +83,7 @@ export class TSOutputSymbol extends OutputSymbol {
       aliasTarget: this.aliasTarget,
       default: this.default,
       export: this.export,
+      internal: this.internal,
       tsFlags: this.tsFlags,
       metadata: this.metadata,
     });
@@ -89,6 +98,11 @@ export class TSOutputSymbol extends OutputSymbol {
     watch(
       () => this.export,
       (exp) => (copy.export = exp),
+    );
+
+    watch(
+      () => this.internal,
+      (int) => (copy.internal = int),
     );
 
     watch(
@@ -111,6 +125,26 @@ export class TSOutputSymbol extends OutputSymbol {
     }
     this.#export = value;
     trigger(this, TriggerOpTypes.SET, "export", value, !value);
+  }
+
+  #internal: boolean;
+
+  /**
+   * Whether this symbol is internal. Internal symbols are exported from their
+   * source module but are not re-exported through barrel files or the public
+   * package surface.
+   */
+  get internal() {
+    track(this, TrackOpTypes.GET, "internal");
+    return this.#internal;
+  }
+
+  set internal(value: boolean) {
+    if (this.#internal === value) {
+      return;
+    }
+    this.#internal = value;
+    trigger(this, TriggerOpTypes.SET, "internal", value, !value);
   }
 
   #default: boolean;
@@ -208,6 +242,7 @@ export class TSOutputSymbol extends OutputSymbol {
       ...info,
       export: this.export,
       default: this.default,
+      internal: this.internal,
       tsFlags: this.tsFlags,
       hasInstanceMembers: this.hasInstanceMembers,
       isTypeSymbol: this.isTypeSymbol,

--- a/packages/typescript/src/symbols/ts-package-scope.ts
+++ b/packages/typescript/src/symbols/ts-package-scope.ts
@@ -88,7 +88,8 @@ export class TSPackageScope extends OutputScope {
 
   findExportedSymbol(refkey: Refkey): [string, TSModuleScope] | null {
     for (const [publicPath, module] of this.exportedSymbols) {
-      if (module.exportedSymbols.has(refkey)) {
+      const sym = module.exportedSymbols.get(refkey);
+      if (sym && !sym.internal) {
         return [publicPath, module];
       }
     }

--- a/packages/typescript/test/barrel.test.tsx
+++ b/packages/typescript/test/barrel.test.tsx
@@ -51,3 +51,131 @@ it("ignores non-TS files", () => {
     "test2.ts": "",
   });
 });
+
+it("excludes internal declarations from barrel re-exports", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="utils.ts">
+        <ts.FunctionDeclaration export name="publicUtil">
+          return 1;
+        </ts.FunctionDeclaration>
+        <hbr />
+        <ts.FunctionDeclaration export internal name="internalHelper">
+          return 2;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "utils.ts": d`
+      export function publicUtil() {
+        return 1;
+      }
+      export function internalHelper() {
+        return 2;
+      }
+    `,
+    "index.ts": d`
+      export { publicUtil } from "./utils.js";
+    `,
+  });
+});
+
+it("uses export * when no declarations are internal", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="utils.ts">
+        <ts.FunctionDeclaration export name="one">
+          return 1;
+        </ts.FunctionDeclaration>
+        <hbr />
+        <ts.FunctionDeclaration export name="two">
+          return 2;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "utils.ts": d`
+      export function one() {
+        return 1;
+      }
+      export function two() {
+        return 2;
+      }
+    `,
+    "index.ts": d`
+      export * from "./utils.js";
+    `,
+  });
+});
+
+it("omits module from barrel when all exports are internal", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="public.ts">
+        <ts.FunctionDeclaration export name="publicFn">
+          return 1;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.SourceFile path="internal.ts">
+        <ts.FunctionDeclaration export internal name="helperA">
+          return 2;
+        </ts.FunctionDeclaration>
+        <hbr />
+        <ts.FunctionDeclaration export internal name="helperB">
+          return 3;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "public.ts": d`
+      export function publicFn() {
+        return 1;
+      }
+    `,
+    "internal.ts": d`
+      export function helperA() {
+        return 2;
+      }
+      export function helperB() {
+        return 3;
+      }
+    `,
+    "index.ts": d`
+      export * from "./public.js";
+    `,
+  });
+});
+
+it("supports internal on various declaration types", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="decls.ts">
+        <ts.VarDeclaration export name="publicVar">
+          42
+        </ts.VarDeclaration>
+        ;<hbr />
+        <ts.VarDeclaration export internal name="internalVar">
+          99
+        </ts.VarDeclaration>
+        ;<hbr />
+        <ts.InterfaceDeclaration export name="PublicIface" />
+        <hbr />
+        <ts.InterfaceDeclaration export internal name="InternalIface" />
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "decls.ts": d`
+      export const publicVar = 42;
+      export const internalVar = 99;
+      export interface PublicIface {}
+      export interface InternalIface {}
+    `,
+    "index.ts": d`
+      export { PublicIface, publicVar } from "./decls.js";
+    `,
+  });
+});

--- a/packages/typescript/test/barrel.test.tsx
+++ b/packages/typescript/test/barrel.test.tsx
@@ -208,7 +208,7 @@ it("aliases duplicate export names across modules", () => {
     `,
     "index.ts": d`
       export * from "./a.js";
-      export { helper as helper_1 } from "./b.js";
+      export { helper as helper_2 } from "./b.js";
     `,
   });
 });
@@ -255,7 +255,7 @@ it("aliases duplicate exports with mixed non-conflicting names", () => {
     `,
     "index.ts": d`
       export * from "./a.js";
-      export { bar, helper as helper_1 } from "./b.js";
+      export { bar, helper as helper_2 } from "./b.js";
     `,
   });
 });
@@ -298,8 +298,8 @@ it("aliases duplicate exports across three modules", () => {
     `,
     "index.ts": d`
       export * from "./a.js";
-      export { helper as helper_1 } from "./b.js";
-      export { helper as helper_2 } from "./c.js";
+      export { helper as helper_2 } from "./b.js";
+      export { helper as helper_3 } from "./c.js";
     `,
   });
 });
@@ -339,7 +339,7 @@ it("handles duplicate exports combined with internal exports", () => {
     `,
     "index.ts": d`
       export * from "./a.js";
-      export { helper as helper_1 } from "./b.js";
+      export { helper as helper_2 } from "./b.js";
     `,
   });
 });

--- a/packages/typescript/test/barrel.test.tsx
+++ b/packages/typescript/test/barrel.test.tsx
@@ -179,3 +179,167 @@ it("supports internal on various declaration types", () => {
     `,
   });
 });
+
+it("aliases duplicate export names across modules", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="a.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 1;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.SourceFile path="b.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 2;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "a.ts": d`
+      export function helper() {
+        return 1;
+      }
+    `,
+    "b.ts": d`
+      export function helper() {
+        return 2;
+      }
+    `,
+    "index.ts": d`
+      export * from "./a.js";
+      export { helper as helper_1 } from "./b.js";
+    `,
+  });
+});
+
+it("aliases duplicate exports with mixed non-conflicting names", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="a.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 1;
+        </ts.FunctionDeclaration>
+        <hbr />
+        <ts.FunctionDeclaration export name="foo">
+          return 2;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.SourceFile path="b.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 3;
+        </ts.FunctionDeclaration>
+        <hbr />
+        <ts.FunctionDeclaration export name="bar">
+          return 4;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "a.ts": d`
+      export function helper() {
+        return 1;
+      }
+      export function foo() {
+        return 2;
+      }
+    `,
+    "b.ts": d`
+      export function helper() {
+        return 3;
+      }
+      export function bar() {
+        return 4;
+      }
+    `,
+    "index.ts": d`
+      export * from "./a.js";
+      export { bar, helper as helper_1 } from "./b.js";
+    `,
+  });
+});
+
+it("aliases duplicate exports across three modules", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="a.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 1;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.SourceFile path="b.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 2;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.SourceFile path="c.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 3;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "a.ts": d`
+      export function helper() {
+        return 1;
+      }
+    `,
+    "b.ts": d`
+      export function helper() {
+        return 2;
+      }
+    `,
+    "c.ts": d`
+      export function helper() {
+        return 3;
+      }
+    `,
+    "index.ts": d`
+      export * from "./a.js";
+      export { helper as helper_1 } from "./b.js";
+      export { helper as helper_2 } from "./c.js";
+    `,
+  });
+});
+
+it("handles duplicate exports combined with internal exports", () => {
+  expect(
+    <Output>
+      <ts.SourceFile path="a.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 1;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.SourceFile path="b.ts">
+        <ts.FunctionDeclaration export name="helper">
+          return 2;
+        </ts.FunctionDeclaration>
+        <hbr />
+        <ts.FunctionDeclaration export internal name="secret">
+          return 3;
+        </ts.FunctionDeclaration>
+      </ts.SourceFile>
+      <ts.BarrelFile />
+    </Output>,
+  ).toRenderTo({
+    "a.ts": d`
+      export function helper() {
+        return 1;
+      }
+    `,
+    "b.ts": d`
+      export function helper() {
+        return 2;
+      }
+      export function secret() {
+        return 3;
+      }
+    `,
+    "index.ts": d`
+      export * from "./a.js";
+      export { helper as helper_1 } from "./b.js";
+    `,
+  });
+});


### PR DESCRIPTION
Add an `internal` boolean prop to all declaration components (`FunctionDeclaration`, `VarDeclaration`, `ClassDeclaration`, `InterfaceDeclaration`, `EnumDeclaration`, `TypeDeclaration`). When a declaration has both `export` and `internal`, it is
  exported from its source module but excluded from:

   - Barrel file re-exports (uses filtered named exports instead of `export *`)
   - Cross-package public symbol resolution

   This enables keeping utility declarations importable within a package while hiding them from the generated public API surface.

   Additionally, barrel files now detect and resolve name conflicts when multiple source files export symbols with the same name. Instead of emitting conflicting `export *` statements that cause TypeScript build errors, the barrel falls back to named
   re-exports with deterministic aliases (e.g. `export { helper as helper_1 } from "./b.js"`). Cross-package reference resolution uses the aliased name so consumer imports match the barrel's exports.