### PR TITLE
feat(typespec): add StringLiteral and StringTemplateExpr components

### DIFF
--- a/packages/typespec/src/components/index.ts
+++ b/packages/typespec/src/components/index.ts
@@ -13,6 +13,8 @@ export * from "./model/model-property.jsx";
 export * from "./namespace/namespace.jsx";
 export * from "./operation/operation-declaration.jsx";
 export * from "./source-file/source-file.jsx";
+export * from "./string-literal/string-literal.jsx";
+export * from "./string-literal/string-template-expr.jsx";
 export * from "./template-parameters/template-parameters.jsx";
 export * from "./union/union-declaration.jsx";
 export * from "./union/union-expression.jsx";

--- a/packages/typespec/src/components/string-literal/string-literal.test.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.test.tsx
@@ -11,13 +11,26 @@ beforeEach(() => {
   resetProgram();
 });
 
-it("renders a simple string literal", () => {
+it("renders a simple string literal via value prop", () => {
+  expect(<StringLiteral value="hello world" />).toRenderTo(`"hello world"`);
+});
+
+it("renders a simple string literal via children", () => {
   expect(<StringLiteral>hello world</StringLiteral>).toRenderTo(
     `"hello world"`,
   );
 });
 
-it("renders a multi-line string literal", () => {
+it("renders a multi-line string via value prop", () => {
+  expect(<StringLiteral value={"line one\nline two"} multiline />).toRenderTo(`
+    """
+      line one
+      line two
+      """
+  `);
+});
+
+it("renders a multi-line string via children", () => {
   expect(
     <StringLiteral multiline>
       {code`
@@ -56,13 +69,31 @@ it("renders a multi-line string template with interpolation", () => {
   `);
 });
 
+it("renders a multi-line string as an alias type", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <AliasDeclaration
+          name="Greeting"
+          type={<StringLiteral value={"line one\nline two"} multiline />}
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    alias Greeting = """
+      line one
+      line two
+      """
+  `);
+});
+
 it("renders a string literal as an alias type", () => {
   expect(
     <Output namePolicy={createTypeSpecNamePolicy()}>
       <SourceFile path="main.tsp">
         <AliasDeclaration
           name="Greeting"
-          type={<StringLiteral>hello world</StringLiteral>}
+          type={<StringLiteral value="hello world" />}
         />
       </SourceFile>
     </Output>,

--- a/packages/typespec/src/components/string-literal/string-literal.test.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.test.tsx
@@ -21,13 +21,19 @@ it("renders a simple string literal via children", () => {
   );
 });
 
-it("renders a multi-line string via value prop", () => {
-  expect(<StringLiteral value={"line one\nline two"} multiline />).toRenderTo(`
+it("auto-detects multiline when value contains newlines", () => {
+  expect(<StringLiteral value={"line one\nline two"} />).toRenderTo(`
     """
       line one
       line two
       """
   `);
+});
+
+it("emits value as-is when multiline is explicitly false", () => {
+  expect(
+    <StringLiteral value={"line one\nline two"} multiline={false} />,
+  ).toRenderTo(`"line one\nline two"`);
 });
 
 it("renders a multi-line string via children", () => {
@@ -75,7 +81,7 @@ it("renders a multi-line string as an alias type", () => {
       <SourceFile path="main.tsp">
         <AliasDeclaration
           name="Greeting"
-          type={<StringLiteral value={"line one\nline two"} multiline />}
+          type={<StringLiteral value={"line one\nline two"} />}
         />
       </SourceFile>
     </Output>,

--- a/packages/typespec/src/components/string-literal/string-literal.test.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.test.tsx
@@ -66,11 +66,9 @@ it("renders a string literal as an alias type", () => {
         />
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
-      alias Greeting = "hello world"
-    `,
-  });
+  ).toRenderTo(`
+    alias Greeting = "hello world"
+  `);
 });
 
 it("renders a StringTemplateExpr", () => {

--- a/packages/typespec/src/components/string-literal/string-literal.test.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.test.tsx
@@ -1,0 +1,78 @@
+import { code, Output } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../../contexts/program.js";
+import { createTypeSpecNamePolicy } from "../../name-policy.js";
+import { AliasDeclaration } from "../alias/alias-declaration.jsx";
+import { SourceFile } from "../source-file/source-file.jsx";
+import { StringLiteral } from "./string-literal.jsx";
+import { StringTemplateExpr } from "./string-template-expr.jsx";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("renders a simple string literal", () => {
+  expect(<StringLiteral>hello world</StringLiteral>).toRenderTo(
+    `"hello world"`,
+  );
+});
+
+it("renders a multi-line string literal", () => {
+  expect(
+    <StringLiteral multiline>
+      {code`
+        line one
+        line two
+      `}
+    </StringLiteral>,
+  ).toRenderTo(`
+    """
+      line one
+      line two
+      """
+  `);
+});
+
+it("renders a string template with interpolation", () => {
+  expect(
+    <StringLiteral>
+      hello <StringTemplateExpr>name</StringTemplateExpr>!
+    </StringLiteral>,
+  ).toRenderTo(`"hello \${name}!"`);
+});
+
+it("renders a multi-line string template with interpolation", () => {
+  expect(
+    <StringLiteral multiline>
+      hello <StringTemplateExpr>name</StringTemplateExpr>
+      <hbr />
+      goodbye
+    </StringLiteral>,
+  ).toRenderTo(`
+    """
+      hello \${name}
+      goodbye
+      """
+  `);
+});
+
+it("renders a string literal as an alias type", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <AliasDeclaration
+          name="Greeting"
+          type={<StringLiteral>hello world</StringLiteral>}
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "main.tsp": `
+      alias Greeting = "hello world"
+    `,
+  });
+});
+
+it("renders a StringTemplateExpr", () => {
+  expect(<StringTemplateExpr>expr</StringTemplateExpr>).toRenderTo(`\${expr}`);
+});

--- a/packages/typespec/src/components/string-literal/string-literal.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.tsx
@@ -61,9 +61,7 @@ export function StringLiteral(props: StringLiteralProps) {
   // When single-line, emit value as-is (even if it contains \n).
   const content =
     props.children ??
-    (isMultiline
-      ? valueToChildren(props.value ?? "")
-      : (props.value ?? ""));
+    (isMultiline ? valueToChildren(props.value ?? "") : (props.value ?? ""));
 
   if (isMultiline) {
     return (

--- a/packages/typespec/src/components/string-literal/string-literal.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.tsx
@@ -2,10 +2,17 @@ import { Children } from "@alloy-js/core";
 
 export interface StringLiteralProps {
   /**
-   * The string content. May include {@link StringTemplateExpr} children
-   * for interpolation.
+   * The string value. For multi-line strings, newlines in the value are
+   * rendered as line breaks. Use this for simple strings without interpolation.
    */
-  children: Children;
+  value?: string;
+
+  /**
+   * The string content as children. Use this for template expressions
+   * with {@link StringTemplateExpr} interpolation. If both `value` and
+   * `children` are provided, `children` takes precedence.
+   */
+  children?: Children;
 
   /**
    * Render as a triple-quoted multi-line string (`""" ... """`).
@@ -17,32 +24,25 @@ export interface StringLiteralProps {
 /**
  * A TypeSpec string literal or string template literal.
  *
- * @example Simple string
+ * @example Simple string via value prop
  * ```tsx
- * <StringLiteral>hello world</StringLiteral>
+ * <StringLiteral value="hello world" />
  * ```
  * Produces: `"hello world"`
  *
- * @example Multi-line string
+ * @example Multi-line string via value prop
  * ```tsx
- * <StringLiteral multiline>
- *   {code`
- *     This is a multi line string
- *     - opt 1
- *     - opt 2
- *   `}
- * </StringLiteral>
+ * <StringLiteral value={"line one\nline two"} multiline />
  * ```
  * Produces:
  * ```typespec
  * """
- *   This is a multi line string
- *   - opt 1
- *   - opt 2
+ *   line one
+ *   line two
  *   """
  * ```
  *
- * @example Template literal with interpolation
+ * @example Template literal with interpolation via children
  * ```tsx
  * <StringLiteral>
  *   hello <StringTemplateExpr>{refkey(greeting)}</StringTemplateExpr>!
@@ -51,13 +51,15 @@ export interface StringLiteralProps {
  * Produces: `"hello ${greeting}!"`
  */
 export function StringLiteral(props: StringLiteralProps) {
+  const content = props.children ?? valueToChildren(props.value ?? "");
+
   if (props.multiline) {
     return (
       <>
         {'"""'}
         <indent>
           <hbr />
-          {props.children}
+          {content}
           <hbr />
           {'"""'}
         </indent>
@@ -65,5 +67,20 @@ export function StringLiteral(props: StringLiteralProps) {
     );
   }
 
-  return <>"{props.children}"</>;
+  return <>"{content}"</>;
+}
+
+function valueToChildren(value: string): Children {
+  const lines = value.split("\n");
+  if (lines.length === 1) {
+    return value;
+  }
+  const result: Children[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0) {
+      result.push(<hbr />);
+    }
+    result.push(lines[i]);
+  }
+  return result;
 }

--- a/packages/typespec/src/components/string-literal/string-literal.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.tsx
@@ -16,7 +16,9 @@ export interface StringLiteralProps {
 
   /**
    * Render as a triple-quoted multi-line string (`""" ... """`).
-   * When true, content is indented and wrapped in triple-quote delimiters.
+   * When omitted, auto-detects based on the `value` prop: if the value
+   * contains newlines, multiline is used automatically since TypeSpec has
+   * no `\n` escape sequences. Set explicitly to override auto-detection.
    */
   multiline?: boolean;
 }
@@ -51,9 +53,19 @@ export interface StringLiteralProps {
  * Produces: `"hello ${greeting}!"`
  */
 export function StringLiteral(props: StringLiteralProps) {
-  const content = props.children ?? valueToChildren(props.value ?? "");
+  const isMultiline =
+    props.multiline ??
+    (props.value !== undefined && props.value.includes("\n"));
 
-  if (props.multiline) {
+  // When multiline, split value on \n into hbr-separated lines.
+  // When single-line, emit value as-is (even if it contains \n).
+  const content =
+    props.children ??
+    (isMultiline
+      ? valueToChildren(props.value ?? "")
+      : (props.value ?? ""));
+
+  if (isMultiline) {
     return (
       <>
         {'"""'}

--- a/packages/typespec/src/components/string-literal/string-literal.tsx
+++ b/packages/typespec/src/components/string-literal/string-literal.tsx
@@ -1,0 +1,69 @@
+import { Children } from "@alloy-js/core";
+
+export interface StringLiteralProps {
+  /**
+   * The string content. May include {@link StringTemplateExpr} children
+   * for interpolation.
+   */
+  children: Children;
+
+  /**
+   * Render as a triple-quoted multi-line string (`""" ... """`).
+   * When true, content is indented and wrapped in triple-quote delimiters.
+   */
+  multiline?: boolean;
+}
+
+/**
+ * A TypeSpec string literal or string template literal.
+ *
+ * @example Simple string
+ * ```tsx
+ * <StringLiteral>hello world</StringLiteral>
+ * ```
+ * Produces: `"hello world"`
+ *
+ * @example Multi-line string
+ * ```tsx
+ * <StringLiteral multiline>
+ *   {code`
+ *     This is a multi line string
+ *     - opt 1
+ *     - opt 2
+ *   `}
+ * </StringLiteral>
+ * ```
+ * Produces:
+ * ```typespec
+ * """
+ *   This is a multi line string
+ *   - opt 1
+ *   - opt 2
+ *   """
+ * ```
+ *
+ * @example Template literal with interpolation
+ * ```tsx
+ * <StringLiteral>
+ *   hello <StringTemplateExpr>{refkey(greeting)}</StringTemplateExpr>!
+ * </StringLiteral>
+ * ```
+ * Produces: `"hello ${greeting}!"`
+ */
+export function StringLiteral(props: StringLiteralProps) {
+  if (props.multiline) {
+    return (
+      <>
+        {'"""'}
+        <indent>
+          <hbr />
+          {props.children}
+          <hbr />
+          {'"""'}
+        </indent>
+      </>
+    );
+  }
+
+  return <>"{props.children}"</>;
+}

--- a/packages/typespec/src/components/string-literal/string-template-expr.tsx
+++ b/packages/typespec/src/components/string-literal/string-template-expr.tsx
@@ -1,0 +1,28 @@
+import { Children } from "@alloy-js/core";
+
+export interface StringTemplateExprProps {
+  /** The expression to interpolate inside `${ }`. */
+  children: Children;
+}
+
+/**
+ * A TypeSpec string template expression (`${expr}`).
+ * Must be used inside a {@link StringLiteral}.
+ *
+ * @example
+ * ```tsx
+ * <StringLiteral>
+ *   hello <StringTemplateExpr>{refkey(greeting)}</StringTemplateExpr>!
+ * </StringLiteral>
+ * ```
+ * Produces: `"hello ${greeting}!"`
+ */
+export function StringTemplateExpr(props: StringTemplateExprProps) {
+  return (
+    <>
+      {"${"}
+      {props.children}
+      {"}"}
+    </>
+  );
+}


### PR DESCRIPTION
- StringLiteral renders single-line (`"..."`) or multi-line (`"""..."""'`) string literals via the multiline prop
- StringTemplateExpr wraps children in ${} for interpolation
- Multi-line strings use raw <indent> intrinsic to keep closing triple quotes at the same indentation level as content
- Export both components from package entry point