### PR TITLE
feat(typespec): add const declarations and value expressions

### DIFF
--- a/packages/typespec/src/components/const/const-declaration.test.tsx
+++ b/packages/typespec/src/components/const/const-declaration.test.tsx
@@ -17,11 +17,9 @@ it("renders a const declaration with a value", () => {
         <ConstDeclaration name="maxAge" value="255" />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
+  ).toRenderTo(`
       const maxAge = 255
-    `,
-  });
+  `);
 });
 
 it("renders a const declaration with a type annotation", () => {

--- a/packages/typespec/src/components/const/const-declaration.test.tsx
+++ b/packages/typespec/src/components/const/const-declaration.test.tsx
@@ -78,7 +78,7 @@ it("renders a const with an object value expression", () => {
   expect(
     <Output namePolicy={createTypeSpecNamePolicy()}>
       <SourceFile path="main.tsp">
-        <ConstDeclaration name="origin" value={'#{ x: 0, y: 0 }'} />
+        <ConstDeclaration name="origin" value={"#{ x: 0, y: 0 }"} />
       </SourceFile>
     </Output>,
   ).toRenderTo({

--- a/packages/typespec/src/components/const/const-declaration.test.tsx
+++ b/packages/typespec/src/components/const/const-declaration.test.tsx
@@ -1,0 +1,89 @@
+import { Output, refkey, StatementList } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { Reference } from "../reference/reference.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { ConstDeclaration } from "./const-declaration.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders a const declaration with a value", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ConstDeclaration name="maxAge" value="255" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      const maxAge = 255
+    `,
+  });
+});
+
+it("renders a const declaration with a type annotation", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ConstDeclaration name="maxAge" type="uint8" value="255" />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      const maxAge: uint8 = 255
+    `,
+  });
+});
+
+it("renders a const declaration with a string value", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ConstDeclaration name="greeting" value={`"hello"`} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      const greeting = "hello"
+    `,
+  });
+});
+
+it("resolves a const reference from another declaration", () => {
+  const maxAgeKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <StatementList>
+          <ConstDeclaration name="maxAge" value="255" refkey={maxAgeKey} />
+          <ConstDeclaration
+            name="limit"
+            value={<Reference refkey={maxAgeKey} />}
+          />
+        </StatementList>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      const maxAge = 255;
+      const limit = maxAge;
+    `,
+  });
+});
+
+it("renders a const with an object value expression", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ConstDeclaration name="origin" value={'#{ x: 0, y: 0 }'} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      const origin = #{ x: 0, y: 0 }
+    `,
+  });
+});

--- a/packages/typespec/src/components/const/const-declaration.tsx
+++ b/packages/typespec/src/components/const/const-declaration.tsx
@@ -1,0 +1,56 @@
+import {
+  Children,
+  Declaration,
+  Name,
+  Namekey,
+  Refkey,
+  Scope,
+  useScope,
+} from "@alloy-js/core";
+import { useTypeSpecNamePolicy } from "../../name-policy.js";
+import { NamedTypeScope } from "../../scopes/named-type.js";
+import { NamespaceScope } from "../../scopes/namespace.js";
+import { createNamedTypeSymbol } from "../../symbols/factories.js";
+
+export interface ConstDeclarationProps {
+  /** The const name. */
+  name: string | Namekey;
+  /** Refkey for referencing this const from other declarations. */
+  refkey?: Refkey;
+  /** Optional type annotation. */
+  type?: Children;
+  /** The value expression. */
+  value: Children;
+}
+
+/**
+ * A TypeSpec const declaration.
+ *
+ * @example
+ * ```tsx
+ * <ConstDeclaration name="maxAge" type="uint8" value="255" />
+ * ```
+ * This will produce:
+ * ```typespec
+ * const maxAge: uint8 = 255
+ * ```
+ */
+export function ConstDeclaration(props: ConstDeclarationProps) {
+  const sym = createNamedTypeSymbol(props.name, "const", {
+    refkeys: props.refkey,
+    namePolicy: useTypeSpecNamePolicy().for("const"),
+  });
+
+  const parentScope = useScope() as NamespaceScope;
+  const namedTypeScope = new NamedTypeScope(sym, parentScope);
+
+  return (
+    <Declaration symbol={sym}>
+      <Scope value={namedTypeScope}>
+        const <Name />
+        {props.type && <>: {props.type}</>}
+        {" "}= {props.value}
+      </Scope>
+    </Declaration>
+  );
+}

