### PR TITLE
[TSP] Adding Model, Enum, and Union

### DIFF
--- a/packages/typespec/src/components/enum/enum-declaration.test.tsx
+++ b/packages/typespec/src/components/enum/enum-declaration.test.tsx
@@ -1,0 +1,206 @@
+import { List, Output, refkey, StatementList } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { Namespace } from "../namespace/namespace.jsx";
+import { Reference } from "../reference/reference.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { EnumDeclaration } from "./enum-declaration.jsx";
+import { EnumMember } from "./enum-member.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders a basic enum", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <EnumDeclaration name="Direction">
+          <List comma hardline enderPunctuation>
+            <EnumMember name="North" />
+            <EnumMember name="South" />
+            <EnumMember name="East" />
+            <EnumMember name="West" />
+          </List>
+        </EnumDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      enum Direction {
+        North,
+        South,
+        East,
+        West,
+      }
+    `,
+  });
+});
+
+it("renders an enum with string values", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <EnumDeclaration name="Color">
+          <List comma hardline enderPunctuation>
+            <EnumMember name="Red" value={`"red"`} />
+            <EnumMember name="Green" value={`"green"`} />
+            <EnumMember name="Blue" value={`"blue"`} />
+          </List>
+        </EnumDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      enum Color {
+        Red: "red",
+        Green: "green",
+        Blue: "blue",
+      }
+    `,
+  });
+});
+
+it("renders an enum with numeric values", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <EnumDeclaration name="Status">
+          <List comma hardline enderPunctuation>
+            <EnumMember name="Ok" value="200" />
+            <EnumMember name="NotFound" value="404" />
+          </List>
+        </EnumDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      enum Status {
+        Ok: 200,
+        NotFound: 404,
+      }
+    `,
+  });
+});
+
+it("renders an empty enum", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <EnumDeclaration name="Empty" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      enum Empty {}
+    `,
+  });
+});
+
+it("applies the enum name policy", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <EnumDeclaration name="model" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      enum \`model\` {}
+    `,
+  });
+});
+
+it("does not deconflict enum names across namespaces", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <EnumDeclaration name="Direction" />
+        </Namespace>
+        <hbr />
+        <hbr />
+        <Namespace name="B">
+          <EnumDeclaration name="Direction" />
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      namespace A {
+        enum Direction {}
+      }
+
+      namespace B {
+        enum Direction {}
+      }
+    `,
+  });
+});
+
+it("deconflicts duplicate enum names within the same namespace", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <StatementList>
+            <EnumDeclaration name="Direction" />
+            <EnumDeclaration name="Direction" />
+          </StatementList>
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      namespace A;
+
+      enum Direction {};
+      enum Direction_2 {};
+    `,
+  });
+});
+
+it("resolves an enum reference from another declaration", () => {
+  const directionKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <StatementList>
+          <EnumDeclaration name="Direction" refkey={directionKey} />
+          <EnumDeclaration name="ExtendedDirection" />
+        </StatementList>
+        <hbr />
+        <Reference refkey={directionKey} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      enum Direction {};
+      enum ExtendedDirection {};
+      Direction
+    `,
+  });
+});
+
+it("resolves an enum member reference", () => {
+  const northKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <EnumDeclaration name="Direction">
+          <EnumMember name="North" refkey={northKey} />
+        </EnumDeclaration>
+        <hbr />
+        <Reference refkey={northKey} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      enum Direction {
+        North
+      }
+      North
+    `,
+  });
+});

--- a/packages/typespec/src/components/enum/enum-declaration.tsx
+++ b/packages/typespec/src/components/enum/enum-declaration.tsx
@@ -1,0 +1,38 @@
+import {
+  Block,
+  Children,
+  Declaration,
+  Name,
+  Namekey,
+  Refkey,
+  Scope,
+  useScope,
+} from "@alloy-js/core";
+import { useTypeSpecNamePolicy } from "../../name-policy.js";
+import { NamedTypeScope } from "../../scopes/named-type.js";
+import { NamespaceScope } from "../../scopes/namespace.js";
+import { createNamedTypeSymbol } from "../../symbols/factories.js";
+
+export interface EnumDeclarationProps {
+  name: string | Namekey;
+  refkey?: Refkey;
+  children?: Children;
+}
+
+export function EnumDeclaration(props: EnumDeclarationProps) {
+  const sym = createNamedTypeSymbol(props.name, "enum", {
+    refkeys: props.refkey,
+    namePolicy: useTypeSpecNamePolicy().for("enum"),
+  });
+
+  const parentScope = useScope() as NamespaceScope;
+  const namedTypeScope = new NamedTypeScope(sym, parentScope);
+
+  return (
+    <Declaration symbol={sym}>
+      <Scope value={namedTypeScope}>
+        enum <Name /> <Block>{props.children}</Block>
+      </Scope>
+    </Declaration>
+  );
+}

