### PR TITLE
feat(typespec): add doc, decorators, and directives support to Namespace

### DIFF
--- a/packages/typespec/src/components/namespace/namespace.test.tsx
+++ b/packages/typespec/src/components/namespace/namespace.test.tsx
@@ -1,5 +1,6 @@
 import { Output } from "@alloy-js/core";
 import { expect, it } from "vitest";
+import { DecoratorApplication } from "../decorator/decorator-application.jsx";
 import { SourceFile } from "../source-file/source-file.jsx";
 import { Namespace } from "./namespace.jsx";
 
@@ -10,12 +11,11 @@ it("renders a namespace with contents", () => {
         <Namespace name="My.Namespace">Contents!</Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
-        namespace My.Namespace;
+  ).toRenderTo(`
+    namespace My.Namespace;
 
-        Contents!`,
-  });
+    Contents!
+  `);
 });
 
 it("renders namespaces when a file level namespace is present", () => {
@@ -27,12 +27,109 @@ it("renders namespaces when a file level namespace is present", () => {
         </Namespace>
       </SourceFile>
     </Output>,
-  ).toRenderTo({
-    "main.tsp": `
-        namespace File.Level;
+  ).toRenderTo(`
+    namespace File.Level;
 
-        namespace My.Namespace {
+    namespace My.Namespace {
+      Contents!
+    }
+  `);
+});
+
+it("renders a namespace with a doc comment", () => {
+  expect(
+    <Output>
+      <SourceFile path="main.tsp">
+        <Namespace name="MyApi" doc="My API namespace">
           Contents!
-        }`,
-  });
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    /**
+     * My API namespace
+     */
+    namespace MyApi;
+
+    Contents!
+  `);
+});
+
+it("renders a namespace with decorators", () => {
+  expect(
+    <Output>
+      <SourceFile path="main.tsp">
+        <Namespace
+          name="MyApi"
+          decorators={<DecoratorApplication decorator="service" />}
+        >
+          Contents!
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    @service
+    namespace MyApi;
+
+    Contents!
+  `);
+});
+
+it("renders a nested namespace with doc and decorators", () => {
+  expect(
+    <Output>
+      <SourceFile path="main.tsp">
+        <Namespace name="File.Level">
+          <Namespace
+            name="Inner"
+            doc="Inner namespace"
+            decorators={<DecoratorApplication decorator="service" />}
+          >
+            Contents!
+          </Namespace>
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    namespace File.Level;
+
+    /**
+     * Inner namespace
+     */
+    @service
+    namespace Inner {
+      Contents!
+    }
+  `);
+});
+
+it("renders a namespace with doc, directives, and decorators", () => {
+  expect(
+    <Output>
+      <SourceFile path="main.tsp">
+        <Namespace
+          name="MyApi"
+          doc="My API"
+          directives={
+            <>
+              #suppress "no-unused" "testing"
+              <hbr />
+            </>
+          }
+          decorators={<DecoratorApplication decorator="service" />}
+        >
+          Contents!
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    /**
+     * My API
+     */
+    #suppress "no-unused" "testing"
+    @service
+    namespace MyApi;
+
+    Contents!
+  `);
 });

--- a/packages/typespec/src/components/namespace/namespace.tsx
+++ b/packages/typespec/src/components/namespace/namespace.tsx
@@ -10,12 +10,22 @@ import { Children } from "@alloy-js/core/jsx-runtime";
 import { NamespaceScope } from "../../scopes/namespace.js";
 import { SourceFileScope } from "../../scopes/source-file.js";
 import { createNamespaceSymbol } from "../../symbols/factories.js";
+import { DocWhen } from "../doc/doc-comment.jsx";
 import { NamespaceName } from "./namespace-name.jsx";
 import { NamespaceScopeComponent } from "./namespace-scope.jsx";
 
 export interface NamespaceProps {
+  /** The namespace name, or an array of dotted segments. */
   name: (string | Namekey) | (string | Namekey)[];
+  /** Refkey(s) for referencing this namespace from other components. */
   refkey?: Refkey | Refkey[];
+  /** Doc comment rendered as `/** ... *\/` above the namespace. */
+  doc?: Children;
+  /** Directives (`#suppress`, `#deprecated`) to apply to the namespace. */
+  directives?: Children;
+  /** Decorators (e.g. `@service`) to apply to the namespace. */
+  decorators?: Children;
+  /** The namespace body contents. */
   children?: Children;
 }
 
@@ -30,6 +40,9 @@ export function Namespace(props: NamespaceProps) {
 
   return (
     <>
+      <DocWhen doc={props.doc} />
+      {props.directives}
+      {props.decorators}
       namespace <NamespaceName symbol={namespaceSymbol} relative />
       <NamespaceScopeComponent symbol={namespaceSymbol}>
         <Switch>


### PR DESCRIPTION
Add doc, directives, and decorators props to the Namespace component, matching the pattern used by ModelDeclaration and OperationDeclaration.

- Added DocWhen rendering for doc comments
- Added directives and decorators pass-through rendering
- Added JSDoc for all NamespaceProps fields
- Added tests for doc, decorators, directives, and nested namespace cases