### PR TITLE
fix(core): export fragment in jsx-runtime

### DIFF
--- a/packages/core/src/jsx-runtime.ts
+++ b/packages/core/src/jsx-runtime.ts
@@ -39,3 +39,5 @@ export function jsx(type: Component<any>, props: Record<string, unknown>) {
 }
 
 export const jsxs = jsx;
+
+export { Fragment } from "./runtime/fragment.js";


### PR DESCRIPTION
Export `Fragment` in `./jsx-runtime`, fixing builds without custom transform and  `"jsx": "react-jsx"`.