### PR TITLE
feat(typespec): add doc comment components and doc prop to declarations

### DIFF
--- a/packages/typespec/src/components/alias/alias-declaration.test.tsx
+++ b/packages/typespec/src/components/alias/alias-declaration.test.tsx
@@ -20,11 +20,9 @@ it("renders a basic alias", () => {
         <AliasDeclaration name="StringOrInt" type={`string | int32`} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       alias StringOrInt = string | int32
-    `,
-  });
+    `);
 });
 
 it("renders an alias with union expression children", () => {
@@ -41,11 +39,9 @@ it("renders an alias with union expression children", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       alias Breed = Beagle | GermanShepherd | GoldenRetriever
-    `,
-  });
+    `);
 });
 
 it("renders an alias with template parameters", () => {
@@ -55,11 +51,9 @@ it("renders an alias with template parameters", () => {
         <AliasDeclaration name="Response" templateParameters={["T"]} type="T" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       alias Response<T> = T
-    `,
-  });
+    `);
 });
 
 it("renders an alias with constrained template parameters", () => {
@@ -73,11 +67,9 @@ it("renders an alias with constrained template parameters", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       alias StringAlias<T extends string> = T
-    `,
-  });
+    `);
 });
 
 it("renders an alias with default template parameter", () => {
@@ -93,11 +85,9 @@ it("renders an alias with default template parameter", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       alias Options<T extends string = "default"> = T
-    `,
-  });
+    `);
 });
 
 it("applies the alias name policy", () => {
@@ -107,11 +97,9 @@ it("applies the alias name policy", () => {
         <AliasDeclaration name="model" type="string" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       alias \`model\` = string
-    `,
-  });
+    `);
 });
 
 it("deconflicts duplicate alias names within the same namespace", () => {
@@ -126,14 +114,12 @@ it("deconflicts duplicate alias names within the same namespace", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
       alias Options = string;
       alias Options_2 = int32;
-    `,
-  });
+    `);
 });
 
 it("resolves an alias reference from another declaration", () => {
@@ -153,14 +139,12 @@ it("resolves an alias reference from another declaration", () => {
         </StatementList>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       alias Options = "one" | "two";
       model Foo {
         Options
       };
-    `,
-  });
+    `);
 });
 
 it("resolves an alias reference across namespaces", () => {
@@ -178,8 +162,7 @@ it("resolves an alias reference across namespaces", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       using A;
 
       namespace A {
@@ -189,8 +172,7 @@ it("resolves an alias reference across namespaces", () => {
       namespace B {
         Options
       }
-    `,
-  });
+    `);
 });
 
 it("renders an alias with a doc comment", () => {
@@ -204,12 +186,10 @@ it("renders an alias with a doc comment", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * Available options
        */
       alias Options = "one" | "two"
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/alias/alias-declaration.test.tsx
+++ b/packages/typespec/src/components/alias/alias-declaration.test.tsx
@@ -192,3 +192,24 @@ it("resolves an alias reference across namespaces", () => {
     `,
   });
 });
+
+it("renders an alias with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <AliasDeclaration
+          name="Options"
+          type={'"one" | "two"'}
+          doc="Available options"
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * Available options
+       */
+      alias Options = "one" | "two"
+    `,
+  });
+});

--- a/packages/typespec/src/components/alias/alias-declaration.tsx
+++ b/packages/typespec/src/components/alias/alias-declaration.tsx
@@ -11,6 +11,7 @@ import { useTypeSpecNamePolicy } from "../../name-policy.js";
 import { NamedTypeScope } from "../../scopes/named-type.js";
 import { NamespaceScope } from "../../scopes/namespace.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 import {
   TemplateParameterDescriptor,
   TemplateParameters,
@@ -36,6 +37,8 @@ export interface AliasDeclarationProps {
   templateParameters?: (string | TemplateParameterDescriptor)[];
   /** The type expression the alias is bound to. */
   type: Children;
+  /** Doc comment rendered as `/** ... *\/` above the declaration. */
+  doc?: Children;
 }
 
 /**
@@ -43,10 +46,11 @@ export interface AliasDeclarationProps {
  *
  * @example
  * ```tsx
- * <AliasDeclaration name="Options" type={'"one" | "two"'} />
+ * <AliasDeclaration name="Options" type={'"one" | "two"'} doc="Available options" />
  * ```
  * This will produce:
  * ```typespec
+ * /** Available options *\/
  * alias Options = "one" | "two"
  * ```
  */