--- a/packages/typespec/src/components/enum/enum-member.tsx
+++ b/packages/typespec/src/components/enum/enum-member.tsx
@@ -1,0 +1,21 @@
+import { Children, Declaration, Name, Namekey, Refkey } from "@alloy-js/core";
+import { createEnumMemberSymbol } from "../../symbols/factories.js";
+
+export interface EnumMemberProps {
+  name: string | Namekey;
+  refkey?: Refkey;
+  value?: Children;
+}
+
+export function EnumMember(props: EnumMemberProps) {
+  const sym = createEnumMemberSymbol(props.name, {
+    refkeys: props.refkey,
+  });
+
+  return (
+    <Declaration symbol={sym}>
+      <Name />
+      {props.value !== undefined && <>: {props.value}</>}
+    </Declaration>
+  );
+}

--- a/packages/typespec/src/components/index.ts
+++ b/packages/typespec/src/components/index.ts
@@ -1,3 +1,6 @@
+export * from "./model/model-declaration.jsx";
+export * from "./model/model-expression.jsx";
+export * from "./model/model-property.jsx";
 export * from "./namespace/namespace.jsx";
 export * from "./operation/operation-declaration.jsx";
 export * from "./source-file/source-file.jsx";

--- a/packages/typespec/src/components/index.ts
+++ b/packages/typespec/src/components/index.ts
@@ -1,3 +1,5 @@
+export * from "./enum/enum-declaration.jsx";
+export * from "./enum/enum-member.jsx";
 export * from "./model/model-declaration.jsx";
 export * from "./model/model-expression.jsx";
 export * from "./model/model-property.jsx";
@@ -5,3 +7,6 @@ export * from "./namespace/namespace.jsx";
 export * from "./operation/operation-declaration.jsx";
 export * from "./source-file/source-file.jsx";
 export * from "./template-parameters/template-parameters.jsx";
+export * from "./union/union-declaration.jsx";
+export * from "./union/union-expression.jsx";
+export * from "./union/union-variant.jsx";

