### PR TITLE
fix: resolve function-local refkeys from indented `code` blocks (#429)

### DIFF
--- a/.chronus/changes/fix-indented-code-refkey-scope-2026-6-24-15-42-0.md
+++ b/.chronus/changes/fix-indented-code-refkey-scope-2026-6-24-15-42-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+Fix references to function-local symbols (e.g. parameters) resolving against the wrong scope when emitted from an indented line of a `code` template. Child collection no longer eagerly invokes intrinsic (`indent`/`group`/...) creators, so their refkeys resolve at render time inside the correct scope.

--- a/packages/core/src/runtime/component.ts
+++ b/packages/core/src/runtime/component.ts
@@ -6,6 +6,33 @@ import type { AlloyNode } from "../render/node.js";
 export const RENDERABLE = Symbol.for("Alloy.CustomElement");
 
 /**
+ * Marker placed on the thunks produced by `sti(...)` (the simple template
+ * component creators for intrinsics such as `indent`, `group`, `hbr`).
+ *
+ * Unlike a {@link ComponentCreator}, these thunks eagerly materialize an
+ * intrinsic `ElementNode` (resolving any refkey children) the moment they are
+ * invoked. Child-collection helpers such as `children()`/`childrenArray()` must
+ * therefore treat them as opaque leaves rather than invoking them during keyed
+ * child analysis — otherwise refkeys get resolved against the wrong scope
+ * before the owning component has established its own scope.
+ *
+ * @internal
+ */
+export const _INTRINSIC_CREATOR = Symbol.for("Alloy.IntrinsicCreator");
+
+/**
+ * Returns true if `item` is a thunk produced by `sti(...)` (see
+ * {@link _INTRINSIC_CREATOR}).
+ *
+ * @internal
+ */
+export function _isIntrinsicCreator(item: unknown): boolean {
+  return (
+    typeof item === "function" && (item as any)[_INTRINSIC_CREATOR] === true
+  );
+}
+
+/**
  * A renderable object is any object that has an `[ay.RENDERABLE]` method that
  * returns children. This is used to allow custom object types to be used as
  * children in Alloy components.

--- a/packages/core/src/sti.ts
+++ b/packages/core/src/sti.ts
@@ -1,6 +1,6 @@
 import { code, text } from "./code.js";
 import type { ElementNode } from "./render/node.js";
-import { Children } from "./runtime/component.js";
+import { Children, _INTRINSIC_CREATOR } from "./runtime/component.js";
 import { createIntrinsic } from "./runtime/create-intrinsic.js";
 import { IntrinsicElements } from "./runtime/intrinsic.js";
 
@@ -28,14 +28,18 @@ export function sti<T extends keyof IntrinsicElements>(
 ): StiSignature<T> {
   return (...args) => {
     const props: IntrinsicElements[T] | undefined = args[0];
-    const fn: StiComponentCreator = () => createIntrinsic(name, props);
+    const fn = markIntrinsicCreator(() =>
+      createIntrinsic(name, props),
+    ) as StiComponentCreator;
     fn.children = (...children: Children[]) => {
       const propsWithChildren = {
         ...(props ?? {}),
         children,
       };
 
-      return () => createIntrinsic(name, propsWithChildren as any);
+      return markIntrinsicCreator(() =>
+        createIntrinsic(name, propsWithChildren as any),
+      );
     };
 
     fn.code = (template, ...substitutions) => {
@@ -44,7 +48,9 @@ export function sti<T extends keyof IntrinsicElements>(
         children: code(template, ...substitutions),
       };
 
-      return () => createIntrinsic(name, propsWithChildren as any);
+      return markIntrinsicCreator(() =>
+        createIntrinsic(name, propsWithChildren as any),
+      );
     };
 
     fn.text = (template, ...substitutions) => {
@@ -53,8 +59,17 @@ export function sti<T extends keyof IntrinsicElements>(
         children: text(template, ...substitutions),
       };
 
-      return () => createIntrinsic(name, propsWithChildren as any);
+      return markIntrinsicCreator(() =>
+        createIntrinsic(name, propsWithChildren as any),
+      );
     };
     return fn;
   };
+}
+
+function markIntrinsicCreator<T extends (...args: any[]) => ElementNode>(
+  fn: T,
+): T {
+  (fn as any)[_INTRINSIC_CREATOR] = true;
+  return fn;
 }

--- a/packages/core/src/utils.tsx
+++ b/packages/core/src/utils.tsx
@@ -15,6 +15,7 @@ import {
 } from "./reactivity.js";
 import { AlloyNode, FRAGMENT_NODE } from "./render/node.js";
 import {
+  _isIntrinsicCreator,
   Children,
   ComponentCreator,
   isComponentCreator,
@@ -501,7 +502,8 @@ export function children(
       return children.map(collectChildren).flat();
     } else if (
       typeof children === "function" &&
-      !isComponentCreator(children)
+      !isComponentCreator(children) &&
+      !_isIntrinsicCreator(children)
     ) {
       return collectChildren(children());
     } else if (children instanceof AlloyNode) {

--- a/packages/core/test/children.test.tsx
+++ b/packages/core/test/children.test.tsx
@@ -1,4 +1,10 @@
-import { children, Children } from "@alloy-js/core";
+import {
+  children,
+  Children,
+  childrenArray,
+  code,
+  isComponentCreator,
+} from "@alloy-js/core";
 import { expect, it } from "vitest";
 
 it("handles a single element", () => {
@@ -25,4 +31,45 @@ it("handles a multiple elements", () => {
       <Bar />
     </Foo>,
   ).toRenderTo(`BarBar`);
+});
+
+it("does not eagerly invoke intrinsic creators from indented code blocks", () => {
+  // Indented lines of a `code` block are wrapped in `indent(...)` intrinsic
+  // creators. `childrenArray`/`children` must keep them opaque rather than
+  // invoking them during keyed-child analysis, otherwise their children
+  // (e.g. refkeys) get materialized against the wrong scope. See issue #429.
+  const arr = childrenArray(
+    () => code`
+      if (x) {
+        return 1;
+      }
+    `,
+  );
+
+  // The intrinsic creators are left opaque (still functions) ...
+  expect(arr.some((c) => typeof c === "function")).toBe(true);
+  // ... and they are not mistaken for component creators (so keyed-child
+  // analysis and unkeyed-child routing keep treating them as plain content).
+  expect(arr.every((c) => !isComponentCreator(c))).toBe(true);
+
+  function Wrapper(props: { children?: Children }) {
+    // Force the same children-analysis path a scope-introducing component
+    // (e.g. FunctionDeclaration) uses before rendering its body.
+    const collected = childrenArray(() => props.children);
+    return collected;
+  }
+
+  expect(
+    <Wrapper>
+      {code`
+        if (x) {
+          return 1;
+        }
+      `}
+    </Wrapper>,
+  ).toRenderTo(`
+    if (x) {
+      return 1;
+    }
+  `);
 });

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -1,4 +1,5 @@
 import {
+  code,
   List,
   memberRefkey,
   namekey,
@@ -157,6 +158,38 @@ it("supports type parameters by element", () => {
   `);
 });
 
+it("resolves references to function-local symbols from deeply indented code blocks (#429)", () => {
+  const value = refkey();
+  expect(
+    <TestFile>
+      <FunctionDeclaration
+        export
+        name="serialize"
+        parameters={[{ name: "value", type: "string | null", refkey: value }]}
+        returnType="string"
+      >
+        {code`
+          if (value) {
+            if (!${value}) {
+              return ${value} as any;
+            }
+          }
+          return ${value};
+        `}
+      </FunctionDeclaration>
+    </TestFile>,
+  ).toRenderTo(`
+    export function serialize(value: string | null): string {
+      if (value) {
+        if (!value) {
+          return value as any;
+        }
+      }
+      return value;
+    }
+  `);
+});
+
 it("do not add an extra comma when there is no parameters", () => {
   expect(
     <TestFile>
@@ -165,6 +198,34 @@ it("do not add an extra comma when there is no parameters", () => {
   ).toRenderTo(`
     function thisFunctionNameIsTooLongSoTheFormatterWillInsertLineBreakAndIfBreakNodes() {
 
+    }
+  `);
+});
+
+it("resolves references to function-local symbols from indented code blocks (#429)", () => {
+  const value = refkey();
+  expect(
+    <TestFile>
+      <FunctionDeclaration
+        export
+        name="serialize"
+        parameters={[{ name: "value", type: "string | null", refkey: value }]}
+        returnType="string"
+      >
+        {code`
+          if (!${value}) {
+            return ${value} as any;
+          }
+          return ${value};
+        `}
+      </FunctionDeclaration>
+    </TestFile>,
+  ).toRenderTo(`
+    export function serialize(value: string | null): string {
+      if (!value) {
+        return value as any;
+      }
+      return value;
     }
   `);
 });


### PR DESCRIPTION
Fixes #429.

## Problem

Referencing a **function-local symbol** (a parameter or local declaration) via a refkey from an **indented** line inside a `code` template throws:

```
Error: Cannot reference a symbol inside a function from outside a function
```

The same reference at the base (non-indented) line works. Regression from `0.23.x` introduced by the eager `createIntrinsic` insert change in `0.24.0`.

## Root cause

`code` wraps every indented line in an `indent(...)` intrinsic creator produced by `sti()` — a plain `() => createIntrinsic("indent", props)` thunk. Scope-introducing components such as `FunctionDeclaration` call `childrenArray(() => props.children)` to locate keyed children **before** wrapping the body in `<LexicalScope>`.

`children()` → `collectChildren` eagerly **invokes** plain function children. Invoking the `indent` thunk runs `createIntrinsic`, which now eagerly `insert`s its children; for refkey children that runs `insertRefkey` → `insertReactive` → `effect`, capturing the **module scope** as the owner (the `LexicalScope` hasn't been entered yet). The refkey then resolves against the wrong scope and `validateSymbolReachable` throws.

Base-level refkeys avoid this because they are never wrapped in a thunk, so they stay opaque and resolve later inside the correct scope.

## Fix

This is the same hazard `collectChildren` already guards against for `ComponentCreator`s: deferred thunks with context-sensitive side effects must run at their insertion point, not during keyed-child analysis.

- Add an internal `_INTRINSIC_CREATOR` marker symbol + `_isIntrinsicCreator()` predicate, and tag every thunk produced by `sti()`.
- In `collectChildren`, skip invoking intrinsic creators (mirroring the existing `isComponentCreator` skip). They stay opaque during child analysis and are only invoked at render time via `insertReactive`, inside the correct scope.

This can only improve context-correctness — for components where analysis context equals render context (the vast majority) the materialized output is identical; only scope-repositioning components like `FunctionDeclaration` are affected, and for those the refkey now resolves at its true render site.

### Trade-off

Each intrinsic produced by `code`/`sti` now reaches `insert` as a function and goes through `insertReactive` (one bracketed slot + one effect) instead of being materialized during collection. The outer effect has no tracked deps (it's effectively one-shot) and comment markers don't count as content, so output and formatting are unchanged.

## Tests

- `packages/core/test/children.test.tsx` — `childrenArray` keeps intrinsic creators opaque (not invoked, not mistaken for component creators) and still renders correctly.
- `packages/typescript/test/function-declaration.test.tsx` — end-to-end regressions for a `FunctionDeclaration` whose body is a `code` block referencing a parameter refkey from an indented and a deeply (2-level) indented line.

Reviewed by the project's `architect` agent; feedback (mark exports `@internal`, unify the marking path, add a deep-nested test, document the trade-off) incorporated.

All package test suites pass; `build`, `lint`, and `format` are clean.