@@ -61,6 +65,7 @@ export function AliasDeclaration(props: AliasDeclarationProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       <Scope value={namedTypeScope}>
         alias <Name />
         {props.templateParameters && (

--- a/packages/typespec/src/components/doc/doc-comment.test.tsx
+++ b/packages/typespec/src/components/doc/doc-comment.test.tsx
@@ -96,16 +96,14 @@ it("renders a doc comment before a model declaration", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * A pet in the store
        */
       model Pet {
         name: string
       }
-    `,
-  });
+    `);
 });
 
 it("renders DocWhen when doc is provided", () => {
@@ -116,14 +114,12 @@ it("renders DocWhen when doc is provided", () => {
         <ModelDeclaration name="Pet" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * A pet in the store
        */
       model Pet {}
-    `,
-  });
+    `);
 });
 
 it("renders nothing for DocWhen when doc is undefined", () => {
@@ -134,9 +130,7 @@ it("renders nothing for DocWhen when doc is undefined", () => {
         <ModelDeclaration name="Pet" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Pet {}
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/doc/doc-comment.test.tsx
+++ b/packages/typespec/src/components/doc/doc-comment.test.tsx
@@ -1,0 +1,142 @@
+import { Output } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { ModelDeclaration } from "../model/model-declaration.jsx";
+import { ModelProperty } from "../model/model-property.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import {
+  DocComment,
+  DocParam,
+  DocReturns,
+  DocTemplate,
+  DocWhen,
+} from "./doc-comment.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders a simple doc comment", () => {
+  expect(<DocComment>A pet in the store</DocComment>).toRenderTo(`
+    /**
+     * A pet in the store
+     */
+  `);
+});
+
+it("renders a doc comment with @param tag", () => {
+  expect(
+    <DocComment>
+      Get a pet by ID
+      <DocParam name="id">The unique identifier</DocParam>
+    </DocComment>,
+  ).toRenderTo(`
+    /**
+     * Get a pet by ID
+     * @param id The unique identifier
+     */
+  `);
+});
+
+it("renders a doc comment with @returns tag", () => {
+  expect(
+    <DocComment>
+      Get a pet
+      <DocReturns>The pet object</DocReturns>
+    </DocComment>,
+  ).toRenderTo(`
+    /**
+     * Get a pet
+     * @returns The pet object
+     */
+  `);
+});
+
+it("renders a doc comment with @template tag", () => {
+  expect(
+    <DocComment>
+      A container type
+      <DocTemplate name="T">The element type</DocTemplate>
+    </DocComment>,
+  ).toRenderTo(`
+    /**
+     * A container type
+     * @template T The element type
+     */
+  `);
+});
+
+it("renders a doc comment with multiple tags", () => {
+  expect(
+    <DocComment>
+      Create a new pet
+      <DocParam name="name">The pet name</DocParam>
+      <DocParam name="age">The pet age</DocParam>
+      <DocReturns>The created pet</DocReturns>
+    </DocComment>,
+  ).toRenderTo(`
+    /**
+     * Create a new pet
+     * @param name The pet name
+     * @param age The pet age
+     * @returns The created pet
+     */
+  `);
+});
+
+it("renders a doc comment before a model declaration", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <DocComment>A pet in the store</DocComment>
+        <hbr />
+        <ModelDeclaration name="Pet">
+          <ModelProperty name="name" type="string" />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * A pet in the store
+       */
+      model Pet {
+        name: string
+      }
+    `,
+  });
+});
+
+it("renders DocWhen when doc is provided", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <DocWhen doc="A pet in the store" />
+        <ModelDeclaration name="Pet" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * A pet in the store
+       */
+      model Pet {}
+    `,
+  });
+});
+
+it("renders nothing for DocWhen when doc is undefined", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <DocWhen doc={undefined} />
+        <ModelDeclaration name="Pet" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Pet {}
+    `,
+  });
+});

--- a/packages/typespec/src/components/doc/doc-comment.tsx
+++ b/packages/typespec/src/components/doc/doc-comment.tsx
@@ -1,0 +1,147 @@
+import { Children, List, Show } from "@alloy-js/core";
+
+export interface DocCommentProps {
+  /** The main description text for the doc comment. */
+  children: Children;
+}
+
+/**
+ * A TypeSpec doc comment (`/** ... *\/`), rendered as a block comment
+ * with ` * ` continuation lines.
+ *
+ * @example
+ * ```tsx
+ * <DocComment>A pet in the store</DocComment>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /**
+ *  * A pet in the store
+ *  *\/
+ * ```
+ */
+export function DocComment(props: DocCommentProps) {
+  return (
+    <>
+      {"/**"}
+      <hbr />
+      {" * "}
+      <align string=" * ">
+        <List>{props.children}</List>
+      </align>
+      <hbr />
+      {" */"}
+    </>
+  );
+}
+
+export interface DocParamProps {
+  /** The parameter name. */
+  name: string;
+  /** Description of the parameter. */
+  children: Children;
+}
+
+/**
+ * A `@param` tag inside a TypeSpec doc comment.
+ *
+ * @example
+ * ```tsx
+ * <DocComment>
+ *   Description
+ *   <DocParam name="id">The unique identifier</DocParam>
+ * </DocComment>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /**
+ *  * Description
+ *  * \@param id The unique identifier
+ *  *\/
+ * ```
+ */
+export function DocParam(props: DocParamProps) {
+  return (
+    <>
+      @param {props.name} {props.children}
+    </>
+  );
+}
+
+export interface DocTagProps {
+  /** The content of the tag. */
+  children: Children;
+}
+
+/**
+ * A `@returns` tag inside a TypeSpec doc comment.
+ *
+ * @example
+ * ```tsx
+ * <DocComment>
+ *   Description
+ *   <DocReturns>The result</DocReturns>
+ * </DocComment>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /**
+ *  * Description
+ *  * \@returns The result
+ *  *\/
+ * ```
+ */
+export function DocReturns(props: DocTagProps) {
+  return <>@returns {props.children}</>;
+}
+
+export interface DocTemplateProps {
+  /** The template parameter name. */
+  name: string;
+  /** Description of the template parameter. */
+  children: Children;
+}
+
+/**
+ * A `@template` tag inside a TypeSpec doc comment.
+ *
+ * @example
+ * ```tsx
+ * <DocComment>
+ *   Description
+ *   <DocTemplate name="T">The element type</DocTemplate>
+ * </DocComment>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /**
+ *  * Description
+ *  * \@template T The element type
+ *  *\/
+ * ```
+ */
+export function DocTemplate(props: DocTemplateProps) {
+  return (
+    <>
+      @template {props.name} {props.children}
+    </>
+  );
+}
+
+export interface DocWhenProps {
+  /** The doc content to conditionally render. */
+  doc: Children | undefined;
+}
+
+/**
+ * Conditionally renders a {@link DocComment} followed by a line break,
+ * only when `doc` is provided.
+ */
+export function DocWhen(props: DocWhenProps) {
+  return (
+    <Show when={Boolean(props.doc)}>
+      <DocComment children={props.doc} />
+      <hbr />
+    </Show>
+  );
+}

--- a/packages/typespec/src/components/enum/enum-declaration.test.tsx
+++ b/packages/typespec/src/components/enum/enum-declaration.test.tsx
@@ -242,3 +242,31 @@ it("renders an enum with decorators", () => {
     `,
   });
 });
+
+it("renders an enum with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <EnumDeclaration name="Direction" doc="Cardinal directions">
+          <List comma hardline enderPunctuation>
+            <EnumMember name="North" doc="Points north" />
+            <EnumMember name="South" />
+          </List>
+        </EnumDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * Cardinal directions
+       */
+      enum Direction {
+        /**
+         * Points north
+         */
+        North,
+        South,
+      }
+    `,
+  });
+});