--- a/packages/typespec/src/components/model/model-declaration.test.tsx
+++ b/packages/typespec/src/components/model/model-declaration.test.tsx
@@ -1,0 +1,408 @@
+import { Output, refkey, StatementList } from "@alloy-js/core";
+import { renderToString } from "@alloy-js/core/testing";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { Namespace } from "../namespace/namespace.jsx";
+import { Reference } from "../reference/reference.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { ModelDeclaration } from "./model-declaration.jsx";
+import { ModelExpression } from "./model-expression.jsx";
+import { ModelProperty } from "./model-property.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders an empty model", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Foo" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {}
+    `,
+  });
+});
+
+it("renders a model with properties", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Foo">
+          <StatementList>
+            <ModelProperty name="name" type="string" />
+            <ModelProperty name="age" type="int32" optional />
+          </StatementList>
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {
+        name: string;
+        age?: int32;
+      }
+    `,
+  });
+});
+
+it("renders a model with 'extends'", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Bar" extends="Foo" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Bar extends Foo {}
+    `,
+  });
+});
+
+it("renders a model with 'extends' and properties", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Bar" extends="Foo">
+          <ModelProperty name="extra" type="boolean" />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Bar extends Foo {
+        extra: boolean
+      }
+    `,
+  });
+});
+
+it("renders a model with 'is'", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="MyString" is="string" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model MyString is string
+    `,
+  });
+});
+
+it("throws if 'is' and 'extends' are both provided", () => {
+  const consoleMock = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  afterEach(() => {
+    consoleMock.mockReset();
+  });
+
+  expect(() =>
+    renderToString(
+      <Output namePolicy={createTypeSpecNamePolicy()}>
+        <SourceFile path="main.tsp">
+          <ModelDeclaration name="Foo" is="string" extends="Bar" />
+        </SourceFile>
+      </Output>,
+    ),
+  ).toThrow(
+    "A model declaration cannot have both 'is' and 'extends'/'children' properties.",
+  );
+});
+
+it("throws if 'is' and children are both provided", () => {
+  const consoleMock = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  afterEach(() => {
+    consoleMock.mockReset();
+  });
+
+  expect(() =>
+    renderToString(
+      <Output namePolicy={createTypeSpecNamePolicy()}>
+        <SourceFile path="main.tsp">
+          <ModelDeclaration name="Foo" is="string">
+            <ModelProperty name="name" type="string" />
+          </ModelDeclaration>
+        </SourceFile>
+      </Output>,
+    ),
+  ).toThrow(
+    "A model declaration cannot have both 'is' and 'extends'/'children' properties.",
+  );
+});
+
+it("applies the model name policy", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="model" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model \`model\` {}
+    `,
+  });
+});
+
+it("applies the model-property name policy", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Foo">
+          <ModelProperty name="model" type="string" />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {
+        \`model\`: string
+      }
+    `,
+  });
+});
+
+it("does not deconflict model names across namespaces", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <ModelDeclaration name="Foo" />
+        </Namespace>
+        <hbr />
+        <hbr />
+        <Namespace name="B">
+          <ModelDeclaration name="Foo" />
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      namespace A {
+        model Foo {}
+      }
+
+      namespace B {
+        model Foo {}
+      }
+    `,
+  });
+});
+
+it("deconflicts duplicate model names within the same namespace", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <StatementList>
+            <ModelDeclaration name="Foo" />
+            <ModelDeclaration name="Foo" />
+          </StatementList>
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      namespace A;
+
+      model Foo {};
+      model Foo_2 {};
+    `,
+  });
+});
+
+it("renders a model with template parameters", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Container" templateParameters={["T"]} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Container<T> {}
+    `,
+  });
+});
+
+it("renders a model with constrained template parameters", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="Wrapper"
+          templateParameters={[{ name: "T", extends: "BaseModel" }]}
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Wrapper<T extends BaseModel> {}
+    `,
+  });
+});
+
+it("resolves template parameter references within the model", () => {
+  const typeKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="Container"
+          templateParameters={[{ name: "T", refkey: typeKey }]}
+        >
+          <ModelProperty name="value" type={<Reference refkey={typeKey} />} />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Container<T> {
+        value: T
+      }
+    `,
+  });
+});
+
+it("does not resolve template parameter references outside the model", () => {
+  const typeKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="Container"
+          templateParameters={[{ name: "T", refkey: typeKey }]}
+        />
+        <hbr />
+        <Reference refkey={typeKey} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": expect.stringContaining("Unresolved Symbol"),
+  });
+});
+
+it("resolves a model reference from another declaration", () => {
+  const fooKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <StatementList>
+          <ModelDeclaration name="Foo" refkey={fooKey} />
+          <ModelDeclaration
+            name="Bar"
+            extends={<Reference refkey={fooKey} />}
+          />
+        </StatementList>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {};
+      model Bar extends Foo {};
+    `,
+  });
+});
+
+it("resolves a model property reference", () => {
+  const propKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Foo">
+          <ModelProperty name="id" type="string" refkey={propKey} />
+        </ModelDeclaration>
+        <hbr />
+        <Reference refkey={propKey} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {
+        id: string
+      }
+      id
+    `,
+  });
+});
+
+it("renders a model expression as a property type", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Foo">
+          <ModelProperty
+            name="nested"
+            type={
+              <ModelExpression>
+                <ModelProperty name="x" type="int32" />
+              </ModelExpression>
+            }
+          />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {
+        nested: {
+          x: int32
+        }
+      }
+    `,
+  });
+});
+
+it("renders a model expression as 'extends'", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="Foo"
+          extends={
+            <ModelExpression>
+              <ModelProperty name="id" type="string" />
+            </ModelExpression>
+          }
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo extends {
+        id: string
+      } {}
+    `,
+  });
+});
+
+it("renders a model expression as 'is'", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="Foo"
+          is={
+            <ModelExpression>
+              <ModelProperty name="id" type="string" />
+            </ModelExpression>
+          }
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo is {
+        id: string
+      }
+    `,
+  });
+});

