### PR TITLE
perf(core): cache ALLOY_DEBUG env-var read and gate debug-hook calls

### DIFF
--- a/.chronus/changes/perf-devtools-debug-gate-2026-4-27.md
+++ b/.chronus/changes/perf-devtools-debug-gate-2026-4-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+Reduce per-render overhead when devtools/debug are disabled. `isDevtoolsEnabled()` now caches the `ALLOY_DEBUG` env-var read at module load (use `refreshDebugState()` from tests that mutate the env var dynamically), and `effect()`, `ref()`, `shallowRef()`, `computed()`, `toRef()`, and `toRefs()` now gate their debug-hook bookkeeping behind `isDebugEnabled()` so the argument objects and source-location captures aren't built when debug is off.

--- a/packages/core/src/devtools/devtools-server.browser.ts
+++ b/packages/core/src/devtools/devtools-server.browser.ts
@@ -60,3 +60,7 @@ export async function enableDevtoolsAndConnect(
 export async function resetDevtoolsServerForTests(): Promise<void> {
   // No-op in browser
 }
+
+export function refreshDebugState(): void {
+  // No-op in browser
+}

--- a/packages/core/src/devtools/devtools-server.ts
+++ b/packages/core/src/devtools/devtools-server.ts
@@ -153,6 +153,19 @@ function isNodeEnvironment() {
   );
 }
 