--- a/packages/typespec/src/components/enum/enum-declaration.test.tsx
+++ b/packages/typespec/src/components/enum/enum-declaration.test.tsx
@@ -27,16 +27,14 @@ it("renders a basic enum", () => {
         </EnumDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       enum Direction {
         North,
         South,
         East,
         West,
       }
-    `,
-  });
+    `);
 });
 
 it("renders an enum with string values", () => {
@@ -52,15 +50,13 @@ it("renders an enum with string values", () => {
         </EnumDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       enum Color {
         Red: "red",
         Green: "green",
         Blue: "blue",
       }
-    `,
-  });
+    `);
 });
 
 it("renders an enum with numeric values", () => {
@@ -75,14 +71,12 @@ it("renders an enum with numeric values", () => {
         </EnumDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       enum Status {
         Ok: 200,
         NotFound: 404,
       }
-    `,
-  });
+    `);
 });
 
 it("renders an empty enum", () => {
@@ -92,11 +86,9 @@ it("renders an empty enum", () => {
         <EnumDeclaration name="Empty" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       enum Empty {}
-    `,
-  });
+    `);
 });
 
 it("applies the enum name policy", () => {
@@ -106,11 +98,9 @@ it("applies the enum name policy", () => {
         <EnumDeclaration name="model" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       enum \`model\` {}
-    `,
-  });
+    `);
 });
 
 it("does not deconflict enum names across namespaces", () => {
@@ -127,8 +117,7 @@ it("does not deconflict enum names across namespaces", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A {
         enum Direction {}
       }
@@ -136,8 +125,7 @@ it("does not deconflict enum names across namespaces", () => {
       namespace B {
         enum Direction {}
       }
-    `,
-  });
+    `);
 });
 
 it("deconflicts duplicate enum names within the same namespace", () => {
@@ -152,14 +140,12 @@ it("deconflicts duplicate enum names within the same namespace", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
       enum Direction {};
       enum Direction_2 {};
-    `,
-  });
+    `);
 });
 
 it("resolves an enum reference from another declaration", () => {
@@ -175,13 +161,11 @@ it("resolves an enum reference from another declaration", () => {
         <Reference refkey={directionKey} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       enum Direction {};
       enum ExtendedDirection {};
       Direction
-    `,
-  });
+    `);
 });
 
 it("resolves an enum member reference", () => {
@@ -196,14 +180,12 @@ it("resolves an enum member reference", () => {
         <Reference refkey={northKey} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       enum Direction {
         North
       }
       North
-    `,
-  });
+    `);
 });
 
 it("renders an enum with decorators", () => {
@@ -231,16 +213,14 @@ it("renders an enum with decorators", () => {
         </EnumDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       @doc("Cardinal directions")
       enum Direction {
         @doc("Up")
         North,
         South,
       }
-    `,
-  });
+    `);
 });
 
 it("renders an enum with a doc comment", () => {
@@ -255,8 +235,7 @@ it("renders an enum with a doc comment", () => {
         </EnumDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * Cardinal directions
        */
@@ -267,6 +246,5 @@ it("renders an enum with a doc comment", () => {
         North,
         South,
       }
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/enum/enum-declaration.tsx
+++ b/packages/typespec/src/components/enum/enum-declaration.tsx
@@ -12,14 +12,42 @@ import { useTypeSpecNamePolicy } from "../../name-policy.js";
 import { NamedTypeScope } from "../../scopes/named-type.js";
 import { NamespaceScope } from "../../scopes/namespace.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 
 export interface EnumDeclarationProps {
+  /** The enum name. */
   name: string | Namekey;
+  /** Refkey for referencing this enum from other declarations. */
   refkey?: Refkey;
+  /** Doc comment rendered as `/** ... *\/` above the declaration. */
+  doc?: Children;
+  /** Decorators to apply to the enum. */
   decorators?: Children;
+  /** Enum body (members, spread expressions, etc.). */
   children?: Children;
 }
 