--- a/packages/typespec/src/components/model/model-declaration.tsx
+++ b/packages/typespec/src/components/model/model-declaration.tsx
@@ -1,0 +1,62 @@
+import {
+  Block,
+  Children,
+  Declaration,
+  Name,
+  Namekey,
+  Refkey,
+  Scope,
+  useScope,
+} from "@alloy-js/core";
+import { useTypeSpecNamePolicy } from "../../name-policy.js";
+import { NamedTypeScope } from "../../scopes/named-type.js";
+import { NamespaceScope } from "../../scopes/namespace.js";
+import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import {
+  TemplateParameterDescriptor,
+  TemplateParameters,
+} from "../template-parameters/template-parameters.jsx";
+
+export interface ModelDeclarationProps {
+  name: string | Namekey;
+  refkey?: Refkey;
+  templateParameters?: (string | TemplateParameterDescriptor)[];
+  extends?: Children;
+  is?: Children;
+  children?: Children;
+}
+
+export function ModelDeclaration(props: ModelDeclarationProps) {
+  if (props.is && (props.extends || props.children)) {
+    throw new Error(
+      "A model declaration cannot have both 'is' and 'extends'/'children' properties.",
+    );
+  }
+
+  const sym = createNamedTypeSymbol(props.name, "model", {
+    refkeys: props.refkey,
+    namePolicy: useTypeSpecNamePolicy().for("model"),
+  });
+
+  const parentScope = useScope() as NamespaceScope;
+  const namedTypeScope = new NamedTypeScope(sym, parentScope);
+
+  return (
+    <Declaration symbol={sym}>
+      <Scope value={namedTypeScope}>
+        model <Name />
+        {props.templateParameters && (
+          <TemplateParameters parameters={props.templateParameters} />
+        )}
+        {props.is && <> is {props.is}</>}
+        {!props.is && (
+          <>
+            {props.extends && <> extends {props.extends}</>}
+            {" "}
+            <Block>{props.children}</Block>
+          </>
+        )}
+      </Scope>
+    </Declaration>
+  );
+}

--- a/packages/typespec/src/components/model/model-expression.tsx
+++ b/packages/typespec/src/components/model/model-expression.tsx
@@ -1,0 +1,9 @@
+import { Block, Children } from "@alloy-js/core";
+
+export interface ModelExpressionProps {
+  children?: Children;
+}
+
+export function ModelExpression(props: ModelExpressionProps) {
+  return <Block>{props.children}</Block>;
+}

--- a/packages/typespec/src/components/model/model-property.tsx
+++ b/packages/typespec/src/components/model/model-property.tsx
@@ -1,0 +1,22 @@
+import { Children, Declaration, Name, Namekey, Refkey } from "@alloy-js/core";
+import { createModelPropertySymbol } from "../../symbols/factories.js";
+
+export interface ModelPropertyProps {
+  name: string | Namekey;
+  refkey?: Refkey;
+  type: Children;
+  optional?: boolean;
+}
+
+export function ModelProperty(props: ModelPropertyProps) {
+  const sym = createModelPropertySymbol(props.name, {
+    refkeys: props.refkey,
+  });
+
+  return (
+    <Declaration symbol={sym}>
+      <Name />
+      {props.optional ? "?" : ""}: {props.type}
+    </Declaration>
+  );
+}