--- a/packages/typespec/src/components/const/const-declaration.tsx
+++ b/packages/typespec/src/components/const/const-declaration.tsx
@@ -48,8 +48,7 @@ export function ConstDeclaration(props: ConstDeclarationProps) {
     <Declaration symbol={sym}>
       <Scope value={namedTypeScope}>
         const <Name />
-        {props.type && <>: {props.type}</>}
-        {" "}= {props.value}
+        {props.type && <>: {props.type}</>} = {props.value}
       </Scope>
     </Declaration>
   );

--- a/packages/typespec/src/components/index.ts
+++ b/packages/typespec/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./alias/alias-declaration.jsx";
+export * from "./const/const-declaration.jsx";
 export * from "./decorator/augment-decorator.jsx";
 export * from "./decorator/decorator-application.jsx";
 export * from "./enum/enum-declaration.jsx";
@@ -14,3 +15,5 @@ export * from "./template-parameters/template-parameters.jsx";
 export * from "./union/union-declaration.jsx";
 export * from "./union/union-expression.jsx";
 export * from "./union/union-variant.jsx";
+export * from "./value/array-value.jsx";
+export * from "./value/object-value.jsx";

--- a/packages/typespec/src/components/value/array-value.test.tsx
+++ b/packages/typespec/src/components/value/array-value.test.tsx
@@ -1,0 +1,42 @@
+import { Output } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { ConstDeclaration } from "../const/const-declaration.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { ArrayValue } from "./array-value.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders an array value expression", () => {
+  expect(<ArrayValue values={['"one"', '"two"', '"three"']} />).toRenderTo(
+    '#["one", "two", "three"]',
+  );
+});
+
+it("renders an empty array value", () => {
+  expect(<ArrayValue values={[]} />).toRenderTo("#[]");
+});
+
+it("renders a single-element array value", () => {
+  expect(<ArrayValue values={['"hello"']} />).toRenderTo('#["hello"]');
+});
+
+it("renders a const with an array value", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ConstDeclaration
+          name="tags"
+          value={<ArrayValue values={['"TypeSpec"', '"JSON"']} />}
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      const tags = #["TypeSpec", "JSON"]
+    `,
+  });
+});

--- a/packages/typespec/src/components/value/array-value.tsx
+++ b/packages/typespec/src/components/value/array-value.tsx
@@ -18,5 +18,9 @@ export interface ArrayValueProps {
  * ```
  */
 export function ArrayValue(props: ArrayValueProps) {
-  return <>#[<List joiner=", ">{props.values}</List>]</>;
+  return (
+    <>
+      #[<List joiner=", ">{props.values}</List>]
+    </>
+  );
 }

--- a/packages/typespec/src/components/value/array-value.tsx
+++ b/packages/typespec/src/components/value/array-value.tsx
@@ -1,0 +1,22 @@
+import { Children, List } from "@alloy-js/core";
+
+export interface ArrayValueProps {
+  /** The array items. */
+  values: Children[];
+}
+
+/**
+ * A TypeSpec array value expression (`#[...]`).
+ *
+ * @example
+ * ```tsx
+ * <ArrayValue values={['"one"', '"two"', '"three"']} />
+ * ```
+ * This will produce:
+ * ```typespec
+ * #["one", "two", "three"]
+ * ```
+ */
+export function ArrayValue(props: ArrayValueProps) {
+  return <>#[<List joiner=", ">{props.values}</List>]</>;
+}

--- a/packages/typespec/src/components/value/object-value.test.tsx
+++ b/packages/typespec/src/components/value/object-value.test.tsx
@@ -1,0 +1,100 @@
+import { List, Output } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { ConstDeclaration } from "../const/const-declaration.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { ObjectValue, ObjectValueProperty } from "./object-value.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders an object value expression", () => {
+  expect(
+    <ObjectValue>
+      <List comma hardline enderPunctuation>
+        <ObjectValueProperty name="x" value="0" />
+        <ObjectValueProperty name="y" value="0" />
+      </List>
+    </ObjectValue>,
+  ).toRenderTo(`
+    #{
+      x: 0,
+      y: 0,
+    }
+  `);
+});
+
+it("renders an object value property", () => {
+  expect(<ObjectValueProperty name="x" value="42" />).toRenderTo("x: 42");
+});
+
+it("renders a const with an object value", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ConstDeclaration
+          name="origin"
+          value={
+            <ObjectValue>
+              <List comma hardline enderPunctuation>
+                <ObjectValueProperty name="x" value="0" />
+                <ObjectValueProperty name="y" value="0" />
+              </List>
+            </ObjectValue>
+          }
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      const origin = #{
+        x: 0,
+        y: 0,
+      }
+    `,
+  });
+});
+
+it("renders a nested object value", () => {
+  expect(
+    <ObjectValue>
+      <List comma hardline enderPunctuation>
+        <ObjectValueProperty
+          name="start"
+          value={
+            <ObjectValue>
+              <List comma hardline enderPunctuation>
+                <ObjectValueProperty name="x" value="0" />
+                <ObjectValueProperty name="y" value="0" />
+              </List>
+            </ObjectValue>
+          }
+        />
+        <ObjectValueProperty
+          name="end"
+          value={
+            <ObjectValue>
+              <List comma hardline enderPunctuation>
+                <ObjectValueProperty name="x" value="1" />
+                <ObjectValueProperty name="y" value="1" />
+              </List>
+            </ObjectValue>
+          }
+        />
+      </List>
+    </ObjectValue>,
+  ).toRenderTo(`
+    #{
+      start: #{
+        x: 0,
+        y: 0,
+      },
+      end: #{
+        x: 1,
+        y: 1,
+      },
+    }
+  `);
+});

--- a/packages/typespec/src/components/value/object-value.tsx
+++ b/packages/typespec/src/components/value/object-value.tsx
@@ -49,5 +49,9 @@ export interface ObjectValuePropertyProps {
  * ```
  */
 export function ObjectValueProperty(props: ObjectValuePropertyProps) {
-  return <>{props.name}: {props.value}</>;
+  return (
+    <>
+      {props.name}: {props.value}
+    </>
+  );
 }