+/**
+ * A TypeSpec enum declaration.
+ *
+ * @example
+ * ```tsx
+ * <EnumDeclaration name="Direction" doc="Cardinal directions">
+ *   <List comma hardline enderPunctuation>
+ *     <EnumMember name="North" />
+ *     <EnumMember name="South" />
+ *   </List>
+ * </EnumDeclaration>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** Cardinal directions *\/
+ * enum Direction {
+ *   North,
+ *   South,
+ * }
+ * ```
+ */
 export function EnumDeclaration(props: EnumDeclarationProps) {
   const sym = createNamedTypeSymbol(props.name, "enum", {
     refkeys: props.refkey,
@@ -31,6 +59,7 @@ export function EnumDeclaration(props: EnumDeclarationProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Scope value={namedTypeScope}>
         enum <Name /> <Block>{props.children}</Block>

--- a/packages/typespec/src/components/enum/enum-member.tsx
+++ b/packages/typespec/src/components/enum/enum-member.tsx
@@ -1,13 +1,33 @@
 import { Children, Declaration, Name, Namekey, Refkey } from "@alloy-js/core";
 import { createEnumMemberSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 
 export interface EnumMemberProps {
+  /** The member name. */
   name: string | Namekey;
+  /** Refkey for referencing this member from other declarations. */
   refkey?: Refkey;
+  /** Optional explicit value (`: "val"` or `: 123`). */
   value?: Children;
+  /** Doc comment rendered as `/** ... *\/` above the member. */
+  doc?: Children;
+  /** Decorators to apply to the member. */
   decorators?: Children;
 }
 
+/**
+ * A TypeSpec enum member.
+ *
+ * @example
+ * ```tsx
+ * <EnumMember name="North" doc="Points north" />
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** Points north *\/
+ * North
+ * ```
+ */
 export function EnumMember(props: EnumMemberProps) {
   const sym = createEnumMemberSymbol(props.name, {
     refkeys: props.refkey,
@@ -15,6 +35,7 @@ export function EnumMember(props: EnumMemberProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Name />
       {props.value !== undefined && <>: {props.value}</>}

--- a/packages/typespec/src/components/index.ts
+++ b/packages/typespec/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./alias/alias-declaration.jsx";
 export * from "./const/const-declaration.jsx";
 export * from "./decorator/augment-decorator.jsx";
 export * from "./decorator/decorator-application.jsx";
+export * from "./doc/doc-comment.jsx";
 export * from "./enum/enum-declaration.jsx";
 export * from "./enum/enum-member.jsx";
 export * from "./import/import-statement.jsx";

--- a/packages/typespec/src/components/interface/interface-declaration.test.tsx
+++ b/packages/typespec/src/components/interface/interface-declaration.test.tsx
@@ -18,11 +18,9 @@ it("renders an empty interface", () => {
         <InterfaceDeclaration name="Foo" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Foo {}
-    `,
-  });
+    `);
 });
 
 it("renders an interface with operations", () => {
@@ -34,13 +32,11 @@ it("renders an interface with operations", () => {
         </InterfaceDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Foo {
         bar(): void
       }
-    `,
-  });
+    `);
 });
 
 it("renders an interface with extends", () => {
@@ -50,11 +46,9 @@ it("renders an interface with extends", () => {
         <InterfaceDeclaration name="Bar" extends="Foo" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Bar extends Foo {}
-    `,
-  });
+    `);
 });
 
 it("renders an interface with extends and operations", () => {
@@ -70,13 +64,11 @@ it("renders an interface with extends and operations", () => {
         </InterfaceDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Bar extends Foo {
         extra(id: string): void
       }
-    `,
-  });
+    `);
 });
 
 it("renders an interface with template parameters", () => {
@@ -86,11 +78,9 @@ it("renders an interface with template parameters", () => {
         <InterfaceDeclaration name="Foo" templateParameters={["T"]} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Foo<T> {}
-    `,
-  });
+    `);
 });
 
 it("renders an interface with constrained template parameters", () => {
@@ -105,11 +95,9 @@ it("renders an interface with constrained template parameters", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Foo<T extends BaseModel = DefaultModel> {}
-    `,
-  });
+    `);
 });
 
 it("resolves template parameter references within the interface", () => {
@@ -129,13 +117,11 @@ it("resolves template parameter references within the interface", () => {
         </InterfaceDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface ResourceOps<T> {
         get(id: string): T
       }
-    `,
-  });
+    `);
 });
 
 it("does not resolve template parameter references outside the interface", () => {
@@ -163,11 +149,9 @@ it("applies the interface name policy", () => {
         <InterfaceDeclaration name="model" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface \`model\` {}
-    `,
-  });
+    `);
 });
 
 it("deconflicts duplicate interface names within the same namespace", () => {
@@ -180,12 +164,10 @@ it("deconflicts duplicate interface names within the same namespace", () => {
         </StatementList>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Foo {};
       interface Foo_2 {};
-    `,
-  });
+    `);
 });
 
 it("resolves an interface reference from another declaration", () => {
@@ -202,12 +184,10 @@ it("resolves an interface reference from another declaration", () => {
         </StatementList>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       interface Foo {};
       interface Bar extends Foo {};
-    `,
-  });
+    `);
 });
 
 it("renders an interface with a doc comment", () => {
@@ -219,14 +199,12 @@ it("renders an interface with a doc comment", () => {
         </InterfaceDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * Pet store API
        */
       interface PetStore {
         getPet(): Pet
       }
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/interface/interface-declaration.test.tsx
+++ b/packages/typespec/src/components/interface/interface-declaration.test.tsx
@@ -209,3 +209,24 @@ it("resolves an interface reference from another declaration", () => {
     `,
   });
 });
+
+it("renders an interface with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <InterfaceDeclaration name="PetStore" doc="Pet store API">
+          <OperationDeclaration name="getPet" returnType="Pet" />
+        </InterfaceDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * Pet store API
+       */
+      interface PetStore {
+        getPet(): Pet
+      }
+    `,
+  });
+});

--- a/packages/typespec/src/components/interface/interface-declaration.tsx
+++ b/packages/typespec/src/components/interface/interface-declaration.tsx
@@ -12,19 +12,44 @@ import { useTypeSpecNamePolicy } from "../../name-policy.js";
 import { NamedTypeScope } from "../../scopes/named-type.js";
 import { NamespaceScope } from "../../scopes/namespace.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 import {
   TemplateParameterDescriptor,
   TemplateParameters,
 } from "../template-parameters/template-parameters.jsx";
 
 export interface InterfaceDeclarationProps {
+  /** The interface name. */
   name: string | Namekey;
+  /** Refkey for referencing this interface from other declarations. */
   refkey?: Refkey;
+  /** Template parameters for the interface. */
   templateParameters?: (string | TemplateParameterDescriptor)[];
+  /** The interfaces this interface extends. */
   extends?: Children;
+  /** Doc comment rendered as `/** ... *\/` above the declaration. */
+  doc?: Children;
+  /** Interface body (operations). */
   children?: Children;
 }
 
+/**
+ * A TypeSpec interface declaration.
+ *
+ * @example
+ * ```tsx
+ * <InterfaceDeclaration name="PetStore" doc="Pet store API">
+ *   <OperationDeclaration name="getPet" returnType="Pet" />
+ * </InterfaceDeclaration>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** Pet store API *\/
+ * interface PetStore {
+ *   getPet(): Pet
+ * }
+ * ```
+ */
 export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
   const sym = createNamedTypeSymbol(props.name, "interface", {
     refkeys: props.refkey,
@@ -36,6 +61,7 @@ export function InterfaceDeclaration(props: InterfaceDeclarationProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       <Scope value={namedTypeScope}>
         interface <Name />
         {props.templateParameters && (

--- a/packages/typespec/src/components/model/model-declaration.test.tsx
+++ b/packages/typespec/src/components/model/model-declaration.test.tsx
@@ -22,11 +22,9 @@ it("renders an empty model", () => {
         <ModelDeclaration name="Foo" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo {}
-    `,
-  });
+    `);
 });
 
 it("renders a model with properties", () => {
@@ -41,14 +39,12 @@ it("renders a model with properties", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo {
         name: string;
         age?: int32;
       }
-    `,
-  });
+    `);
 });
 
 it("renders a model with 'extends'", () => {
@@ -58,11 +54,9 @@ it("renders a model with 'extends'", () => {
         <ModelDeclaration name="Bar" extends="Foo" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Bar extends Foo {}
-    `,
-  });
+    `);
 });
 
 it("renders a model with 'extends' and properties", () => {
@@ -74,13 +68,11 @@ it("renders a model with 'extends' and properties", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Bar extends Foo {
         extra: boolean
       }
-    `,
-  });
+    `);
 });
 
 it("renders a model with 'is'", () => {
@@ -90,11 +82,9 @@ it("renders a model with 'is'", () => {
         <ModelDeclaration name="MyString" is="string" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model MyString is string
-    `,
-  });
+    `);
 });
 
 it("throws if 'is' and 'extends' are both provided", () => {
@@ -146,11 +136,9 @@ it("applies the model name policy", () => {
         <ModelDeclaration name="model" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model \`model\` {}
-    `,
-  });
+    `);
 });
 
 it("applies the model-property name policy", () => {
@@ -162,13 +150,11 @@ it("applies the model-property name policy", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo {
         \`model\`: string
       }
-    `,
-  });
+    `);
 });
 
 it("does not deconflict model names across namespaces", () => {
@@ -185,8 +171,7 @@ it("does not deconflict model names across namespaces", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A {
         model Foo {}
       }
@@ -194,8 +179,7 @@ it("does not deconflict model names across namespaces", () => {
       namespace B {
         model Foo {}
       }
-    `,
-  });
+    `);
 });
 
 it("deconflicts duplicate model names within the same namespace", () => {
@@ -210,14 +194,12 @@ it("deconflicts duplicate model names within the same namespace", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
       model Foo {};
       model Foo_2 {};
-    `,
-  });
+    `);
 });
 
 it("renders a model with template parameters", () => {
@@ -227,11 +209,9 @@ it("renders a model with template parameters", () => {
         <ModelDeclaration name="Container" templateParameters={["T"]} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Container<T> {}
-    `,
-  });
+    `);
 });
 
 it("renders a model with constrained template parameters", () => {
@@ -244,11 +224,9 @@ it("renders a model with constrained template parameters", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Wrapper<T extends BaseModel> {}
-    `,
-  });
+    `);
 });
 
 it("resolves template parameter references within the model", () => {
@@ -264,13 +242,11 @@ it("resolves template parameter references within the model", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Container<T> {
         value: T
       }
-    `,
-  });
+    `);
 });
 
 it("does not resolve template parameter references outside the model", () => {
@@ -305,12 +281,10 @@ it("resolves a model reference from another declaration", () => {
         </StatementList>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo {};
       model Bar extends Foo {};
-    `,
-  });
+    `);
 });
 
 it("resolves a model property reference", () => {
@@ -325,14 +299,12 @@ it("resolves a model property reference", () => {
         <Reference refkey={propKey} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo {
         id: string
       }
       id
-    `,
-  });
+    `);
 });
 
 it("renders a model expression as a property type", () => {
@@ -351,15 +323,13 @@ it("renders a model expression as a property type", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo {
         nested: {
           x: int32
         }
       }
-    `,
-  });
+    `);
 });
 
 it("renders a model expression as 'extends'", () => {
@@ -376,13 +346,11 @@ it("renders a model expression as 'extends'", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo extends {
         id: string
       } {}
-    `,
-  });
+    `);
 });
 
 it("renders a model expression as 'is'", () => {
@@ -399,13 +367,11 @@ it("renders a model expression as 'is'", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Foo is {
         id: string
       }
-    `,
-  });
+    `);
 });
 
 it("renders a model with decorators", () => {
@@ -431,16 +397,14 @@ it("renders a model with decorators", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       @doc("A pet model")
       @tag("pets")
       model Pet {
         @doc("The pet name")
         name: string
       }
-    `,
-  });
+    `);
 });
 
 it("renders a model with a doc comment", () => {
@@ -452,16 +416,14 @@ it("renders a model with a doc comment", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * A pet in the store
        */
       model Pet {
         name: string
       }
-    `,
-  });
+    `);
 });
 
 it("renders a model property with a doc comment", () => {
@@ -473,16 +435,14 @@ it("renders a model property with a doc comment", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       model Pet {
         /**
          * The pet name
          */
         name: string
       }
-    `,
-  });
+    `);
 });
 
 it("renders a model with doc and decorators", () => {
@@ -500,8 +460,7 @@ it("renders a model with doc and decorators", () => {
         </ModelDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * A pet in the store
        */
@@ -509,6 +468,5 @@ it("renders a model with doc and decorators", () => {
       model Pet {
         name: string
       }
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/model/model-declaration.test.tsx
+++ b/packages/typespec/src/components/model/model-declaration.test.tsx
@@ -442,3 +442,73 @@ it("renders a model with decorators", () => {
     `,
   });
 });