--- a/packages/typespec/src/components/union/union-declaration.test.tsx
+++ b/packages/typespec/src/components/union/union-declaration.test.tsx
@@ -1,0 +1,259 @@
+import { List, Output, refkey, StatementList } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { Namespace } from "../namespace/namespace.jsx";
+import { Reference } from "../reference/reference.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { UnionDeclaration } from "./union-declaration.jsx";
+import { UnionVariant } from "./union-variant.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders a union with anonymous variants", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="StringOrInt">
+          <List comma hardline enderPunctuation>
+            <UnionVariant type="string" />
+            <UnionVariant type="int32" />
+          </List>
+        </UnionDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union StringOrInt {
+        string,
+        int32,
+      }
+    `,
+  });
+});
+
+it("renders a union with named variants", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="Result">
+          <List comma hardline enderPunctuation>
+            <UnionVariant name="success" type="string" />
+            <UnionVariant name="failure" type="int32" />
+          </List>
+        </UnionDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union Result {
+        success: string,
+        failure: int32,
+      }
+    `,
+  });
+});
+
+it("renders a union with mixed anonymous and named variants", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="Mixed">
+          <List comma hardline enderPunctuation>
+            <UnionVariant type="string" />
+            <UnionVariant name="nothing" type="null" />
+          </List>
+        </UnionDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union Mixed {
+        string,
+        nothing: null,
+      }
+    `,
+  });
+});
+
+it("renders an empty union", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="Empty" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union Empty {}
+    `,
+  });
+});
+
+it("renders a union with template parameters", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="Maybe" templateParameters={["T"]}>
+          <List comma hardline enderPunctuation>
+            <UnionVariant name="value" type={<Reference refkey={refkey()} />} />
+            <UnionVariant type="null" />
+          </List>
+        </UnionDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": expect.stringContaining("union Maybe<T>"),
+  });
+});
+
+it("resolves template parameter references within the union", () => {
+  const typeKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration
+          name="Maybe"
+          templateParameters={[{ name: "T", refkey: typeKey }]}
+        >
+          <List comma hardline enderPunctuation>
+            <UnionVariant name="value" type={<Reference refkey={typeKey} />} />
+            <UnionVariant type="null" />
+          </List>
+        </UnionDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union Maybe<T> {
+        value: T,
+        null,
+      }
+    `,
+  });
+});
+
+it("does not resolve template parameter references outside the union", () => {
+  const typeKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration
+          name="Maybe"
+          templateParameters={[{ name: "T", refkey: typeKey }]}
+        />
+        <hbr />
+        <Reference refkey={typeKey} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": expect.stringContaining("Unresolved Symbol"),
+  });
+});
+
+it("applies the union name policy", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="model" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union \`model\` {}
+    `,
+  });
+});
+
+it("does not deconflict union names across namespaces", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <UnionDeclaration name="Result" />
+        </Namespace>
+        <hbr />
+        <hbr />
+        <Namespace name="B">
+          <UnionDeclaration name="Result" />
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      namespace A {
+        union Result {}
+      }
+
+      namespace B {
+        union Result {}
+      }
+    `,
+  });
+});
+
+it("deconflicts duplicate union names within the same namespace", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <StatementList>
+            <UnionDeclaration name="Result" />
+            <UnionDeclaration name="Result" />
+          </StatementList>
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      namespace A;
+
+      union Result {};
+      union Result_2 {};
+    `,
+  });
+});
+
+it("resolves a union reference from another declaration", () => {
+  const resultKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <StatementList>
+          <UnionDeclaration name="Result" refkey={resultKey} />
+        </StatementList>
+        <hbr />
+        <Reference refkey={resultKey} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union Result {};
+      Result
+    `,
+  });
+});
+
+it("resolves a named union variant reference", () => {
+  const successKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="Result">
+          <UnionVariant name="success" type="string" refkey={successKey} />
+        </UnionDeclaration>
+        <hbr />
+        <Reference refkey={successKey} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      union Result {
+        success: string
+      }
+      success
+    `,
+  });
+});

--- a/packages/typespec/src/components/union/union-declaration.tsx
+++ b/packages/typespec/src/components/union/union-declaration.tsx
@@ -17,25 +17,17 @@ import {
   TemplateParameters,
 } from "../template-parameters/template-parameters.jsx";
 