+// Cached once at module load. Stable for production runs. Tests that modify
+// process.env.ALLOY_DEBUG dynamically must call refreshDebugState() afterward.
+let _envDebugEnabled: boolean =
+  isNodeEnvironment() && Boolean(process.env.ALLOY_DEBUG);
+
+/**
+ * Invalidates the cached env-var result for isDevtoolsEnabled(). Call this in
+ * test beforeEach hooks after modifying process.env.ALLOY_DEBUG.
+ */
+export function refreshDebugState(): void {
+  _envDebugEnabled = isNodeEnvironment() && Boolean(process.env.ALLOY_DEBUG);
+}
+
 function getCwd() {
   if (!isNodeEnvironment()) return undefined;
   try {
@@ -177,7 +190,7 @@ function resolveDebugPort() {
 /** Returns true when devtools are enabled (via env var or explicit call). */
 export function isDevtoolsEnabled() {
   if (!isNodeEnvironment()) return false;
-  return devtoolsExplicitlyEnabled || Boolean(process.env.ALLOY_DEBUG);
+  return devtoolsExplicitlyEnabled || _envDebugEnabled;
 }
 
 /** Returns true when a devtools client is currently connected. */
@@ -463,6 +476,8 @@ export async function resetDevtoolsServerForTests() {
   loggedDevtoolsLinks = false;
   subscribedPromise = null;
   resolveSubscribed = null;
+  // Re-read the env var in case tests modified process.env.ALLOY_DEBUG
+  refreshDebugState();
   // Close the trace DB so each test starts fresh
   closeTrace();
 }

--- a/packages/core/src/reactivity.ts
+++ b/packages/core/src/reactivity.ts
@@ -255,13 +255,16 @@ export function effect<T>(
   };
 
   const debugInfo = options?.debug;
-  const effectId = debug.effect.register({
-    name: debugInfo?.name ?? fn.name,
-    type: debugInfo?.type,
-    createdAt: captureSourceLocation(),
-    contextId: context.id,
-    ownerContextId: resolveOwnerEffectContextId(context),
-  });
+  const effectId =
+    isDebugEnabled() ?
+      debug.effect.register({
+        name: debugInfo?.name ?? fn.name,
+        type: debugInfo?.type,
+        createdAt: captureSourceLocation(),
+        contextId: context.id,
+        ownerContextId: resolveOwnerEffectContextId(context),
+      })
+    : -1;
 
   if (effectId !== -1) {
     context.meta ??= {};
@@ -458,13 +461,15 @@ export function ref<T>(
   options?: { isInfrastructure?: boolean },
 ): Ref<T> {
   const result = vueRef(value) as Ref<T>;
-  debug.effect.registerRef({
-    id: refId(result),
-    kind: "ref",
-    createdAt: captureSourceLocation(),
-    createdByEffectId: globalContext?.meta?.effectId,
-    isInfrastructure: options?.isInfrastructure,
-  });
+  if (isDebugEnabled()) {
+    debug.effect.registerRef({
+      id: refId(result),
+      kind: "ref",
+      createdAt: captureSourceLocation(),
+      createdByEffectId: globalContext?.meta?.effectId,
+      isInfrastructure: options?.isInfrastructure,
+    });
+  }
   return result;
 }
 
@@ -492,24 +497,28 @@ export function shallowReactive<T extends object>(
 
 export function shallowRef<T>(value?: T, options?: { label?: string }): Ref<T> {
   const result = vueShallowRef(value) as Ref<T>;
-  debug.effect.registerRef({
-    id: refId(result),
-    kind: "shallowRef",
-    label: options?.label,
-    createdAt: captureSourceLocation(),
-    createdByEffectId: globalContext?.meta?.effectId,
-  });
+  if (isDebugEnabled()) {
+    debug.effect.registerRef({
+      id: refId(result),
+      kind: "shallowRef",
+      label: options?.label,
+      createdAt: captureSourceLocation(),
+      createdByEffectId: globalContext?.meta?.effectId,
+    });
+  }
   return result;
 }
 
 export function computed<T>(getter: () => T): Ref<T> {
   const result = vueComputed(getter) as Ref<T>;
-  debug.effect.registerRef({
-    id: refId(result),
-    kind: "computed",
-    createdAt: captureSourceLocation(),
-    createdByEffectId: globalContext?.meta?.effectId,
-  });
+  if (isDebugEnabled()) {
+    debug.effect.registerRef({
+      id: refId(result),
+      kind: "computed",
+      createdAt: captureSourceLocation(),
+      createdByEffectId: globalContext?.meta?.effectId,
+    });
+  }
   return result;
 }
 
@@ -522,12 +531,14 @@ export function toRef<T extends object, K extends keyof T>(
     defaultValue === undefined ?
       (vueToRef(object, key) as Ref<T[K]>)
     : (vueToRef(object, key, defaultValue) as Ref<T[K]>);
-  debug.effect.registerRef({
-    id: refId(result),
-    kind: "toRef",
-    createdAt: captureSourceLocation(),
-    createdByEffectId: globalContext?.meta?.effectId,
-  });
+  if (isDebugEnabled()) {
+    debug.effect.registerRef({
+      id: refId(result),
+      kind: "toRef",
+      createdAt: captureSourceLocation(),
+      createdByEffectId: globalContext?.meta?.effectId,
+    });
+  }
   return result;
 }
 
@@ -535,13 +546,15 @@ export function toRefs<T extends object>(
   object: T,
 ): { [K in keyof T]: Ref<T[K]> } {
   const result = vueToRefs(object) as { [K in keyof T]: Ref<T[K]> };
-  for (const refValue of Object.values(result) as Ref<unknown>[]) {
-    debug.effect.registerRef({
-      id: refId(refValue),
-      kind: "toRef",
-      createdAt: captureSourceLocation(),
-      createdByEffectId: globalContext?.meta?.effectId,
-    });
+  if (isDebugEnabled()) {
+    for (const refValue of Object.values(result) as Ref<unknown>[]) {
+      debug.effect.registerRef({
+        id: refId(refValue),
+        kind: "toRef",
+        createdAt: captureSourceLocation(),
+        createdByEffectId: globalContext?.meta?.effectId,
+      });
+    }
   }
   return result;
 }

--- a/packages/core/test/reactivity/shallow-reactive.test.tsx
+++ b/packages/core/test/reactivity/shallow-reactive.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { refreshDebugState } from "../../src/devtools/devtools-server.js";
 import {
   getReactiveCreationLocation,
   shallowReactive,
@@ -10,6 +11,7 @@ describe("shallowReactive creation location", () => {
   beforeEach(() => {
     origDebug = process.env.ALLOY_DEBUG;
     process.env.ALLOY_DEBUG = "1";
+    refreshDebugState();
   });
 
   afterEach(() => {
@@ -18,6 +20,7 @@ describe("shallowReactive creation location", () => {
     } else {
       process.env.ALLOY_DEBUG = origDebug;
     }
+    refreshDebugState();
   });
 
   it("stores creation location keyed by raw target when debug enabled", () => {
@@ -31,6 +34,7 @@ describe("shallowReactive creation location", () => {
 
   it("does not store location when debug is disabled", () => {
     delete process.env.ALLOY_DEBUG;
+    refreshDebugState();
     const raw = { y: 2 };
     shallowReactive(raw);
 


### PR DESCRIPTION
Two small perf changes that reduce render-loop overhead when devtools/debug are disabled (the common production path).

## Commits

1. **`perf(core): gate debug.effect.register{,Ref} calls behind isDebugEnabled()`** — In `reactivity.ts`, `effect()`, `ref()`, `shallowRef()`, `computed()`, `toRef()`, and `toRefs()` previously built debug argument objects (with embedded `refId()`, `captureSourceLocation()`, and `resolveOwnerEffectContextId()` calls) on every creation, even when debug was off. Those calls and their WeakMap bookkeeping are now gated behind `isDebugEnabled()`.

2. **`perf(core): cache ALLOY_DEBUG env-var read in isDevtoolsEnabled()`** — `isDevtoolsEnabled()` is on every render-loop hot path (effect/ref/appendTextNode/appendPrintHook/etc.). It now caches `process.env.ALLOY_DEBUG` once at module load instead of re-reading it on every call. A new `refreshDebugState()` export lets tests that mutate the env var dynamically invalidate the cache; `shallow-reactive.test.tsx` and `resetDevtoolsServerForTests()` call it.

The two changes compose: with the cached env-var read, the new `isDebugEnabled()` gate in commit 1 is effectively free.

## Verification

- `pnpm vitest run packages/core` — 365 tests pass
- Lint and prettier clean on changed files
- Changelog entry added under `.chronus/changes/`