+
+it("renders a model with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Pet" doc="A pet in the store">
+          <ModelProperty name="name" type="string" />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * A pet in the store
+       */
+      model Pet {
+        name: string
+      }
+    `,
+  });
+});
+
+it("renders a model property with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Pet">
+          <ModelProperty name="name" type="string" doc="The pet name" />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      model Pet {
+        /**
+         * The pet name
+         */
+        name: string
+      }
+    `,
+  });
+});
+
+it("renders a model with doc and decorators", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="Pet"
+          doc="A pet in the store"
+          decorators={
+            <DecoratorApplication decorator="tag" args={['"pets"']} />
+          }
+        >
+          <ModelProperty name="name" type="string" />
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * A pet in the store
+       */
+      @tag("pets")
+      model Pet {
+        name: string
+      }
+    `,
+  });
+});

--- a/packages/typespec/src/components/model/model-declaration.tsx
+++ b/packages/typespec/src/components/model/model-declaration.tsx
@@ -12,21 +12,50 @@ import { useTypeSpecNamePolicy } from "../../name-policy.js";
 import { NamedTypeScope } from "../../scopes/named-type.js";
 import { NamespaceScope } from "../../scopes/namespace.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 import {
   TemplateParameterDescriptor,
   TemplateParameters,
 } from "../template-parameters/template-parameters.jsx";
 
 export interface ModelDeclarationProps {
+  /** The model name. */
   name: string | Namekey;
+  /** Refkey for referencing this model from other declarations. */
   refkey?: Refkey;
+  /** Template parameters for the model. */
   templateParameters?: (string | TemplateParameterDescriptor)[];
+  /** The base model this model extends. */
   extends?: Children;
+  /** The model this declaration aliases via `is`. */
   is?: Children;
+  /** Doc comment rendered as `/** ... *\/` above the declaration. */
+  doc?: Children;
+  /** Decorators to apply to the model. */
   decorators?: Children;
+  /** Model body (properties, spread expressions, etc.). */
   children?: Children;
 }
 