-export interface ModelDeclarationProps {
+export interface UnionDeclarationProps {
   name: string | Namekey;
   refkey?: Refkey;
   templateParameters?: (string | TemplateParameterDescriptor)[];
-  extends?: Children;
-  is?: Children;
   children?: Children;
 }
 
-export function ModelDeclaration(props: ModelDeclarationProps) {
-  if (props.is && (props.extends || props.children)) {
-    throw new Error(
-      "A model declaration cannot have both 'is' and 'extends'/'children' properties.",
-    );
-  }
-
-  const sym = createNamedTypeSymbol(props.name, "model", {
+export function UnionDeclaration(props: UnionDeclarationProps) {
+  const sym = createNamedTypeSymbol(props.name, "union", {
     refkeys: props.refkey,
-    namePolicy: useTypeSpecNamePolicy().for("model"),
+    namePolicy: useTypeSpecNamePolicy().for("union"),
   });
 
   const parentScope = useScope() as NamespaceScope;
@@ -44,17 +36,11 @@ export function ModelDeclaration(props: ModelDeclarationProps) {
   return (
     <Declaration symbol={sym}>
       <Scope value={namedTypeScope}>
-        model <Name />
+        union <Name />
         {props.templateParameters && (
           <TemplateParameters parameters={props.templateParameters} />
-        )}
-        {props.is && <> is {props.is}</>}
-        {!props.is && (
-          <>
-            {props.extends && <> extends {props.extends}</>}{" "}
-            <Block>{props.children}</Block>
-          </>
-        )}
+        )}{" "}
+        <Block>{props.children}</Block>
       </Scope>
     </Declaration>
   );

--- a/packages/typespec/src/components/union/union-expression.test.tsx
+++ b/packages/typespec/src/components/union/union-expression.test.tsx
@@ -1,0 +1,76 @@
+import { Output, refkey } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { ModelDeclaration } from "../model/model-declaration.jsx";
+import { ModelProperty } from "../model/model-property.jsx";
+import { Reference } from "../reference/reference.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { UnionExpression } from "./union-expression.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders a union expression with two types", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionExpression types={["string", "int32"]} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `string | int32`,
+  });
+});
+
+it("renders a union expression with more than two types", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionExpression types={["string", "int32", "boolean"]} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `string | int32 | boolean`,
+  });
+});
+
+it("renders a union expression with a reference", () => {
+  const fooKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Foo" refkey={fooKey} />
+        <hbr />
+        <UnionExpression types={["string", <Reference refkey={fooKey} />]} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {}
+      string | Foo
+    `,
+  });
+});
+
+it("renders a union expression as a model property type", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Foo">
+          <ModelProperty
+            name="value"
+            type={<UnionExpression types={["string", "null"]} />}
+          />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Foo {
+        value: string | null
+      }
+    `,
+  });
+});

--- a/packages/typespec/src/components/union/union-expression.tsx
+++ b/packages/typespec/src/components/union/union-expression.tsx
@@ -1,0 +1,9 @@
+import { Children, List } from "@alloy-js/core";
+
+export interface UnionExpressionProps {
+  types: Children[];
+}
+
+export function UnionExpression(props: UnionExpressionProps) {
+  return <List joiner=" | ">{props.types}</List>;
+}

--- a/packages/typespec/src/components/union/union-variant.tsx
+++ b/packages/typespec/src/components/union/union-variant.tsx
@@ -1,0 +1,24 @@
+import { Children, Declaration, Name, Namekey, Refkey } from "@alloy-js/core";
+import { createUnionVariantSymbol } from "../../symbols/factories.js";
+
+export interface UnionVariantProps {
+  type: Children;
+  name?: string | Namekey;
+  refkey?: Refkey;
+}
+
+export function UnionVariant(props: UnionVariantProps) {
+  if (props.name === undefined) {
+    return <>{props.type}</>;
+  }
+
+  const sym = createUnionVariantSymbol(props.name, {
+    refkeys: props.refkey,
+  });
+
+  return (
+    <Declaration symbol={sym}>
+      <Name />: {props.type}
+    </Declaration>
+  );
+}

--- a/packages/typespec/src/symbols/factories.ts
+++ b/packages/typespec/src/symbols/factories.ts
@@ -83,6 +83,26 @@ export function createNamedTypeSymbol(
   );
 }
 
+export function createModelPropertySymbol(
+  name: string | Namekey,
+  options: OutputSymbolOptions = {},
+) {
+  const scope = useScope();
+  if (!(scope instanceof NamedTypeScope)) {
+    throw new Error(
+      "Can't create a model property symbol outside of a named type scope.",
+    );
+  }
+  const modelSymbol = scope.ownerSymbol;
+  return withCleanup(
+    new TypeSpecSymbol(
+      name,
+      modelSymbol.members,
+      withNamePolicy(options, "model-property"),
+    ),
+  );
+}
+
 export function createTemplateParameterSymbol(
   name: string | Namekey,
   options: OutputSymbolOptions = {},

--- a/packages/typespec/src/symbols/factories.ts
+++ b/packages/typespec/src/symbols/factories.ts
@@ -103,6 +103,46 @@ export function createModelPropertySymbol(
   );
 }
 
