### PR TITLE
feat(typespec): add builtins audit script, library symbols, and impor…

### DIFF
--- a/packages/typespec/package.json
+++ b/packages/typespec/package.json
@@ -7,6 +7,10 @@
       "development": "./src/index.ts",
       "import": "./dist/src/index.js"
     },
+    "./builtins": {
+      "development": "./src/builtins/index.ts",
+      "import": "./dist/src/builtins/index.js"
+    },
     "./stc": {
       "development": "./src/components/stc/index.ts",
       "import": "./dist/src/components/stc/index.js"

--- a/packages/typespec/scripts/audit-builtins.ts
+++ b/packages/typespec/scripts/audit-builtins.ts
@@ -1,0 +1,360 @@
+/**
+ * Audit script: compares TypeSpec standard library definitions against
+ * our builtins in @alloy-js/typespec to find missing or extra entries.
+ *
+ * Installs all TypeSpec packages in a temporary workspace, parses their
+ * .tsp files, groups symbols by namespace, and compares against our
+ * builtin definitions in src/builtins/<Namespace>/.
+ *
+ * Usage: npx tsx packages/typespec/scripts/audit-builtins.ts
+ *
+ * Exit code 0 = in sync, 1 = differences found.
+ */
+import { execSync } from "child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+// ── TypeSpec packages to install and scan ─────────────────────────────
+
+const TYPESPEC_PACKAGES = [
+  "@typespec/compiler",
+  "@typespec/http",
+  "@typespec/rest",
+  "@typespec/openapi",
+  "@typespec/openapi3",
+  "@typespec/versioning",
+];
+
+// Namespaces to skip (internal / not useful as builtins)
+const SKIP_NAMESPACES = new Set([
+  "Private",
+  "TypeSpec.Prototypes",
+  "TypeSpec.Prototypes.Types",
+  "TypeSpec.Http.Private",
+]);
+
+// ── Symbol extraction ─────────────────────────────────────────────────
+
+function findTspFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!existsSync(dir)) return results;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findTspFiles(fullPath));
+    } else if (entry.name.endsWith(".tsp")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+interface NamespaceSymbols {
+  scalars: string[];
+  models: string[];
+  enums: string[];
+  decorators: string[];
+  unions: string[];
+}
+
+function empty(): NamespaceSymbols {
+  return { scalars: [], models: [], enums: [], decorators: [], unions: [] };
+}
+
+/**
+ * Parse a .tsp file and return a map of namespace -> symbols.
+ * Handles file-level `namespace X;` and block-level `namespace X { }`.
+ */
+function extractByNamespace(tspContent: string): Map<string, NamespaceSymbols> {
+  const result = new Map<string, NamespaceSymbols>();
+  let currentNs = "";
+
+  for (const line of tspContent.split("\n")) {
+    const trimmed = line.trim();
+    let m: RegExpMatchArray | null;
+
+    // Track namespace (file-level `namespace X;` or block `namespace X {`)
+    if ((m = trimmed.match(/^namespace\s+([\w.]+)/))) {
+      currentNs = m[1];
+      if (!result.has(currentNs)) {
+        result.set(currentNs, empty());
+      }
+      continue;
+    }
+
+    if (!currentNs) continue;
+    const symbols = result.get(currentNs)!;
+
+    if ((m = trimmed.match(/^scalar\s+(\w+)/))) {
+      symbols.scalars.push(m[1]);
+    } else if ((m = trimmed.match(/^model\s+(\w+)/))) {
+      symbols.models.push(m[1]);
+    } else if ((m = trimmed.match(/^enum\s+(\w+)/))) {
+      symbols.enums.push(m[1]);
+    } else if ((m = trimmed.match(/^extern\s+dec\s+(\w+)/))) {
+      symbols.decorators.push(m[1]);
+    } else if ((m = trimmed.match(/^union\s+(\w+)/))) {
+      symbols.unions.push(m[1]);
+    }
+  }
+
+  return result;
+}
+
+function merge(a: NamespaceSymbols, b: NamespaceSymbols): NamespaceSymbols {
+  return {
+    scalars: [...a.scalars, ...b.scalars],
+    models: [...a.models, ...b.models],
+    enums: [...a.enums, ...b.enums],
+    decorators: [...a.decorators, ...b.decorators],
+    unions: [...a.unions, ...b.unions],
+  };
+}
+
+function dedup(s: NamespaceSymbols): NamespaceSymbols {
+  return {
+    scalars: [...new Set(s.scalars)].sort(),
+    models: [...new Set(s.models)].sort(),
+    enums: [...new Set(s.enums)].sort(),
+    decorators: [...new Set(s.decorators)].sort(),
+    unions: [...new Set(s.unions)].sort(),
+  };
+}
+
+// ── Load our builtins from source ─────────────────────────────────────
+
+function extractBuiltinKeys(content: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  // Match top-level entries: `  name: { kind: "type" ...` where kind may be
+  // on the same line or the next line after the opening brace.
+  const regex = /^[ \t]+(\w+):\s*\{\s*\n?\s*kind:\s*"(\w[\w-]*)"/gm;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    entries.set(match[1], match[2]);
+  }
+  return entries;
+}
+
+function loadOurBuiltins(builtinDir: string): NamespaceSymbols | null {
+  if (!existsSync(builtinDir)) return null;
+
+  const scalars: string[] = [];
+  const models: string[] = [];
+  const enums: string[] = [];
+  const unions: string[] = [];
+  const decorators: string[] = [];
+
+  // Load decorators file
+  const decoratorsPath = resolve(builtinDir, "decorators.ts");
+  if (existsSync(decoratorsPath)) {
+    const content = readFileSync(decoratorsPath, "utf-8");
+    for (const name of extractBuiltinKeys(content).keys()) {
+      decorators.push(name);
+    }
+  }
+
+  // Load data-types file
+  const dataTypesPath = resolve(builtinDir, "data-types.ts");
+  if (existsSync(dataTypesPath)) {
+    for (const [name, kind] of extractBuiltinKeys(
+      readFileSync(dataTypesPath, "utf-8"),
+    )) {
+      switch (kind) {
+        case "scalar":
+          scalars.push(name);
+          break;
+        case "model":
+          models.push(name);
+          break;
+        case "enum":
+          enums.push(name);
+          break;
+        case "union":
+          unions.push(name);
+          break;
+      }
+    }
+  }
+
+  return { scalars, models, enums, decorators, unions };
+}
+
+// ── Diff ──────────────────────────────────────────────────────────────
+
+interface Diff {
+  category: string;
+  missing: string[];
+  extra: string[];
+}
+
+function diff(category: string, stdlib: string[], ours: string[]): Diff {
+  const stdlibSet = new Set(stdlib);
+  const oursSet = new Set(ours);
+  return {
+    category,
+    missing: stdlib.filter((s) => !oursSet.has(s)),
+    extra: ours.filter((s) => !stdlibSet.has(s)).sort(),
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+const builtinsRoot = resolve(import.meta.dirname!, "../src/builtins");
+
+console.log("Setting up temporary workspace...");
+const tempDir = mkdtempSync(join(tmpdir(), "tsp-audit-"));
+
+try {
+  writeFileSync(
+    join(tempDir, "package.json"),
+    JSON.stringify({
+      name: "tsp-audit",
+      private: true,
+      dependencies: Object.fromEntries(
+        TYPESPEC_PACKAGES.map((pkg) => [pkg, "latest"]),
+      ),
+    }),
+  );
+
+  console.log("Installing TypeSpec packages...");
+  execSync("npm install --quiet 2>&1", { cwd: tempDir, stdio: "pipe" });
+
+  // Collect symbols from all packages, grouped by namespace
+  const allNamespaces = new Map<string, NamespaceSymbols>();
+  const packageVersions = new Map<string, string>();
+
+  for (const pkg of TYPESPEC_PACKAGES) {
+    const pkgDir = join(tempDir, "node_modules", pkg);
+    if (!existsSync(pkgDir)) {
+      console.log(`⚠️  ${pkg} — not installed, skipping`);
+      continue;
+    }
+
+    const version = JSON.parse(
+      readFileSync(join(pkgDir, "package.json"), "utf-8"),
+    ).version;
+    packageVersions.set(pkg, version);
+
+    const libDir = join(pkgDir, "lib");
+    if (!existsSync(libDir)) continue;
+
+    const tspFiles = findTspFiles(libDir);
+    for (const file of tspFiles) {
+      const content = readFileSync(file, "utf-8");
+      const byNs = extractByNamespace(content);
+      for (const [ns, symbols] of byNs) {
+        const existing = allNamespaces.get(ns) ?? empty();
+        allNamespaces.set(ns, merge(existing, symbols));
+      }
+    }
+  }
+
+  // Dedup and sort
+  for (const [ns, symbols] of allNamespaces) {
+    allNamespaces.set(ns, dedup(symbols));
+  }
+
+  // Report
+  console.log();
+  console.log("TypeSpec Builtins Audit");
+  console.log("======================");
+  console.log("Packages:");
+  for (const [pkg, version] of packageVersions) {
+    console.log(`  ${pkg}@${version}`);
+  }
+
+  let totalMissing = 0;
+  let totalExtra = 0;
+  let hasIssues = false;
+
+  const sortedNamespaces = [...allNamespaces.keys()].sort();
+
+  for (const ns of sortedNamespaces) {
+    if (SKIP_NAMESPACES.has(ns)) continue;
+
+    const stdlibSymbols = allNamespaces.get(ns)!;
+    const symbolCount =
+      stdlibSymbols.scalars.length +
+      stdlibSymbols.models.length +
+      stdlibSymbols.enums.length +
+      stdlibSymbols.decorators.length +
+      stdlibSymbols.unions.length;
+
+    if (symbolCount === 0) continue;
+
+    // Map namespace to directory: TypeSpec.Http -> TypeSpec/Http
+    const builtinDir = resolve(builtinsRoot, ns.replace(/\./g, "/"));
+    const ours = loadOurBuiltins(builtinDir);
+
+    console.log(`\n── ${ns} ──`);
+    console.log(
+      `   Stdlib: ${stdlibSymbols.scalars.length}S ${stdlibSymbols.models.length}M ${stdlibSymbols.enums.length}E ${stdlibSymbols.decorators.length}D ${stdlibSymbols.unions.length}U`,
+    );
+
+    if (!ours) {
+      hasIssues = true;
+      const allSymbols = [
+        ...stdlibSymbols.scalars.map((s) => `scalar ${s}`),
+        ...stdlibSymbols.models.map((s) => `model ${s}`),
+        ...stdlibSymbols.enums.map((s) => `enum ${s}`),
+        ...stdlibSymbols.decorators.map((s) => `decorator ${s}`),
+        ...stdlibSymbols.unions.map((s) => `union ${s}`),
+      ];
+      console.log(`   ❌ No builtin directory (${ns.replace(/\./g, "/")})`);
+      for (const s of allSymbols) {
+        console.log(`        - ${s}`);
+      }
+      totalMissing += allSymbols.length;
+      continue;
+    }
+
+    console.log(
+      `   Ours:   ${ours.scalars.length}S ${ours.models.length}M ${ours.enums.length}E ${ours.decorators.length}D ${ours.unions.length}U`,
+    );
+
+    const diffs: Diff[] = [
+      diff("scalars", stdlibSymbols.scalars, ours.scalars),
+      diff("models", stdlibSymbols.models, ours.models),
+      diff("enums", stdlibSymbols.enums, ours.enums),
+      diff("decorators", stdlibSymbols.decorators, ours.decorators),
+      diff("unions", stdlibSymbols.unions, ours.unions),
+    ];
+
+    for (const d of diffs) {
+      if (d.missing.length === 0 && d.extra.length === 0) {
+        console.log(`   ✅ ${d.category}`);
+      } else {
+        if (d.missing.length > 0) {
+          hasIssues = true;
+          console.log(`   ❌ ${d.category} — missing:`);
+          for (const name of d.missing) {
+            console.log(`        - ${name}`);
+          }
+        }
+        if (d.extra.length > 0) {
+          console.log(`   ⚠️  ${d.category} — extra:`);
+          for (const name of d.extra) {
+            console.log(`        ~ ${name}`);
+          }
+        }
+      }
+      totalMissing += d.missing.length;
+      totalExtra += d.extra.length;
+    }
+  }
+
+  console.log(`\n══════════════════════`);
+  console.log(`Total missing: ${totalMissing}, Extra: ${totalExtra}`);
+  console.log(hasIssues ? "❌ Out of sync" : "✅ All in sync");
+  process.exit(hasIssues ? 1 : 0);
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/packages/typespec/src/builtins/TypeSpec/Http/Streams/data-types.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Http/Streams/data-types.ts
@@ -1,0 +1,10 @@
+import { Descriptor, LibraryFrom } from "../../../../index.js";
+
+const dataTypes = {
+  HttpStream: { kind: "model", members: {} },
+  JsonlStream: { kind: "model", members: {} },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDataTypes = LibraryFrom<typeof dataTypes>;
+
+export default dataTypes;

--- a/packages/typespec/src/builtins/TypeSpec/Http/Streams/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Http/Streams/index.ts
@@ -1,0 +1,13 @@
+import { LibrarySymbolReference } from "@alloy-js/core";
+import { createLibrary } from "../../../../index.js";
+import dataTypes, { LibraryDataTypes } from "./data-types.js";
+
+type HttpStreamsLibrary = LibrarySymbolReference & LibraryDataTypes;
+
+const HttpStreams: HttpStreamsLibrary = createLibrary(
+  "TypeSpec.Http.Streams",
+  dataTypes,
+  { packageImport: "@typespec/http" },
+);
+
+export default HttpStreams;

--- a/packages/typespec/src/builtins/TypeSpec/Http/data-types.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Http/data-types.ts
@@ -1,0 +1,46 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const dataTypes = {
+  LinkHeader: { kind: "scalar" },
+  AcceptedResponse: { kind: "model", members: {} },
+  ApiKeyAuth: { kind: "model", members: {} },
+  AuthorizationCodeFlow: { kind: "model", members: {} },
+  BadRequestResponse: { kind: "model", members: {} },
+  BasicAuth: { kind: "model", members: {} },
+  BearerAuth: { kind: "model", members: {} },
+  Body: { kind: "model", members: {} },
+  ClientCredentialsFlow: { kind: "model", members: {} },
+  ConflictResponse: { kind: "model", members: {} },
+  CookieOptions: { kind: "model", members: {} },
+  CreatedResponse: { kind: "model", members: {} },
+  File: { kind: "model", members: {} },
+  ForbiddenResponse: { kind: "model", members: {} },
+  HeaderOptions: { kind: "model", members: {} },
+  HttpPart: { kind: "model", members: {} },
+  HttpPartOptions: { kind: "model", members: {} },
+  ImplicitFlow: { kind: "model", members: {} },
+  Link: { kind: "model", members: {} },
+  LocationHeader: { kind: "model", members: {} },
+  MovedResponse: { kind: "model", members: {} },
+  NoAuth: { kind: "model", members: {} },
+  NoContentResponse: { kind: "model", members: {} },
+  NotFoundResponse: { kind: "model", members: {} },
+  NotModifiedResponse: { kind: "model", members: {} },
+  OAuth2Auth: { kind: "model", members: {} },
+  OkResponse: { kind: "model", members: {} },
+  OpenIdConnectAuth: { kind: "model", members: {} },
+  PlainData: { kind: "model", members: {} },
+  QueryOptions: { kind: "model", members: {} },
+  PasswordFlow: { kind: "model", members: {} },
+  PatchOptions: { kind: "model", members: {} },
+  PathOptions: { kind: "model", members: {} },
+  Response: { kind: "model", members: {} },
+  UnauthorizedResponse: { kind: "model", members: {} },
+  ApiKeyLocation: { kind: "enum", members: {} },
+  AuthType: { kind: "enum", members: {} },
+  OAuth2FlowType: { kind: "enum", members: {} },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDataTypes = LibraryFrom<typeof dataTypes>;
+
+export default dataTypes;

--- a/packages/typespec/src/builtins/TypeSpec/Http/decorators.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Http/decorators.ts
@@ -1,0 +1,27 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const decorators = {
+  body: { kind: "decorator" },
+  cookie: { kind: "decorator" },
+  delete: { kind: "decorator" },
+  get: { kind: "decorator" },
+  head: { kind: "decorator" },
+  header: { kind: "decorator" },
+  bodyIgnore: { kind: "decorator" },
+  bodyRoot: { kind: "decorator" },
+  multipartBody: { kind: "decorator" },
+  patch: { kind: "decorator" },
+  path: { kind: "decorator" },
+  post: { kind: "decorator" },
+  put: { kind: "decorator" },
+  query: { kind: "decorator" },
+  route: { kind: "decorator" },
+  server: { kind: "decorator" },
+  sharedRoute: { kind: "decorator" },
+  statusCode: { kind: "decorator" },
+  useAuth: { kind: "decorator" },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDecorators = LibraryFrom<typeof decorators>;
+
+export default decorators;

--- a/packages/typespec/src/builtins/TypeSpec/Http/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Http/index.ts
@@ -1,0 +1,17 @@
+import { LibrarySymbolReference } from "@alloy-js/core";
+import { createLibrary } from "../../../index.js";
+import dataTypes, { LibraryDataTypes } from "./data-types.js";
+import decorators, { LibraryDecorators } from "./decorators.js";
+
+type HttpLibrary = LibrarySymbolReference & LibraryDecorators & LibraryDataTypes;
+
+const Http: HttpLibrary = createLibrary(
+  "TypeSpec.Http",
+  {
+    ...decorators,
+    ...dataTypes,
+  },
+  { packageImport: "@typespec/http" },
+);
+
+export default Http;

--- a/packages/typespec/src/builtins/TypeSpec/Http/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Http/index.ts
@@ -3,7 +3,9 @@ import { createLibrary } from "../../../index.js";
 import dataTypes, { LibraryDataTypes } from "./data-types.js";
 import decorators, { LibraryDecorators } from "./decorators.js";
 
-type HttpLibrary = LibrarySymbolReference & LibraryDecorators & LibraryDataTypes;
+type HttpLibrary = LibrarySymbolReference &
+  LibraryDecorators &
+  LibraryDataTypes;
 
 const Http: HttpLibrary = createLibrary(
   "TypeSpec.Http",

--- a/packages/typespec/src/builtins/TypeSpec/OpenAPI/data-types.ts
+++ b/packages/typespec/src/builtins/TypeSpec/OpenAPI/data-types.ts
@@ -1,0 +1,14 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const dataTypes = {
+  AdditionalInfo: { kind: "model", members: {} },
+  Contact: { kind: "model", members: {} },
+  ExternalDocs: { kind: "model", members: {} },
+  License: { kind: "model", members: {} },
+  TagMetadata: { kind: "model", members: {} },
+  TagMetadataWithName: { kind: "model", members: {} },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDataTypes = LibraryFrom<typeof dataTypes>;
+
+export default dataTypes;

--- a/packages/typespec/src/builtins/TypeSpec/OpenAPI/decorators.ts
+++ b/packages/typespec/src/builtins/TypeSpec/OpenAPI/decorators.ts
@@ -1,0 +1,16 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const decorators = {
+  defaultResponse: { kind: "decorator" },
+  extension: { kind: "decorator" },
+  externalDocs: { kind: "decorator" },
+  info: { kind: "decorator" },
+  oneOf: { kind: "decorator" },
+  operationId: { kind: "decorator" },
+  tagMetadata: { kind: "decorator" },
+  useRef: { kind: "decorator" },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDecorators = LibraryFrom<typeof decorators>;
+
+export default decorators;

--- a/packages/typespec/src/builtins/TypeSpec/OpenAPI/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/OpenAPI/index.ts
@@ -1,19 +1,19 @@
 import { LibrarySymbolReference } from "@alloy-js/core";
-import { createLibrary } from "../../index.js";
+import { createLibrary } from "../../../index.js";
 import dataTypes, { LibraryDataTypes } from "./data-types.js";
 import decorators, { LibraryDecorators } from "./decorators.js";
 
-type TypeSpecLibrary = LibrarySymbolReference &
+type OpenAPILibrary = LibrarySymbolReference &
   LibraryDecorators &
   LibraryDataTypes;
 
-const TypeSpec: TypeSpecLibrary = createLibrary(
-  "TypeSpec",
+const OpenAPI: OpenAPILibrary = createLibrary(
+  "TypeSpec.OpenAPI",
   {
     ...decorators,
     ...dataTypes,
   },
-  { implicitlyUsed: true },
+  { packageImport: "@typespec/openapi" },
 );
 
-export default TypeSpec;
+export default OpenAPI;

--- a/packages/typespec/src/builtins/TypeSpec/OpenAPI/openapi3.ts
+++ b/packages/typespec/src/builtins/TypeSpec/OpenAPI/openapi3.ts
@@ -1,0 +1,22 @@
+import { LibrarySymbolReference } from "@alloy-js/core";
+import { createLibrary, Descriptor, LibraryFrom } from "../../../index.js";
+
+// These decorators are contributed to the TypeSpec.OpenAPI namespace by the
+// @typespec/openapi3 package (not @typespec/openapi). Both packages share the
+// same namespace — the per-symbol packageImport ensures the correct import is
+// emitted depending on which entry point the consumer uses.
+const decorators = {
+  oneOf: { kind: "decorator" },
+  useRef: { kind: "decorator" },
+} satisfies Record<string, Descriptor>;
+
+type LibraryDecorators = LibraryFrom<typeof decorators>;
+type OpenAPI3Library = LibrarySymbolReference & LibraryDecorators;
+
+const OpenAPI3: OpenAPI3Library = createLibrary(
+  "TypeSpec.OpenAPI",
+  decorators,
+  { packageImport: "@typespec/openapi3" },
+);
+
+export default OpenAPI3;

--- a/packages/typespec/src/builtins/TypeSpec/Reflection/data-types.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Reflection/data-types.ts
@@ -1,0 +1,19 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const dataTypes = {
+  Enum: { kind: "model", members: {} },
+  EnumMember: { kind: "model", members: {} },
+  Interface: { kind: "model", members: {} },
+  Model: { kind: "model", members: {} },
+  ModelProperty: { kind: "model", members: {} },
+  Namespace: { kind: "model", members: {} },
+  Operation: { kind: "model", members: {} },
+  Scalar: { kind: "model", members: {} },
+  StringTemplate: { kind: "model", members: {} },
+  Union: { kind: "model", members: {} },
+  UnionVariant: { kind: "model", members: {} },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDataTypes = LibraryFrom<typeof dataTypes>;
+
+export default dataTypes;

--- a/packages/typespec/src/builtins/TypeSpec/Reflection/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Reflection/index.ts
@@ -1,0 +1,12 @@
+import { LibrarySymbolReference } from "@alloy-js/core";
+import { createLibrary } from "../../../index.js";
+import dataTypes, { LibraryDataTypes } from "./data-types.js";
+
+type ReflectionLibrary = LibrarySymbolReference & LibraryDataTypes;
+
+const Reflection: ReflectionLibrary = createLibrary(
+  "TypeSpec.Reflection",
+  dataTypes,
+);
+
+export default Reflection;

--- a/packages/typespec/src/builtins/TypeSpec/Rest/Resource/data-types.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Rest/Resource/data-types.ts
@@ -1,0 +1,18 @@
+import { Descriptor, LibraryFrom } from "../../../../index.js";
+
+const dataTypes = {
+  CollectionWithNextLink: { kind: "model", members: {} },
+  KeysOf: { kind: "model", members: {} },
+  ParentKeysOf: { kind: "model", members: {} },
+  ResourceCollectionParameters: { kind: "model", members: {} },
+  ResourceCreateModel: { kind: "model", members: {} },
+  ResourceCreateOrUpdateModel: { kind: "model", members: {} },
+  ResourceCreatedResponse: { kind: "model", members: {} },
+  ResourceDeletedResponse: { kind: "model", members: {} },
+  ResourceError: { kind: "model", members: {} },
+  ResourceParameters: { kind: "model", members: {} },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDataTypes = LibraryFrom<typeof dataTypes>;
+
+export default dataTypes;

--- a/packages/typespec/src/builtins/TypeSpec/Rest/Resource/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Rest/Resource/index.ts
@@ -1,0 +1,13 @@
+import { LibrarySymbolReference } from "@alloy-js/core";
+import { createLibrary } from "../../../../index.js";
+import dataTypes, { LibraryDataTypes } from "./data-types.js";
+
+type RestResourceLibrary = LibrarySymbolReference & LibraryDataTypes;
+
+const RestResource: RestResourceLibrary = createLibrary(
+  "TypeSpec.Rest.Resource",
+  dataTypes,
+  { packageImport: "@typespec/rest" },
+);
+
+export default RestResource;

--- a/packages/typespec/src/builtins/TypeSpec/Rest/data-types.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Rest/data-types.ts
@@ -1,0 +1,9 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const dataTypes = {
+  ResourceLocation: { kind: "scalar" },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDataTypes = LibraryFrom<typeof dataTypes>;
+
+export default dataTypes;

--- a/packages/typespec/src/builtins/TypeSpec/Rest/decorators.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Rest/decorators.ts
@@ -1,0 +1,24 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const decorators = {
+  action: { kind: "decorator" },
+  actionSeparator: { kind: "decorator" },
+  autoRoute: { kind: "decorator" },
+  collectionAction: { kind: "decorator" },
+  copyResourceKeyParameters: { kind: "decorator" },
+  createsOrReplacesResource: { kind: "decorator" },
+  createsOrUpdatesResource: { kind: "decorator" },
+  createsResource: { kind: "decorator" },
+  deletesResource: { kind: "decorator" },
+  listsResource: { kind: "decorator" },
+  parentResource: { kind: "decorator" },
+  readsResource: { kind: "decorator" },
+  resource: { kind: "decorator" },
+  segment: { kind: "decorator" },
+  segmentOf: { kind: "decorator" },
+  updatesResource: { kind: "decorator" },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDecorators = LibraryFrom<typeof decorators>;
+
+export default decorators;

--- a/packages/typespec/src/builtins/TypeSpec/Rest/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Rest/index.ts
@@ -1,19 +1,19 @@
 import { LibrarySymbolReference } from "@alloy-js/core";
-import { createLibrary } from "../../index.js";
+import { createLibrary } from "../../../index.js";
 import dataTypes, { LibraryDataTypes } from "./data-types.js";
 import decorators, { LibraryDecorators } from "./decorators.js";
 
-type TypeSpecLibrary = LibrarySymbolReference &
+type RestLibrary = LibrarySymbolReference &
   LibraryDecorators &
   LibraryDataTypes;
 
-const TypeSpec: TypeSpecLibrary = createLibrary(
-  "TypeSpec",
+const Rest: RestLibrary = createLibrary(
+  "TypeSpec.Rest",
   {
     ...decorators,
     ...dataTypes,
   },
-  { implicitlyUsed: true },
+  { packageImport: "@typespec/rest" },
 );
 
-export default TypeSpec;
+export default Rest;

--- a/packages/typespec/src/builtins/TypeSpec/Versioning/decorators.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Versioning/decorators.ts
@@ -1,0 +1,17 @@
+import { Descriptor, LibraryFrom } from "../../../index.js";
+
+const decorators = {
+  added: { kind: "decorator" },
+  madeOptional: { kind: "decorator" },
+  madeRequired: { kind: "decorator" },
+  removed: { kind: "decorator" },
+  renamedFrom: { kind: "decorator" },
+  returnTypeChangedFrom: { kind: "decorator" },
+  typeChangedFrom: { kind: "decorator" },
+  useDependency: { kind: "decorator" },
+  versioned: { kind: "decorator" },
+} satisfies Record<string, Descriptor>;
+
+export type LibraryDecorators = LibraryFrom<typeof decorators>;
+
+export default decorators;

--- a/packages/typespec/src/builtins/TypeSpec/Versioning/index.ts
+++ b/packages/typespec/src/builtins/TypeSpec/Versioning/index.ts
@@ -1,0 +1,13 @@
+import { LibrarySymbolReference } from "@alloy-js/core";
+import { createLibrary } from "../../../index.js";
+import decorators, { LibraryDecorators } from "./decorators.js";
+
+type VersioningLibrary = LibrarySymbolReference & LibraryDecorators;
+
+const Versioning: VersioningLibrary = createLibrary(
+  "TypeSpec.Versioning",
+  decorators,
+  { packageImport: "@typespec/versioning" },
+);
+
+export default Versioning;

--- a/packages/typespec/src/builtins/builtins.test.tsx
+++ b/packages/typespec/src/builtins/builtins.test.tsx
@@ -1,17 +1,17 @@
-import { Output, toRefkey } from "@alloy-js/core";
+import { Output } from "@alloy-js/core";
 import { beforeEach, expect, it } from "vitest";
-import { resetProgram } from "../contexts/program.js";
-import { createLibrary } from "../create-library.js";
-import { createTypeSpecNamePolicy } from "../name-policy.js";
 import { ModelDeclaration } from "../components/model/model-declaration.jsx";
 import { Reference } from "../components/reference/reference.jsx";
 import { ScalarDeclaration } from "../components/scalar-declaration/scalar-declaration.jsx";
 import { SourceFile } from "../components/source-file/source-file.jsx";
-import TypeSpec from "./TypeSpec/index.js";
+import { resetProgram } from "../contexts/program.js";
+import { createLibrary } from "../create-library.js";
+import { createTypeSpecNamePolicy } from "../name-policy.js";
 import Http from "./TypeSpec/Http/index.js";
+import TypeSpec from "./TypeSpec/index.js";
+import OpenAPI3 from "./TypeSpec/OpenAPI/openapi3.js";
 import Reflection from "./TypeSpec/Reflection/index.js";
 import Versioning from "./TypeSpec/Versioning/index.js";
-import OpenAPI3 from "./TypeSpec/OpenAPI/openapi3.js";
 
 beforeEach(() => {
   resetProgram();
@@ -31,7 +31,10 @@ it("references to implicitly-used scalars emit no import or using", () => {
   expect(
     <Output namePolicy={createTypeSpecNamePolicy()}>
       <SourceFile path="main.tsp">
-        <ScalarDeclaration name="MyId" extends={<Reference refkey={TypeSpec.string} />} />
+        <ScalarDeclaration
+          name="MyId"
+          extends={<Reference refkey={TypeSpec.string} />}
+        />
       </SourceFile>
     </Output>,
   ).toRenderTo(`scalar MyId extends string`);
@@ -103,8 +106,7 @@ it("deduplicates using when referencing multiple symbols from same namespace", (
   expect(
     <Output namePolicy={createTypeSpecNamePolicy()}>
       <SourceFile path="main.tsp">
-        <Reference refkey={Http.OkResponse} />
-        {" "}
+        <Reference refkey={Http.OkResponse} />{" "}
         <Reference refkey={Http.NotFoundResponse} />
       </SourceFile>
     </Output>,
@@ -225,7 +227,9 @@ it("accessing a member whose type is a library symbol reference works", () => {
   expect(
     <Output namePolicy={createTypeSpecNamePolicy()}>
       <SourceFile path="main.tsp">
-        <Reference refkey={TypeSpec.DiscriminatedOptions.discriminatorPropertyName} />
+        <Reference
+          refkey={TypeSpec.DiscriminatedOptions.discriminatorPropertyName}
+        />
       </SourceFile>
     </Output>,
   ).toRenderTo(`DiscriminatedOptions.discriminatorPropertyName`);

--- a/packages/typespec/src/builtins/builtins.test.tsx
+++ b/packages/typespec/src/builtins/builtins.test.tsx
@@ -1,0 +1,242 @@
+import { Output, toRefkey } from "@alloy-js/core";
+import { beforeEach, expect, it } from "vitest";
+import { resetProgram } from "../contexts/program.js";
+import { createLibrary } from "../create-library.js";
+import { createTypeSpecNamePolicy } from "../name-policy.js";
+import { ModelDeclaration } from "../components/model/model-declaration.jsx";
+import { Reference } from "../components/reference/reference.jsx";
+import { ScalarDeclaration } from "../components/scalar-declaration/scalar-declaration.jsx";
+import { SourceFile } from "../components/source-file/source-file.jsx";
+import TypeSpec from "./TypeSpec/index.js";
+import Http from "./TypeSpec/Http/index.js";
+import Reflection from "./TypeSpec/Reflection/index.js";
+import Versioning from "./TypeSpec/Versioning/index.js";
+import OpenAPI3 from "./TypeSpec/OpenAPI/openapi3.js";
+
+beforeEach(() => {
+  resetProgram();
+});
+
+it("references to implicitly-used library types emit no import or using", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={TypeSpec.Record} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`Record`);
+});
+
+it("references to implicitly-used scalars emit no import or using", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ScalarDeclaration name="MyId" extends={<Reference refkey={TypeSpec.string} />} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`scalar MyId extends string`);
+});
+
+it("references to compiler library types emit using but no import", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={Reflection.Model} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    using TypeSpec.Reflection;
+
+    Model
+  `);
+});
+
+it("references to external library types emit package import and using", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={Http.OkResponse} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    import "@typespec/http";
+
+    using TypeSpec.Http;
+
+    OkResponse
+  `);
+});
+
+it("references to versioning decorators emit package import and using", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={Versioning.added} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    import "@typespec/versioning";
+
+    using TypeSpec.Versioning;
+
+    added
+  `);
+});
+
+it("same namespace from different packages emits correct imports", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={OpenAPI3.oneOf} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    import "@typespec/openapi3";
+
+    using TypeSpec.OpenAPI;
+
+    oneOf
+  `);
+});
+
+it("deduplicates using when referencing multiple symbols from same namespace", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={Http.OkResponse} />
+        {" "}
+        <Reference refkey={Http.NotFoundResponse} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    import "@typespec/http";
+
+    using TypeSpec.Http;
+
+    OkResponse NotFoundResponse
+  `);
+});
+
+it("can render same library symbol multiple times", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={TypeSpec.string} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`string`);
+
+  resetProgram();
+
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={TypeSpec.string} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`string`);
+});
+
+it("renders library reference with custom createLibrary options", () => {
+  const MyLib = createLibrary(
+    "MyCustom.Lib",
+    {
+      Foo: { kind: "model", members: {} },
+    },
+    { packageImport: "@my/custom-lib" },
+  );
+
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={MyLib.Foo} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    import "@my/custom-lib";
+
+    using MyCustom.Lib;
+
+    Foo
+  `);
+});
+
+it("renders library reference used as model property type", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration name="Pet">
+          name: <Reference refkey={TypeSpec.string} />;
+        </ModelDeclaration>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    model Pet {
+      name: string;
+    }
+  `);
+});
+
+it("renders model with 'is' using a templated builtin type", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="StringMap"
+          is={<Reference refkey={TypeSpec.Record} typeArgs={["unknown"]} />}
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`model StringMap is Record<unknown>`);
+});
+
+it("renders model extending a templated builtin with another builtin arg", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <ModelDeclaration
+          name="Tags"
+          is={
+            <Reference
+              refkey={TypeSpec.Array}
+              typeArgs={[<Reference refkey={TypeSpec.string} />]}
+            />
+          }
+        />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`model Tags is Array<string>`);
+});
+
+it("accessing a member with an inline anonymous type does not crash", () => {
+  // DiscriminatedOptions.envelope has type: { kind: "union", members: {} }
+  // This should not throw even though the type is an inline descriptor
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={TypeSpec.DiscriminatedOptions.envelope} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`DiscriminatedOptions.envelope`);
+});
+
+it("accessing a member whose type is a library symbol reference works", () => {
+  // DiscriminatedOptions.discriminatorPropertyName has type: () => dataTypes.string
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={TypeSpec.DiscriminatedOptions.discriminatorPropertyName} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`DiscriminatedOptions.discriminatorPropertyName`);
+});
+
+it("renders enum member with parent type path (e.g. Lifecycle.Read)", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Reference refkey={TypeSpec.Lifecycle.Read} />
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`Lifecycle.Read`);
+});

--- a/packages/typespec/src/builtins/index.ts
+++ b/packages/typespec/src/builtins/index.ts
@@ -1,1 +1,9 @@
 export { default as TypeSpec, default as default } from "./TypeSpec/index.js";
+export { default as Http } from "./TypeSpec/Http/index.js";
+export { default as HttpStreams } from "./TypeSpec/Http/Streams/index.js";
+export { default as OpenAPI } from "./TypeSpec/OpenAPI/index.js";
+export { default as OpenAPI3 } from "./TypeSpec/OpenAPI/openapi3.js";
+export { default as Reflection } from "./TypeSpec/Reflection/index.js";
+export { default as Rest } from "./TypeSpec/Rest/index.js";
+export { default as RestResource } from "./TypeSpec/Rest/Resource/index.js";
+export { default as Versioning } from "./TypeSpec/Versioning/index.js";

--- a/packages/typespec/src/builtins/index.ts
+++ b/packages/typespec/src/builtins/index.ts
@@ -1,6 +1,6 @@
-export { default as TypeSpec, default as default } from "./TypeSpec/index.js";
 export { default as Http } from "./TypeSpec/Http/index.js";
 export { default as HttpStreams } from "./TypeSpec/Http/Streams/index.js";
+export { default as TypeSpec, default as default } from "./TypeSpec/index.js";
 export { default as OpenAPI } from "./TypeSpec/OpenAPI/index.js";
 export { default as OpenAPI3 } from "./TypeSpec/OpenAPI/openapi3.js";
 export { default as Reflection } from "./TypeSpec/Reflection/index.js";

--- a/packages/typespec/src/components/enum/enum-declaration.test.tsx
+++ b/packages/typespec/src/components/enum/enum-declaration.test.tsx
@@ -184,7 +184,7 @@ it("resolves an enum member reference", () => {
       enum Direction {
         North
       }
-      North
+      Direction.North
     `);
 });
 

--- a/packages/typespec/src/components/model/model-declaration.test.tsx
+++ b/packages/typespec/src/components/model/model-declaration.test.tsx
@@ -303,7 +303,7 @@ it("resolves a model property reference", () => {
       model Foo {
         id: string
       }
-      id
+      Foo.id
     `);
 });
 

--- a/packages/typespec/src/components/reference/reference.tsx
+++ b/packages/typespec/src/components/reference/reference.tsx
@@ -1,6 +1,15 @@
-import { Children, computed, Refkeyable, toRefkey, unresolvedRefkey } from "@alloy-js/core";
+import {
+  Children,
+  computed,
+  Refkeyable,
+  toRefkey,
+  unresolvedRefkey,
+} from "@alloy-js/core";
 import { ref } from "../../symbols/reference.js";
-import { TemplateArguments, TemplateArgumentDescriptor } from "../template-parameters/template-arguments.jsx";
+import {
+  TemplateArgumentDescriptor,
+  TemplateArguments,
+} from "../template-parameters/template-arguments.jsx";
 
 export interface ReferenceProps {
   refkey: Refkeyable;

--- a/packages/typespec/src/components/reference/reference.tsx
+++ b/packages/typespec/src/components/reference/reference.tsx
@@ -1,20 +1,31 @@
-import { computed, emitSymbol, Refkey, unresolvedRefkey } from "@alloy-js/core";
+import { Children, computed, Refkeyable, toRefkey, unresolvedRefkey } from "@alloy-js/core";
 import { ref } from "../../symbols/reference.js";
+import { TemplateArguments, TemplateArgumentDescriptor } from "../template-parameters/template-arguments.jsx";
 
 export interface ReferenceProps {
-  refkey: Refkey;
+  refkey: Refkeyable;
+  /** Optional template/type arguments (e.g. `Record<string>` → `typeArgs={["string"]}`). */
+  typeArgs?: (Children | TemplateArgumentDescriptor)[];
 }
 
 export function Reference(props: ReferenceProps) {
-  const { refkey } = props;
-  const symbol = ref(refkey);
+  const refkey = toRefkey(props.refkey);
+  const result = ref(refkey);
   const renderedRef = computed(() => {
-    const sym = symbol.value;
-    if (sym !== undefined) {
-      return sym.name;
+    const res = result.value;
+    if (res !== undefined) {
+      const { symbol, accessPath } = res;
+      if (accessPath.length > 0) {
+        return [symbol.name, ...accessPath.map((m) => m.name)].join(".");
+      }
+      return symbol.name;
     }
     return unresolvedRefkey(refkey);
   });
-  emitSymbol(symbol);
-  return <>{renderedRef.value}</>;
+  return (
+    <>
+      {renderedRef.value}
+      {props.typeArgs && <TemplateArguments args={props.typeArgs} />}
+    </>
+  );
 }

--- a/packages/typespec/src/components/union/union-declaration.test.tsx
+++ b/packages/typespec/src/components/union/union-declaration.test.tsx
@@ -235,7 +235,7 @@ it("resolves a named union variant reference", () => {
       union Result {
         success: string
       }
-      success
+      Result.success
     `);
 });
 

--- a/packages/typespec/src/create-library.ts
+++ b/packages/typespec/src/create-library.ts
@@ -21,9 +21,9 @@ export interface MemberDescriptor {
   kind: string;
   /**
    * The type of this member. Can be:
-   * - A {@link LibrarySymbolReference} pointing to another library symbol
-   * - A function returning a {@link LibrarySymbolReference} (for circular refs)
-   * - An inline {@link Descriptor} for anonymous types (e.g. inline unions)
+   * - A `LibrarySymbolReference` pointing to another library symbol
+   * - A function returning a `LibrarySymbolReference` (for circular refs)
+   * - An inline `Descriptor` for anonymous types (e.g. inline unions)
    *
    * Inline descriptors are not materialized as referenceable symbols; they
    * serve as documentation of the member's type shape.

--- a/packages/typespec/src/create-library.ts
+++ b/packages/typespec/src/create-library.ts
@@ -1,5 +1,6 @@
 import {
   Binder,
+  isLibrarySymbolReference,
   LibrarySymbolReference,
   namekey,
   refkey,
@@ -18,7 +19,16 @@ import {
 
 export interface MemberDescriptor {
   kind: string;
-  type?: LibrarySymbolReference | (() => LibrarySymbolReference);
+  /**
+   * The type of this member. Can be:
+   * - A {@link LibrarySymbolReference} pointing to another library symbol
+   * - A function returning a {@link LibrarySymbolReference} (for circular refs)
+   * - An inline {@link Descriptor} for anonymous types (e.g. inline unions)
+   *
+   * Inline descriptors are not materialized as referenceable symbols; they
+   * serve as documentation of the member's type shape.
+   */
+  type?: LibrarySymbolReference | (() => LibrarySymbolReference) | Descriptor;
 }
 
 export interface NamedTypeDescriptor<M> {
@@ -95,10 +105,26 @@ export type LibraryFrom<T> = {
 
 interface InternalContext {
   parent(binder: Binder | undefined): NamedTypeSymbol | ProgramScope;
+  libraryOptions?: CreateLibraryOptions;
 }
+
+export interface CreateLibraryOptions {
+  /**
+   * When true, the namespace's members are implicitly available without
+   * a `using` statement (like the core `TypeSpec` namespace).
+   */
+  implicitlyUsed?: boolean;
+  /**
+   * When set, referencing a symbol from this library will automatically
+   * add an `import "<packageImport>";` to the source file.
+   */
+  packageImport?: string;
+}
+
 export function createLibrary<T extends Record<string, Descriptor>>(
   rootNs: string,
   props: T,
+  options?: CreateLibraryOptions,
 ): LibraryFrom<T> {
   const ownerSymbolPerBinder = new WeakMap<
     Binder,
@@ -144,6 +170,7 @@ export function createLibrary<T extends Record<string, Descriptor>>(
           return ownerSymbol;
         });
       },
+      libraryOptions: options,
     },
   ) as LibraryFrom<T>;
 }
@@ -158,6 +185,7 @@ function createSymbolEntry(
     parent(binder) {
       return getSymbol(binder) as NamedTypeSymbol;
     },
+    libraryOptions: context.libraryOptions,
   };
   const obj: LibrarySymbolReference & Record<string, unknown> = {
     [REFKEYABLE]() {
@@ -220,6 +248,25 @@ function createSymbolEntry(
   return obj;
 }
 
+/**
+ * Resolves a member descriptor's `type` field to a symbol, or undefined if it's
+ * an inline descriptor (anonymous type) that can't be materialized as a symbol.
+ */
+function resolveTypeRef(
+  type: MemberDescriptor["type"],
+): ReturnType<LibrarySymbolReference[typeof TO_SYMBOL]> | undefined {
+  if (type === undefined) return undefined;
+  if (typeof type === "function") {
+    const resolved = type();
+    if (isLibrarySymbolReference(resolved)) return resolved[TO_SYMBOL]();
+    // Function returned a raw descriptor (circular self-reference) — no symbol
+    return undefined;
+  }
+  if (isLibrarySymbolReference(type)) return type[TO_SYMBOL]();
+  // Inline descriptor (anonymous type) — no symbol to reference
+  return undefined;
+}
+
 function createSymbolFromDescriptor(
   name: string,
   binder: Binder | undefined,
@@ -228,6 +275,7 @@ function createSymbolFromDescriptor(
   lazyMemberInitializer: () => void,
 ): TypeSpecSymbol {
   const parent = context.parent(binder);
+  const libOpts = context.libraryOptions;
 
   switch (descriptor.kind) {
     case "namespace": {
@@ -243,6 +291,8 @@ function createSymbolFromDescriptor(
         binder,
         refkeys: refkey(),
         lazyMemberInitializer,
+        packageImport: libOpts?.packageImport,
+        implicitlyUsed: libOpts?.implicitlyUsed,
       });
     }
     case "union":
@@ -257,6 +307,8 @@ function createSymbolFromDescriptor(
           binder,
           refkeys: refkey(),
           lazyMemberInitializer,
+          packageImport: libOpts?.packageImport,
+          implicitlyUsed: libOpts?.implicitlyUsed,
         },
       );
     }
@@ -268,12 +320,10 @@ function createSymbolFromDescriptor(
       return new TypeSpecSymbol(namekey(name), parent.members, {
         binder,
         refkeys: refkey(),
-        type:
-          descriptor.type === undefined ? undefined
-          : typeof descriptor.type === "function" ?
-            descriptor.type()[TO_SYMBOL]()
-          : descriptor.type[TO_SYMBOL](),
+        type: resolveTypeRef(descriptor.type),
         lazyMemberInitializer,
+        packageImport: libOpts?.packageImport,
+        implicitlyUsed: libOpts?.implicitlyUsed,
       });
     }
     case "scalar": {
@@ -281,7 +331,12 @@ function createSymbolFromDescriptor(
         namekey(name),
         parent.members,
         descriptor.kind,
-        { binder, refkeys: refkey() },
+        {
+          binder,
+          refkeys: refkey(),
+          packageImport: libOpts?.packageImport,
+          implicitlyUsed: libOpts?.implicitlyUsed,
+        },
       );
     }
     default: {

--- a/packages/typespec/src/symbols/named-type.ts
+++ b/packages/typespec/src/symbols/named-type.ts
@@ -40,6 +40,8 @@ export class NamedTypeSymbol extends TypeSpecSymbol {
     const options = this.getCopyOptions();
     const copy = new NamedTypeSymbol(this.name, this.spaces, this.#kind, {
       ...options,
+      packageImport: this.packageImport,
+      implicitlyUsed: this.implicitlyUsed,
     });
     this.initializeCopy(copy);
     return copy;

--- a/packages/typespec/src/symbols/reference.ts
+++ b/packages/typespec/src/symbols/reference.ts
@@ -13,7 +13,22 @@ import { SourceFileScope, useSourceFileScope } from "../scopes/source-file.js";
 import { relativePath } from "../util.js";
 import { TypeSpecSymbol } from "./typespec.js";
 
-export function ref(refkey: Refkey): Ref<OutputSymbol | undefined> {
+export interface RefResult {
+  symbol: OutputSymbol;
+  /**
+   * The access path to render for this reference. After namespace members
+   * are consumed for `using` resolution, this contains only non-namespace
+   * members that must be rendered as a dot-separated path.
+   *
+   * Examples:
+   *   - `TypeSpec.Record` → accessPath = [] (Record is directly accessible)
+   *   - `TypeSpec.Lifecycle.Read` → accessPath = [Read] (Lifecycle is the
+   *     lexical declaration, Read is a member to render)
+   */
+  accessPath: OutputSymbol[];
+}
+
+export function ref(refkey: Refkey): Ref<RefResult | undefined> {
   const scope = useSourceFileScope();
   if (!scope) {
     throw new Error("Reference used outside of a source file scope.");
@@ -24,50 +39,65 @@ export function ref(refkey: Refkey): Ref<OutputSymbol | undefined> {
       return undefined;
     }
     const result = resolveResult.value;
-    const { commonScope, pathUp, pathDown, lexicalDeclaration } = result;
+    const { commonScope, pathUp, pathDown } = result;
+    let { lexicalDeclaration } = result;
+    // Copy memberPath since we mutate it by shifting namespace members
+    const memberPath = [...result.memberPath];
 
     if (!validateSymbolReachable(pathDown)) {
       return undefined;
     }
 
+    // Shift namespace members off the front of memberPath. Each shifted
+    // namespace becomes the new lexical declaration, and the deepest
+    // namespace is the one we add a `using` for. This mirrors how C#
+    // handles nested namespace resolution.
+    let nsToUse: NamespaceSymbol | undefined;
+    while (
+      isNamespaceSymbol(lexicalDeclaration as TypeSpecSymbol) &&
+      memberPath.length > 0
+    ) {
+      nsToUse = lexicalDeclaration as NamespaceSymbol;
+      lexicalDeclaration = memberPath.shift()!;
+    }
+
+    // Library symbol resolution has three modes:
+    // 1. implicitlyUsed (e.g. TypeSpec core) — emit nothing
+    // 2. packageImport set (e.g. @typespec/http) — emit `import "pkg"` + `using Ns`
+    // 3. Neither (e.g. TypeSpec.Reflection) — falls through to the general
+    //    path below, which emits only `using` (no file import is generated
+    //    because library symbols have no SourceFileScope in their pathDown).
+    const targetSym = result.symbol as TypeSpecSymbol;
+
+    if (targetSym.implicitlyUsed) {
+      return { symbol: lexicalDeclaration, accessPath: memberPath };
+    }
+
+    if (targetSym.packageImport) {
+      scope.addImport(targetSym.packageImport);
+      if (nsToUse) {
+        scope.addUsing(nsToUse);
+      }
+      return { symbol: lexicalDeclaration, accessPath: memberPath };
+    }
+
     if (commonScope instanceof ProgramScope) {
       const originFileScope = pathUp.find((s) => s instanceof SourceFileScope);
-      const originPath = originFileScope?.name;
       const targetFileScope = pathDown.find(
         (s) => s instanceof SourceFileScope,
       );
-      const targetPath = targetFileScope?.name;
-      if (!originPath && !targetPath) {
-        throw new Error("Neither origin nor target path found for reference.");
+      if (originFileScope && targetFileScope) {
+        const importPath = relativePath(originFileScope.name, targetFileScope.name);
+        scope!.addImport(importPath);
       }
-      const importPath = relativePath(originPath!, targetPath!);
-      scope!.addImport(importPath);
-    }
-    if (lexicalDeclaration instanceof NamespaceSymbol) {
-      // Find the innermost namespace containing the target symbol for FQN.
-      const containingNs = findContainingNamespace(result.symbol);
-      scope.addUsing(containingNs ?? lexicalDeclaration);
     }
 
-    return result.symbol;
+    if (nsToUse) {
+      scope.addUsing(nsToUse);
+    }
+
+    return { symbol: lexicalDeclaration, accessPath: memberPath };
   });
-}
-
-/**
- * Finds the innermost namespace that contains the given symbol by walking
- * up the owner chain.
- */
-function findContainingNamespace(
-  symbol: OutputSymbol,
-): NamespaceSymbol | undefined {
-  let current = symbol.ownerSymbol;
-  while (current) {
-    if (isNamespaceSymbol(current as TypeSpecSymbol)) {
-      return current as NamespaceSymbol;
-    }
-    current = current.ownerSymbol;
-  }
-  return undefined;
 }
 
 /**

--- a/packages/typespec/src/symbols/reference.ts
+++ b/packages/typespec/src/symbols/reference.ts
@@ -87,7 +87,10 @@ export function ref(refkey: Refkey): Ref<RefResult | undefined> {
         (s) => s instanceof SourceFileScope,
       );
       if (originFileScope && targetFileScope) {
-        const importPath = relativePath(originFileScope.name, targetFileScope.name);
+        const importPath = relativePath(
+          originFileScope.name,
+          targetFileScope.name,
+        );
         scope!.addImport(importPath);
       }
     }

--- a/packages/typespec/src/symbols/typespec.ts
+++ b/packages/typespec/src/symbols/typespec.ts
@@ -5,7 +5,18 @@ import {
   OutputSymbolOptions,
 } from "@alloy-js/core";
 
-export interface TypeSpecSymbolOptions extends OutputSymbolOptions {}
+export interface TypeSpecSymbolOptions extends OutputSymbolOptions {
+  /**
+   * When set, referencing this symbol will automatically add
+   * an `import "<packageImport>";` to the source file.
+   */
+  packageImport?: string;
+  /**
+   * When true, this symbol is implicitly available without
+   * any `import` or `using` statement.
+   */
+  implicitlyUsed?: boolean;
+}
 
 export type TypeSpecSymbolKind =
   | "symbol"
@@ -22,12 +33,26 @@ export class TypeSpecSymbol extends OutputSymbol {
     options: TypeSpecSymbolOptions = {},
   ) {
     super(name, spaces, options);
+    this.#packageImport = options.packageImport;
+    this.#implicitlyUsed = options.implicitlyUsed ?? false;
+  }
+
+  #packageImport: string | undefined;
+  get packageImport() {
+    return this.#packageImport;
+  }
+
+  #implicitlyUsed: boolean;
+  get implicitlyUsed() {
+    return this.#implicitlyUsed;
   }
 
   copy(): OutputSymbol {
     const options = this.getCopyOptions();
     const copy = new TypeSpecSymbol(this.name, this.spaces, {
       ...options,
+      packageImport: this.#packageImport,
+      implicitlyUsed: this.#implicitlyUsed,
     });
     this.initializeCopy(copy);
 

--- a/packages/typespec/tsconfig.json
+++ b/packages/typespec/tsconfig.json
@@ -8,7 +8,7 @@
     "paths": {
       "#components/*": ["./src/components/*"],
       "#createLibrary": ["./src/create-library.ts"],
-      "#builtins": ["./src/builtins.ts"]
+      "#builtins": ["./src/builtins/index.ts"]
     }
   },
   "references": [{ "path": "../core" }],


### PR DESCRIPTION
…t resolution

- Add repeatable audit script to verify builtins match TypeSpec stdlib
- Add all builtin namespaces: TypeSpec, Http, OpenAPI, Rest, Versioning, Reflection
- Add packageImport/implicitlyUsed to TypeSpecSymbol for automatic import/using generation when referencing library builtins
- Implement three-mode resolution: implicitlyUsed, packageImport, using-only
- Add namespace-shifting in ref() for correct member path rendering (e.g. Lifecycle.Read, DiscriminatedOptions.envelope)
- Add typeArgs prop to Reference component for template types
- Handle inline descriptors gracefully in createLibrary (anonymous types)
- Fix copy() to preserve library metadata
- Add OpenAPI3 separate library entry for split-namespace support