+/**
+ * A TypeSpec model declaration.
+ *
+ * @example
+ * ```tsx
+ * <ModelDeclaration name="Pet" doc="A pet in the store">
+ *   <StatementList>
+ *     <ModelProperty name="name" type="string" />
+ *   </StatementList>
+ * </ModelDeclaration>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** A pet in the store *\/
+ * model Pet {
+ *   name: string;
+ * }
+ * ```
+ */
 export function ModelDeclaration(props: ModelDeclarationProps) {
   if (props.is && (props.extends || props.children)) {
     throw new Error(
@@ -44,6 +73,7 @@ export function ModelDeclaration(props: ModelDeclarationProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Scope value={namedTypeScope}>
         model <Name />

--- a/packages/typespec/src/components/model/model-property.tsx
+++ b/packages/typespec/src/components/model/model-property.tsx
@@ -1,14 +1,39 @@
 import { Children, Declaration, Name, Namekey, Refkey } from "@alloy-js/core";
 import { createModelPropertySymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 
 export interface ModelPropertyProps {
   name: string | Namekey;
   refkey?: Refkey;
   type: Children;
   optional?: boolean;
+  /** Doc comment rendered as `/** ... *\/` above the property. */
+  doc?: Children;
+  /** Decorators to apply to the property. */
   decorators?: Children;
 }
 
+/**
+ * A TypeSpec model property.
+ *
+ * @example
+ * ```tsx
+ * <ModelDeclaration name="Dog">
+ *   <StatementList>
+ *     <ModelProperty name="name" type="string" doc="The dog's name" />
+ *     <ModelProperty name="age" type="uint8" optional default="0" />
+ *   </StatementList>
+ * </ModelDeclaration>
+ * ```
+ * This will produce:
+ * ```typespec
+ * model Dog {
+ *   /** The dog's name *\/
+ *   name: string;
+ *   age?: uint8 = 0;
+ * }
+ * ```
+ */
 export function ModelProperty(props: ModelPropertyProps) {
   const sym = createModelPropertySymbol(props.name, {
     refkeys: props.refkey,
@@ -16,6 +41,7 @@ export function ModelProperty(props: ModelPropertyProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Name />
       {props.optional ? "?" : ""}: {props.type}

--- a/packages/typespec/src/components/operation/operation-declaration.test.tsx
+++ b/packages/typespec/src/components/operation/operation-declaration.test.tsx
@@ -22,12 +22,10 @@ it("renders an operation with no parameters", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op ping(): void`,
-  });
+      op ping(): void`);
 });
 
 it("renders an operation with parameters and return type", () => {
@@ -43,12 +41,10 @@ it("renders an operation with parameters and return type", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op getPet(name: string): Pet`,
-  });
+      op getPet(name: string): Pet`);
 });
 
 it("renders an operation with 'is'", () => {
@@ -60,12 +56,10 @@ it("renders an operation with 'is'", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op deletePet is Delete`,
-  });
+      op deletePet is Delete`);
 });
 
 it("throws if both 'is' and 'parameters' are provided", () => {
@@ -103,12 +97,10 @@ it("applies the operation name policy", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op \`model\`(): void`,
-  });
+      op \`model\`(): void`);
 });
 
 it("deconflicts duplicate operation names within the same namespace", () => {
@@ -123,13 +115,11 @@ it("deconflicts duplicate operation names within the same namespace", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
       op ping(): void;
-      op ping_2(): void;`,
-  });
+      op ping_2(): void;`);
 });
 
 it("renders an operation with multiple parameters", () => {
@@ -148,12 +138,10 @@ it("renders an operation with multiple parameters", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op createPet(name: string, age: int32): Pet`,
-  });
+      op createPet(name: string, age: int32): Pet`);
 });
 
 it("renders an operation in multiple lines if parameters exceed line length limit", () => {
@@ -172,15 +160,13 @@ it("renders an operation in multiple lines if parameters exceed line length limi
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
       op createPet(
         name: string,
         age: int32
-      ): Pet`,
-  });
+      ): Pet`);
 });
 
 it("renders an operation with an optional parameter", () => {
@@ -196,12 +182,10 @@ it("renders an operation with an optional parameter", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op listPets(filter?: string): Pet[]`,
-  });
+      op listPets(filter?: string): Pet[]`);
 });
 
 it("renders an operation with template parameters", () => {
@@ -218,12 +202,10 @@ it("renders an operation with template parameters", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op ReadResource<T>(id: string): T`,
-  });
+      op ReadResource<T>(id: string): T`);
 });
 
 it("renders an operation with constrained template parameters", () => {
@@ -242,12 +224,10 @@ it("renders an operation with constrained template parameters", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op ReadResource<T extends BaseModel = DefaultModel>(id: string): T`,
-  });
+      op ReadResource<T extends BaseModel = DefaultModel>(id: string): T`);
 });
 
 it("resolves template parameter references within the operation", () => {
@@ -265,12 +245,10 @@ it("resolves template parameter references within the operation", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      op ReadResource<T>(id: string): T`,
-  });
+      op ReadResource<T>(id: string): T`);
 });
 
 it("does not resolve template parameter references outside the operation", () => {
@@ -312,13 +290,11 @@ it("renders an operation with decorators", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       @doc("Get a pet")
       @tag("pets")
       op getPet(id: string): Pet
-    `,
-  });
+    `);
 });
 
 it("renders an operation with a doc comment", () => {
@@ -333,12 +309,10 @@ it("renders an operation with a doc comment", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * Get a pet by ID
        */
       op getPet(id: string): Pet
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/operation/operation-declaration.test.tsx
+++ b/packages/typespec/src/components/operation/operation-declaration.test.tsx
@@ -320,3 +320,25 @@ it("renders an operation with decorators", () => {
     `,
   });
 });
+
+it("renders an operation with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <OperationDeclaration
+          name="getPet"
+          doc="Get a pet by ID"
+          parameters={[{ name: "id", type: "string" }]}
+          returnType="Pet"
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * Get a pet by ID
+       */
+      op getPet(id: string): Pet
+    `,
+  });
+});

--- a/packages/typespec/src/components/operation/operation-declaration.tsx
+++ b/packages/typespec/src/components/operation/operation-declaration.tsx
@@ -10,6 +10,7 @@ import {
 import { useTypeSpecNamePolicy } from "../../name-policy.js";
 import { NamedTypeScope } from "../../scopes/named-type.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 import {
   TemplateParameterDescriptor,
   TemplateParameters,
@@ -19,15 +20,42 @@ import { type ParameterDescriptor, Parameters } from "./parameters.jsx";
 export type { ParameterDescriptor } from "./parameters.jsx";
 
 export interface OperationDeclarationProps {
+  /** The operation name. */
   name: string | Namekey;
+  /** Refkey for referencing this operation from other declarations. */
   refkey?: Refkey;
+  /** Template parameters for the operation. */
   templateParameters?: (string | TemplateParameterDescriptor)[];
+  /** Operation parameters. */
   parameters?: ParameterDescriptor[];
+  /** The return type of the operation. */
   returnType?: Children;
+  /** The operation this declaration aliases via `is`. */
   is?: Children;
+  /** Doc comment rendered as `/** ... *\/` above the declaration. */
+  doc?: Children;
+  /** Decorators to apply to the operation. */
   decorators?: Children;
 }
 
+/**
+ * A TypeSpec operation declaration.
+ *
+ * @example
+ * ```tsx
+ * <OperationDeclaration
+ *   name="getPet"
+ *   doc="Get a pet by ID"
+ *   parameters={[{ name: "id", type: "string" }]}
+ *   returnType="Pet"
+ * />
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** Get a pet by ID *\/
+ * op getPet(id: string): Pet
+ * ```
+ */
 export function OperationDeclaration(props: OperationDeclarationProps) {
   if (props.is && (props.parameters || props.returnType)) {
     throw new Error(
@@ -48,6 +76,7 @@ export function OperationDeclaration(props: OperationDeclarationProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Scope value={namedTypeScope}>
         {!isInsideInterface && <>op </>}

--- a/packages/typespec/src/components/scalar-declaration/scalar-declaration.test.tsx
+++ b/packages/typespec/src/components/scalar-declaration/scalar-declaration.test.tsx
@@ -20,11 +20,9 @@ it("renders a scalar", () => {
         <ScalarDeclaration name="Foo" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       scalar Foo
-    `,
-  });
+    `);
 });
 
 it("renders a scalar with 'is'", () => {
@@ -34,11 +32,9 @@ it("renders a scalar with 'is'", () => {
         <ScalarDeclaration name="Foo" is="string" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       scalar Foo is string
-    `,
-  });
+    `);
 });
 
 it("renders a scalar with 'extends'", () => {
@@ -48,11 +44,9 @@ it("renders a scalar with 'extends'", () => {
         <ScalarDeclaration name="Foo" extends="Bar" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       scalar Foo extends Bar
-    `,
-  });
+    `);
 });
 
 it("throws if both 'is' and 'extends' are provided", () => {
@@ -82,11 +76,9 @@ it("applies the scalar name policy", () => {
         <ScalarDeclaration name="model" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       scalar \`model\`
-    `,
-  });
+    `);
 });
 
 it("does not deconflict names across namespaces", () => {
@@ -103,16 +95,14 @@ it("does not deconflict names across namespaces", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A {
         scalar Foo
       }
 
       namespace B {
         scalar Foo
-      }`,
-  });
+      }`);
 });
 
 it("deconflicts duplicate names within the same namespace", () => {
@@ -127,13 +117,11 @@ it("deconflicts duplicate names within the same namespace", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
       scalar Foo;
-      scalar Foo_2;`,
-  });
+      scalar Foo_2;`);
 });
 
 it("renders a scalar with template parameters", () => {
@@ -145,12 +133,10 @@ it("renders a scalar with template parameters", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      scalar Unreal<Type>`,
-  });
+      scalar Unreal<Type>`);
 });
 
 it("renders a scalar with constrained template parameters", () => {
@@ -165,12 +151,10 @@ it("renders a scalar with constrained template parameters", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      scalar Unreal<Type extends string>`,
-  });
+      scalar Unreal<Type extends string>`);
 });
 
 it("resolves template parameter references within the scalar", () => {
@@ -187,12 +171,10 @@ it("resolves template parameter references within the scalar", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
-      scalar Wrapped<T> extends T`,
-  });
+      scalar Wrapped<T> extends T`);
 });
 
 it("does not resolve template parameter references outside the scalar", () => {
@@ -228,12 +210,10 @@ it("renders a scalar with decorators", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       @doc("Custom string")
       scalar myString extends string
-    `,
-  });
+    `);
 });
 
 it("renders a scalar with a doc comment", () => {
@@ -243,12 +223,10 @@ it("renders a scalar with a doc comment", () => {
         <ScalarDeclaration name="ipv4" extends="string" doc="An IPv4 address" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * An IPv4 address
        */
       scalar ipv4 extends string
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/scalar-declaration/scalar-declaration.test.tsx
+++ b/packages/typespec/src/components/scalar-declaration/scalar-declaration.test.tsx
@@ -235,3 +235,20 @@ it("renders a scalar with decorators", () => {
     `,
   });
 });