+export function createEnumMemberSymbol(
+  name: string | Namekey,
+  options: OutputSymbolOptions = {},
+) {
+  const scope = useScope();
+  if (!(scope instanceof NamedTypeScope)) {
+    throw new Error(
+      "Can't create an enum member symbol outside of a named type scope.",
+    );
+  }
+  const enumSymbol = scope.ownerSymbol;
+  return withCleanup(
+    new TypeSpecSymbol(
+      name,
+      enumSymbol.members,
+      withNamePolicy(options, "enum"),
+    ),
+  );
+}
+
+export function createUnionVariantSymbol(
+  name: string | Namekey,
+  options: OutputSymbolOptions = {},
+) {
+  const scope = useScope();
+  if (!(scope instanceof NamedTypeScope)) {
+    throw new Error(
+      "Can't create a union variant symbol outside of a named type scope.",
+    );
+  }
+  const unionSymbol = scope.ownerSymbol;
+  return withCleanup(
+    new TypeSpecSymbol(
+      name,
+      unionSymbol.members,
+      withNamePolicy(options, "union"),
+    ),
+  );
+}
+
 export function createTemplateParameterSymbol(
   name: string | Namekey,
   options: OutputSymbolOptions = {},


### PR DESCRIPTION
This pull request introduces new components and comprehensive tests for handling TypeSpec enum, model, and union declarations and expressions in the codebase. The changes add JSX-based components for TypeSpec constructs, along with tests to verify their rendering and name resolution, and update the component exports for broader usage.

**New TypeSpec Components:**

* Added `EnumDeclaration` and `EnumMember` components to represent and render TypeSpec enums, including symbol creation, scoping, and name policy support. [[1]](diffhunk://#diff-671f6ff75026a5fd9b089ce049f9d68ecf9f60d1b1f691d72b1dde045b26f775R1-R38) [[2]](diffhunk://#diff-fcc22ee46c2d9d3422f989a4cd03d94d865b75b6d4272d32c58b438b412b92c9R1-R21)
* Introduced `ModelDeclaration`, `ModelExpression`, and `ModelProperty` components for TypeSpec models, supporting template parameters, inheritance, and error handling for invalid combinations. [[1]](diffhunk://#diff-338644523af808384bfff3fcc10214c3b9a1e71ef455cb09d3c02d7c311dcc25R1-R61) [[2]](diffhunk://#diff-d707faeca50b0421ee462cea426b62e63bf5526bcd83b3d57210421d97f42f8dR1-R9) [[3]](diffhunk://#diff-aa3a7e64edf4f266caac45ce7d0562b82c842e5060ffadfc1d592b8a6cf3612dR1-R22)
* Added `UnionDeclaration`, `UnionVariant`, and `UnionExpression` components to represent TypeSpec unions, supporting template parameters, named/anonymous variants, and union type expressions. [[1]](diffhunk://#diff-c478fb10d00beb785cbee9f401c3ba2a21ea94bbde14096f044f2dbd8d05d235R1-R47) [[2]](diffhunk://#diff-3e796b4e66c7137319c576b524609eebb5af513504739d0710496d501d318d17R1-R24) [[3]](diffhunk://#diff-6e6b0772938b38d113db5083cbc17d044564086fde1639903c8e1398ea0a9306R1-R9)

**Component Exports:**

* Updated `index.ts` to export the new enum, model, and union components for use elsewhere in the codebase.

**Comprehensive Testing:**

* Added test suites for enums (`enum-declaration.test.tsx`), unions (`union-declaration.test.tsx`, `union-expression.test.tsx`), covering rendering, name policy, namespace handling, template parameters, references, and deconfliction logic. [[1]](diffhunk://#diff-a5d65beef82afcaec495350dd0b6c5c4e7fc34a587f09e602943d408d27f4fe3R1-R206) [[2]](diffhunk://#diff-ed1a37f232dd6eb05af014dcb58fb61356d62f43bf267f906352053fa5f4bc37R1-R259) [[3]](diffhunk://#diff-60d15406575964ca0a81f8aa4b69f8bbf23c7321e827e665aa148eedbd07a065R1-R76)