### PR TITLE
Docs: Walk through: Fix model tsx file name

### DIFF
--- a/packages/docs/src/content/docs/guides/typescript-walkthrough.mdx
+++ b/packages/docs/src/content/docs/guides/typescript-walkthrough.mdx
@@ -340,7 +340,7 @@ So let's create both `src/components/Model.tsx` and
       </ts.InterfaceDeclaration>
     );
   }
-`} frame="code"lang="tsx" title="src/components/Model.ts" />
+`} frame="code"lang="tsx" title="src/components/Model.tsx" />
 
 This creates the model properties using a component we'll cover in the next
 section and adds them into an interface declaration. This component introduces


### PR DESCRIPTION
The model component has a code snippet, but the title of the code component is wrong and can be misleading.