+
+it("renders a scalar with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ScalarDeclaration name="ipv4" extends="string" doc="An IPv4 address" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * An IPv4 address
+       */
+      scalar ipv4 extends string
+    `,
+  });
+});

--- a/packages/typespec/src/components/scalar-declaration/scalar-declaration.tsx
+++ b/packages/typespec/src/components/scalar-declaration/scalar-declaration.tsx
@@ -11,20 +11,42 @@ import { useTypeSpecNamePolicy } from "../../name-policy.js";
 import { NamedTypeScope } from "../../scopes/named-type.js";
 import { NamespaceScope } from "../../scopes/namespace.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 import {
   TemplateParameterDescriptor,
   TemplateParameters,
 } from "../template-parameters/template-parameters.jsx";
 
 export interface ScalarDeclarationProps {
+  /** The scalar name. */
   name: string | Namekey;
+  /** Refkey for referencing this scalar from other declarations. */
   refkey?: Refkey;
+  /** Template parameters for the scalar. */
   templateParameters?: (string | TemplateParameterDescriptor)[];
+  /** The scalar this declaration aliases via `is`. */
   is?: Children;
+  /** The base scalar this scalar extends. */
   extends?: Children;
+  /** Doc comment rendered as `/** ... *\/` above the declaration. */
+  doc?: Children;
+  /** Decorators to apply to the scalar. */
   decorators?: Children;
 }
 
+/**
+ * A TypeSpec scalar declaration.
+ *
+ * @example
+ * ```tsx
+ * <ScalarDeclaration name="ipv4" extends="string" doc="An IPv4 address" />
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** An IPv4 address *\/
+ * scalar ipv4 extends string
+ * ```
+ */
 export function ScalarDeclaration(props: ScalarDeclarationProps) {
   const sym = createNamedTypeSymbol(props.name, "scalar", {
     refkeys: props.refkey,
@@ -41,6 +63,7 @@ export function ScalarDeclaration(props: ScalarDeclarationProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Scope value={namedTypeScope}>
         scalar <Name />

--- a/packages/typespec/src/components/union/union-declaration.test.tsx
+++ b/packages/typespec/src/components/union/union-declaration.test.tsx
@@ -293,3 +293,31 @@ it("renders a union with decorators", () => {
     `,
   });
 });
+
+it("renders a union with a doc comment", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <UnionDeclaration name="Pet" doc="A pet type">
+          <List comma hardline enderPunctuation>
+            <UnionVariant name="cat" type="Cat" doc="A cat" />
+            <UnionVariant name="dog" type="Dog" />
+          </List>
+        </UnionDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      /**
+       * A pet type
+       */
+      union Pet {
+        /**
+         * A cat
+         */
+        cat: Cat,
+        dog: Dog,
+      }
+    `,
+  });
+});

--- a/packages/typespec/src/components/union/union-declaration.test.tsx
+++ b/packages/typespec/src/components/union/union-declaration.test.tsx
@@ -25,14 +25,12 @@ it("renders a union with anonymous variants", () => {
         </UnionDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union StringOrInt {
         string,
         int32,
       }
-    `,
-  });
+    `);
 });
 
 it("renders a union with named variants", () => {
@@ -47,14 +45,12 @@ it("renders a union with named variants", () => {
         </UnionDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union Result {
         success: string,
         failure: int32,
       }
-    `,
-  });
+    `);
 });
 
 it("renders a union with mixed anonymous and named variants", () => {
@@ -69,14 +65,12 @@ it("renders a union with mixed anonymous and named variants", () => {
         </UnionDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union Mixed {
         string,
         nothing: null,
       }
-    `,
-  });
+    `);
 });
 
 it("renders an empty union", () => {
@@ -86,11 +80,9 @@ it("renders an empty union", () => {
         <UnionDeclaration name="Empty" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union Empty {}
-    `,
-  });
+    `);
 });
 
 it("renders a union with template parameters", () => {
@@ -126,14 +118,12 @@ it("resolves template parameter references within the union", () => {
         </UnionDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union Maybe<T> {
         value: T,
         null,
       }
-    `,
-  });
+    `);
 });
 
 it("does not resolve template parameter references outside the union", () => {
@@ -161,11 +151,9 @@ it("applies the union name policy", () => {
         <UnionDeclaration name="model" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union \`model\` {}
-    `,
-  });
+    `);
 });
 
 it("does not deconflict union names across namespaces", () => {
@@ -182,8 +170,7 @@ it("does not deconflict union names across namespaces", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A {
         union Result {}
       }
@@ -191,8 +178,7 @@ it("does not deconflict union names across namespaces", () => {
       namespace B {
         union Result {}
       }
-    `,
-  });
+    `);
 });
 
 it("deconflicts duplicate union names within the same namespace", () => {
@@ -207,14 +193,12 @@ it("deconflicts duplicate union names within the same namespace", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       namespace A;
 
       union Result {};
       union Result_2 {};
-    `,
-  });
+    `);
 });
 
 it("resolves a union reference from another declaration", () => {
@@ -229,12 +213,10 @@ it("resolves a union reference from another declaration", () => {
         <Reference refkey={resultKey} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union Result {};
       Result
-    `,
-  });
+    `);
 });
 
 it("resolves a named union variant reference", () => {
@@ -249,14 +231,12 @@ it("resolves a named union variant reference", () => {
         <Reference refkey={successKey} />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       union Result {
         success: string
       }
       success
-    `,
-  });
+    `);
 });
 
 it("renders a union with decorators", () => {
@@ -282,16 +262,14 @@ it("renders a union with decorators", () => {
         </UnionDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       @doc("A pet type")
       union Pet {
         @doc("A cat")
         cat: Cat,
         dog: Dog,
       }
-    `,
-  });
+    `);
 });
 
 it("renders a union with a doc comment", () => {
@@ -306,8 +284,7 @@ it("renders a union with a doc comment", () => {
         </UnionDeclaration>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       /**
        * A pet type
        */
@@ -318,6 +295,5 @@ it("renders a union with a doc comment", () => {
         cat: Cat,
         dog: Dog,
       }
-    `,
-  });
+    `);
 });

--- a/packages/typespec/src/components/union/union-declaration.tsx
+++ b/packages/typespec/src/components/union/union-declaration.tsx
@@ -12,19 +12,48 @@ import { useTypeSpecNamePolicy } from "../../name-policy.js";
 import { NamedTypeScope } from "../../scopes/named-type.js";
 import { NamespaceScope } from "../../scopes/namespace.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 import {
   TemplateParameterDescriptor,
   TemplateParameters,
 } from "../template-parameters/template-parameters.jsx";
 
 export interface UnionDeclarationProps {
+  /** The union name. */
   name: string | Namekey;
+  /** Refkey for referencing this union from other declarations. */
   refkey?: Refkey;
+  /** Template parameters for the union. */
   templateParameters?: (string | TemplateParameterDescriptor)[];
+  /** Doc comment rendered as `/** ... *\/` above the declaration. */
+  doc?: Children;
+  /** Decorators to apply to the union. */
   decorators?: Children;
