### PR TITLE
fix(core): eliminate O(N²) DiagnosticsCollector broadcast

### DIFF
--- a/.chronus/changes/diagnostics-broadcast-perf-2026-4-23.md
+++ b/.chronus/changes/diagnostics-broadcast-perf-2026-4-23.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+Fix O(N²) overhead in `DiagnosticsCollector`. `emit()` and `dismiss()` previously re-broadcast the entire diagnostic history on every call, which dominated render time on large workloads even when debug tracing was disabled (the default). Broadcasts are now skipped when tracing is off, and the trace writer sees per-diagnostic add/remove deltas instead of duplicated inserts.

--- a/packages/core/src/debug/diagnostics-broadcast.test.tsx
+++ b/packages/core/src/debug/diagnostics-broadcast.test.tsx
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { DiagnosticsCollector } from "../diagnostics.js";
+import { closeTrace, initTrace, setChangeListener } from "./trace-writer.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "alloy-diag-test-"));
+});
+
+afterEach(async () => {
+  setChangeListener(null);
+  closeTrace();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+it("does not call insertDiagnostic when tracing is disabled", () => {
+  let events = 0;
+  setChangeListener(() => {
+    events++;
+  });
+
+  const collector = new DiagnosticsCollector();
+  for (let i = 0; i < 100; i++) {
+    collector.emit({ message: `diag ${i}`, severity: "warning" });
+  }
+
+  // No trace DB => no change events should fire.
+  expect(events).toBe(0);
+  expect(collector.getDiagnostics()).toHaveLength(100);
+});
+
+it("emits one added event per diagnostic (linear, not quadratic)", async () => {
+  await initTrace(join(tmpDir, "trace.db"));
+  const events: Array<{ channel: string; action: string }> = [];
+  setChangeListener((event) => {
+    events.push({ channel: event.channel, action: event.action });
+  });
+
+  const collector = new DiagnosticsCollector();
+  const N = 50;
+  for (let i = 0; i < N; i++) {
+    collector.emit({ message: `diag ${i}`, severity: "warning" });
+  }
+
+  const added = events.filter(
+    (e) => e.channel === "diagnostics" && e.action === "added",
+  );
+  expect(added).toHaveLength(N); // was previously N*(N+1)/2 due to re-broadcast
+});
+
+it("emits one removed event per dismissal", async () => {
+  await initTrace(join(tmpDir, "trace.db"));
+  const events: Array<{ channel: string; action: string }> = [];
+  setChangeListener((event) => {
+    events.push({ channel: event.channel, action: event.action });
+  });
+
+  const collector = new DiagnosticsCollector();
+  const handles = [];
+  for (let i = 0; i < 10; i++) {
+    handles.push(collector.emit({ message: `diag ${i}`, severity: "warning" }));
+  }
+
+  for (const h of handles) h.dismiss();
+
+  const added = events.filter(
+    (e) => e.channel === "diagnostics" && e.action === "added",
+  );
+  const removed = events.filter(
+    (e) => e.channel === "diagnostics" && e.action === "removed",
+  );
+  expect(added).toHaveLength(10);
+  expect(removed).toHaveLength(10);
+  expect(collector.getDiagnostics()).toHaveLength(0);
+});
+
+it("dismiss is idempotent and only fires one removal", async () => {
+  await initTrace(join(tmpDir, "trace.db"));
+  const events: Array<{ channel: string; action: string }> = [];
+  setChangeListener((event) => {
+    events.push({ channel: event.channel, action: event.action });
+  });
+
+  const collector = new DiagnosticsCollector();
+  const h = collector.emit({ message: "once", severity: "warning" });
+  h.dismiss();
+  h.dismiss();
+  h.dismiss();
+
+  const removed = events.filter(
+    (e) => e.channel === "diagnostics" && e.action === "removed",
+  );
+  expect(removed).toHaveLength(1);
+});

--- a/packages/core/src/debug/trace-writer.ts
+++ b/packages/core/src/debug/trace-writer.ts
@@ -801,6 +801,8 @@ export function insertRenderError(
   });
 }
 