--- a/packages/typespec/src/components/value/object-value.tsx
+++ b/packages/typespec/src/components/value/object-value.tsx
@@ -1,0 +1,53 @@
+import { Block, Children } from "@alloy-js/core";
+
+export interface ObjectValueProps {
+  /** The object value body (key-value pairs). */
+  children: Children;
+}
+
+/**
+ * A TypeSpec object value expression (`#{ ... }`).
+ *
+ * @example
+ * ```tsx
+ * <ObjectValue>
+ *   <List comma hardline enderPunctuation>
+ *     <ObjectValueProperty name="x" value="0" />
+ *     <ObjectValueProperty name="y" value="0" />
+ *   </List>
+ * </ObjectValue>
+ * ```
+ * This will produce:
+ * ```typespec
+ * #{
+ *   x: 0,
+ *   y: 0,
+ * }
+ * ```
+ */
+export function ObjectValue(props: ObjectValueProps) {
+  return <Block opener="#{">{props.children}</Block>;
+}
+
+export interface ObjectValuePropertyProps {
+  /** The property name. */
+  name: string;
+  /** The property value. */
+  value: Children;
+}
+
+/**
+ * A property inside an {@link ObjectValue}.
+ *
+ * @example
+ * ```tsx
+ * <ObjectValueProperty name="x" value="0" />
+ * ```
+ * This will produce:
+ * ```typespec
+ * x: 0
+ * ```
+ */
+export function ObjectValueProperty(props: ObjectValuePropertyProps) {
+  return <>{props.name}: {props.value}</>;
+}

--- a/packages/typespec/src/name-policy.ts
+++ b/packages/typespec/src/name-policy.ts
@@ -11,12 +11,14 @@ export type TypeSpecElements =
   | "namespace"
   | "operation"
   | "template"
+  | "const"
   | "union";
 
 export function createTypeSpecNamePolicy(): NamePolicy<TypeSpecElements> {
   return createNamePolicy<TypeSpecElements>((name, element) => {
     switch (element) {
       case "alias":
+      case "const":
       case "scalar":
       case "enum":
       case "interface":

--- a/packages/typespec/src/symbols/named-type.ts
+++ b/packages/typespec/src/symbols/named-type.ts
@@ -14,6 +14,7 @@ export type NamedTypeKind =
   | "alias"
   | "operation"
   | "scalar"
+  | "const"
   | "decorator";
 
 export class NamedTypeSymbol extends TypeSpecSymbol {


### PR DESCRIPTION
Add ConstDeclaration, ObjectValue, ObjectValueProperty, and ArrayValue components for TypeSpec const declarations and value expressions.

- ConstDeclaration: renders const with optional type annotation
- ObjectValue/ObjectValueProperty: renders #{ key: value } syntax
- ArrayValue: renders #[item1, item2] syntax
- Added 'const' to NamedTypeKind and name policy