+  /** Union body (variants). */
   children?: Children;
 }
 
+/**
+ * A TypeSpec union declaration.
+ *
+ * @example
+ * ```tsx
+ * <UnionDeclaration name="Pet" doc="A pet type">
+ *   <List comma hardline enderPunctuation>
+ *     <UnionVariant name="cat" type="Cat" />
+ *     <UnionVariant name="dog" type="Dog" />
+ *   </List>
+ * </UnionDeclaration>
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** A pet type *\/
+ * union Pet {
+ *   cat: Cat,
+ *   dog: Dog,
+ * }
+ * ```
+ */
 export function UnionDeclaration(props: UnionDeclarationProps) {
   const sym = createNamedTypeSymbol(props.name, "union", {
     refkeys: props.refkey,
@@ -36,6 +65,7 @@ export function UnionDeclaration(props: UnionDeclarationProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Scope value={namedTypeScope}>
         union <Name />

--- a/packages/typespec/src/components/union/union-variant.tsx
+++ b/packages/typespec/src/components/union/union-variant.tsx
@@ -1,13 +1,33 @@
 import { Children, Declaration, Name, Namekey, Refkey } from "@alloy-js/core";
 import { createUnionVariantSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 
 export interface UnionVariantProps {
+  /** The variant type. */
   type: Children;
+  /** Optional variant name. When omitted, renders just the type. */
   name?: string | Namekey;
+  /** Refkey for referencing this variant from other declarations. */
   refkey?: Refkey;
+  /** Doc comment rendered as `/** ... *\/` above the variant. */
+  doc?: Children;
+  /** Decorators to apply to the variant. */
   decorators?: Children;
 }
 
+/**
+ * A TypeSpec union variant.
+ *
+ * @example
+ * ```tsx
+ * <UnionVariant name="cat" type="Cat" doc="A cat variant" />
+ * ```
+ * This will produce:
+ * ```typespec
+ * /** A cat variant *\/
+ * cat: Cat
+ * ```
+ */
 export function UnionVariant(props: UnionVariantProps) {
   if (props.name === undefined) {
     return <>{props.type}</>;
@@ -19,6 +39,7 @@ export function UnionVariant(props: UnionVariantProps) {
 
   return (
     <Declaration symbol={sym}>
+      <DocWhen doc={props.doc} />
       {props.decorators}
       <Name />: {props.type}
     </Declaration>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,40 @@ importers:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.20.3)(yaml@2.8.0)
 
+  packages/typespec:
+    dependencies:
+      '@alloy-js/core':
+        specifier: workspace:~
+        version: link:../core
+      change-case:
+        specifier: 'catalog:'
+        version: 5.4.4
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
+    devDependencies:
+      '@alloy-js/cli':
+        specifier: workspace:~
+        version: link:../cli
+      '@alloy-js/rollup-plugin':
+        specifier: workspace:~
+        version: link:../rollup-plugin
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.52.9(@types/node@24.10.9)
+      '@rollup/plugin-typescript':
+        specifier: 'catalog:'
+        version: 12.1.4(rollup@4.46.2)(tslib@2.8.1)(typescript@5.9.3)
+      concurrently:
+        specifier: 'catalog:'
+        version: 9.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.20.3)(yaml@2.8.0)
+
   samples/basic-project:
     dependencies:
       '@alloy-js/core':
@@ -8484,7 +8518,7 @@ snapshots:
 
   '@rollup/plugin-typescript@12.1.4(rollup@4.46.2)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.46.2)
       resolve: 1.22.10
       typescript: 5.9.3
     optionalDependencies:


### PR DESCRIPTION
Add DocComment, DocParam, DocReturns, DocTemplate, and DocWhen components for rendering TypeSpec documentation comments (`/** ... */`).

Add a `doc?: Children` prop to all 10 declaration components (ModelDeclaration, ModelProperty, EnumDeclaration, EnumMember, UnionDeclaration, UnionVariant, InterfaceDeclaration, OperationDeclaration, ScalarDeclaration, AliasDeclaration), rendered via `<DocWhen>` following the same pattern used in the C# package.