### PR TITLE
feat(typespec): add spread parameter support for operations

### DIFF
--- a/packages/typespec/src/components/operation/operation-declaration.test.tsx
+++ b/packages/typespec/src/components/operation/operation-declaration.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { resetProgram } from "../../contexts/program.js";
 import { createTypeSpecNamePolicy } from "../../name-policy.js";
 import { DecoratorApplication } from "../decorator/decorator-application.jsx";
+import { ModelDeclaration } from "../model/model-declaration.jsx";
 import { Namespace } from "../namespace/namespace.jsx";
 import { Reference } from "../reference/reference.jsx";
 import { SourceFile } from "../source-file/source-file.jsx";
@@ -315,4 +316,71 @@ it("renders an operation with a doc comment", () => {
        */
       op getPet(id: string): Pet
     `);
+});
+
+it("renders an operation with spread parameters", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <OperationDeclaration
+          name="getUser"
+          parameters={[
+            { spread: "CommonParams" },
+            { name: "extra", type: "boolean" },
+          ]}
+          returnType="User"
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    op getUser(...CommonParams, extra: boolean): User
+  `);
+});
+
+it("renders an operation with only spread parameters", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <OperationDeclaration
+          name="getUser"
+          parameters={[{ spread: "CommonParams" }]}
+          returnType="User"
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    op getUser(...CommonParams): User
+  `);
+});
+
+it("renders an operation with a spread reference", () => {
+  const paramsKey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <StatementList>
+            <ModelDeclaration name="CommonParams" refkey={paramsKey}>
+              id: string
+            </ModelDeclaration>
+            <OperationDeclaration
+              name="getUser"
+              parameters={[
+                { spread: <Reference refkey={paramsKey} /> },
+                { name: "extra", type: "boolean" },
+              ]}
+              returnType="User"
+            />
+          </StatementList>
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    namespace A;
+
+    model CommonParams {
+      id: string
+    };
+    op getUser(...CommonParams, extra: boolean): User;
+  `);
 });

--- a/packages/typespec/src/components/operation/operation-declaration.tsx
+++ b/packages/typespec/src/components/operation/operation-declaration.tsx
@@ -15,9 +15,13 @@ import {
   TemplateParameterDescriptor,
   TemplateParameters,
 } from "../template-parameters/template-parameters.jsx";
-import { type ParameterDescriptor, Parameters } from "./parameters.jsx";
+import { type ParameterEntry, Parameters } from "./parameters.jsx";
 
-export type { ParameterDescriptor } from "./parameters.jsx";
+export type {
+  ParameterDescriptor,
+  ParameterEntry,
+  SpreadParameterDescriptor,
+} from "./parameters.jsx";
 
 export interface OperationDeclarationProps {
   /** The operation name. */
@@ -27,7 +31,7 @@ export interface OperationDeclarationProps {
   /** Template parameters for the operation. */
   templateParameters?: (string | TemplateParameterDescriptor)[];
   /** Operation parameters. */
-  parameters?: ParameterDescriptor[];
+  parameters?: ParameterEntry[];
   /** The return type of the operation. */
   returnType?: Children;
   /** The operation this declaration aliases via `is`. */

--- a/packages/typespec/src/components/operation/parameters.tsx
+++ b/packages/typespec/src/components/operation/parameters.tsx
@@ -6,23 +6,35 @@ export interface ParameterDescriptor {
   optional?: boolean;
 }
 
-export function Parameters(props: { parameters?: ParameterDescriptor[] }) {
+export interface SpreadParameterDescriptor {
+  spread: Children;
+}
+
+export type ParameterEntry = ParameterDescriptor | SpreadParameterDescriptor;
+
+export function Parameters(props: { parameters?: ParameterEntry[] }) {
   return (
     <group>
       (
       {props.parameters && props.parameters.length > 0 && (
         <Indent softline trailingBreak>
           <For each={props.parameters} comma line>
-            {(param) => (
-              <>
-                {param.name}
-                {param.optional ? "?" : ""}: {param.type}
-              </>
-            )}
+            {(param) =>
+              isSpread(param) ?
+                <>...{param.spread}</>
+              : <>
+                  {param.name}
+                  {param.optional ? "?" : ""}: {param.type}
+                </>
+            }
           </For>
         </Indent>
       )}
       )
     </group>
   );
+}
+
+function isSpread(param: ParameterEntry): param is SpreadParameterDescriptor {
+  return "spread" in param;
 }


### PR DESCRIPTION
Add SpreadParameterDescriptor and ParameterEntry types to support spread parameters in operation declarations (e.g. `op foo(...CommonParams, name: string)`).

Also update GAPS.md to reflect current state: remove completed items from missing/partial lists, add newly implemented features.