+let stmtDeleteDiagnostic: StatementSync | undefined;
+
 export function insertDiagnostic(
   message: string,
   severity: string | undefined,
@@ -808,10 +810,10 @@ export function insertDiagnostic(
   sourceLine: number | undefined,
   sourceCol: number | undefined,
   componentStack: string | undefined,
-): void {
-  if (!db) return;
+): number | undefined {
+  if (!db) return undefined;
   const s = nextSeq();
-  stmtInsertDiagnostic.run(
+  const info = stmtInsertDiagnostic.run(
     message,
     severity ?? null,
     sourceFile ?? null,
@@ -820,7 +822,9 @@ export function insertDiagnostic(
     componentStack ?? null,
     s,
   );
+  const id = Number(info.lastInsertRowid);
   notifyChange("diagnostics", "added", {
+    id,
     message,
     severity: severity ?? null,
     source_file: sourceFile ?? null,
@@ -829,6 +833,16 @@ export function insertDiagnostic(
     component_stack: componentStack ?? null,
     seq: s,
   });
+  return id;
+}
+
+export function deleteDiagnostic(id: number): void {
+  if (!db) return;
+  if (!stmtDeleteDiagnostic) {
+    stmtDeleteDiagnostic = db.prepare(`DELETE FROM diagnostics WHERE id = ?`);
+  }
+  stmtDeleteDiagnostic.run(id);
+  notifyChange("diagnostics", "removed", { id, seq: nextSeq() });
 }
 
 /**
@@ -946,6 +960,7 @@ export function commitTransaction(): void {
 export function closeTrace(): void {
   db?.close();
   db = null;
+  stmtDeleteDiagnostic = undefined;
 }
 
 export function resetTrace(): void {

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -1,5 +1,9 @@
 import { getRenderNodeId } from "./debug/index.js";
-import { insertDiagnostic } from "./debug/trace-writer.js";
+import {
+  deleteDiagnostic,
+  insertDiagnostic,
+  isTraceEnabled,
+} from "./debug/trace-writer.js";
 import { getContext } from "./reactivity.js";
 import { getRenderStackSnapshot } from "./render-stack.js";
 import type { SourceLocation } from "./runtime/component.js";
@@ -31,22 +35,31 @@ export interface DiagnosticHandle {
   dismiss(): void;
 }
 
+function buildComponentStack(): DiagnosticStackEntry[] {
+  return getRenderStackSnapshot().map((entry) => ({
+    name: entry.displayName,
+    renderNodeId:
+      entry.context?.meta?.renderNode ?
+        getRenderNodeId(entry.context.meta.renderNode)
+      : undefined,
+    source: entry.source,
+  }));
+}
+
 export class DiagnosticsCollector {
   private entries = new Map<string, Diagnostic>();
   private order: string[] = [];
+  private traceRowIds = new Map<string, number>();
 
   emit(input: DiagnosticInput): DiagnosticHandle {
+    const traceEnabled = isTraceEnabled();
+    // Component stack is only required when a trace consumer will read it,
+    // or when the caller explicitly provided one. Building it walks the full
+    // render stack, which is expensive on hot paths.
     const componentStack =
       input.componentStack ??
-      getRenderStackSnapshot().map((entry) => ({
-        name: entry.displayName,
-        renderNodeId:
-          entry.context?.meta?.renderNode ?
-            getRenderNodeId(entry.context.meta.renderNode)
-          : undefined,
-        source: entry.source,
-      }));
-    const source = input.source ?? componentStack.at(-1)?.source ?? undefined;
+      (traceEnabled ? buildComponentStack() : undefined);
+    const source = input.source ?? componentStack?.at(-1)?.source ?? undefined;
     const id = `diag-${this.order.length + 1}-${Date.now()}`;
     const diagnostic: Diagnostic = {
       id,
@@ -58,28 +71,8 @@ export class DiagnosticsCollector {
     this.entries.set(id, diagnostic);
     this.order.push(id);
 
-    // Broadcast updated diagnostics
-    this.broadcast();
-
-    return {
-      dismiss: () => {
-        this.entries.delete(id);
-        // Broadcast updated diagnostics after dismissal
-        this.broadcast();
-      },
-    };
-  }
-
-  getDiagnostics() {
-    return this.order
-      .map((id) => this.entries.get(id))
-      .filter((entry): entry is Diagnostic => Boolean(entry));
-  }
-
-  private broadcast() {
-    const diagnostics = this.getDiagnostics();
-    for (const diagnostic of diagnostics) {
-      insertDiagnostic(
+    if (traceEnabled) {
+      const rowId = insertDiagnostic(
         diagnostic.message,
         diagnostic.severity,
         diagnostic.source?.fileName,
@@ -89,7 +82,27 @@ export class DiagnosticsCollector {
           JSON.stringify(diagnostic.componentStack)
         : undefined,
       );
+      if (rowId !== undefined) {
+        this.traceRowIds.set(id, rowId);
+      }
     }
+
+    return {
+      dismiss: () => {
+        if (!this.entries.delete(id)) return;
+        const rowId = this.traceRowIds.get(id);
+        if (rowId !== undefined) {
+          this.traceRowIds.delete(id);
+          if (isTraceEnabled()) deleteDiagnostic(rowId);
+        }
+      },
+    };
+  }
+
+  getDiagnostics() {
+    return this.order
+      .map((id) => this.entries.get(id))
+      .filter((entry): entry is Diagnostic => Boolean(entry));
   }
 }
 


### PR DESCRIPTION
## Problem

A CPU profile of a large CDK-style generator run (~204s wall time, single-threaded, no I/O wait) showed **~83% of total CPU inside `DiagnosticsCollector.broadcast()`** in `packages/core/src/diagnostics.ts`.

`broadcast()` re-emitted the **entire** diagnostic history on every `emit()` and every `dismiss()`, so N diagnostics produced O(N²) calls into `insertDiagnostic()` in the SQLite trace writer. `insertDiagnostic` short-circuits with `if (!db) return` when tracing is off (the default), so ~100M no-op function calls were being made purely for a notification API whose recipient was switched off. Even when tracing is on, the repeated inserts were duplicating rows in the `diagnostics` SQLite table and spamming duplicate `diagnostics:report` devtools messages.

## Changes

- **`packages/core/src/diagnostics.ts`**:
  - Guard broadcast with `isTraceEnabled()` so the hot path is a single check when tracing is off. (Devtools enabling always initializes the trace DB, so this covers devtools too.)
  - Switch from full-history re-broadcast to per-operation deltas: one `added` event per `emit()`, one `removed` event per `dismiss()`. Fixes duplicate SQLite inserts and duplicate devtools messages.
  - Defer `getRenderStackSnapshot()` / component stack construction unless a trace consumer will read it or the caller explicitly supplies one. Avoids wasted per-emit work in production.
  - Track the SQLite row id per emitted diagnostic so dismiss can delete the specific row. Dismiss is idempotent.
- **`packages/core/src/debug/trace-writer.ts`**:
  - `insertDiagnostic()` now returns the inserted row id (`lastInsertRowid`).
  - New `deleteDiagnostic(id)` helper that removes the row and emits `notifyChange(\"diagnostics\", \"removed\", …)`.
  - Reset the lazily-prepared delete statement in `closeTrace()` so re-opening the DB re-prepares against the new connection.
- **New test file** `packages/core/src/debug/diagnostics-broadcast.test.tsx`:
  - Asserts tracing-off path never calls `insertDiagnostic` (no change events fire).
  - Asserts N emits produce exactly N `added` events (previously N(N+1)/2).
  - Asserts N dismisses produce exactly N `removed` events.
  - Asserts `dismiss()` is idempotent.

## Expected impact

The profile author projected: network render ~200s → ~20–30s; full multi-service build ~504s → ~130s. Even with tracing enabled, runtime is now linear in the number of diagnostics instead of quadratic, and the SQLite trace no longer contains duplicate rows.

## Validation

- `pnpm --filter @alloy-js/core test` — all 357 tests pass (353 existing + 4 new).
- Lint clean on changed files.
- Build succeeds.

## Not included

- The profile suggested caching `isDevtoolsEnabled()` to avoid repeated `process.env.ALLOY_DEBUG` reads (~0.75% of profile time). The existing `test/reactivity/shallow-reactive.test.tsx` test explicitly toggles `process.env.ALLOY_DEBUG` at runtime and relies on dynamic re-reads, so caching would change documented behavior for a sub-1% gain. Skipped.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>