### PR TITLE
fix: function-local refkeys from indented code blocks via ComponentCreator (#429) [alt to #430]

### DIFF
--- a/.chronus/changes/fix-indented-code-refkey-scope-2026-6-24-15-42-0.md
+++ b/.chronus/changes/fix-indented-code-refkey-scope-2026-6-24-15-42-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@alloy-js/core"
+---
+
+Fix references to function-local symbols (e.g. parameters) resolving against the wrong scope when emitted from an indented line of a `code` template. Child collection no longer eagerly invokes intrinsic (`indent`/`group`/...) creators, so their refkeys resolve at render time inside the correct scope.

--- a/packages/core/src/sti.ts
+++ b/packages/core/src/sti.ts
@@ -1,6 +1,5 @@
 import { code, text } from "./code.js";
-import type { ElementNode } from "./render/node.js";
-import { Children } from "./runtime/component.js";
+import { Children, Component, ComponentCreator } from "./runtime/component.js";
 import { createIntrinsic } from "./runtime/create-intrinsic.js";
 import { IntrinsicElements } from "./runtime/intrinsic.js";
 
@@ -11,50 +10,59 @@ export type StiSignature<T extends keyof IntrinsicElements> = (
   : [props: IntrinsicElements[T]]
 ) => StiComponentCreator;
 
-export type StiComponentCreator = (() => ElementNode) & {
+export type StiComponentCreator = ComponentCreator & {
   code(
     template: TemplateStringsArray,
     ...substitutions: Children[]
-  ): () => ElementNode;
+  ): ComponentCreator;
   text(
     template: TemplateStringsArray,
     ...substitutions: Children[]
-  ): () => ElementNode;
-  children(...children: Children[]): () => ElementNode;
+  ): ComponentCreator;
+  children(...children: Children[]): ComponentCreator;
 };
 
 export function sti<T extends keyof IntrinsicElements>(
   name: T,
 ): StiSignature<T> {
+  // A stable component identity for this intrinsic. Producing `ComponentCreator`s
+  // (rather than plain function thunks) means child collection
+  // (`children()`/`childrenArray()`) treats them as opaque deferred thunks
+  // instead of invoking them during keyed-child analysis. `insert` then runs
+  // them at their real render position, inside the correct owner context, so
+  // refkeys in indented `code` blocks resolve against the right scope.
+  const component: Component = (props) =>
+    createIntrinsic(name, props as IntrinsicElements[T]);
+  // Give the component a readable identity so render-stack / error diagnostics
+  // report the intrinsic name (e.g. "indent") rather than "component".
+  Object.defineProperty(component, "name", { value: name });
+
+  function createCreator(props?: IntrinsicElements[T]): ComponentCreator {
+    const creator: ComponentCreator = () => createIntrinsic(name, props);
+    creator.component = component;
+    creator.props = props as any;
+    return creator;
+  }
+
   return (...args) => {
     const props: IntrinsicElements[T] | undefined = args[0];
-    const fn: StiComponentCreator = () => createIntrinsic(name, props);
-    fn.children = (...children: Children[]) => {
-      const propsWithChildren = {
+    const fn = createCreator(props) as StiComponentCreator;
+
+    fn.children = (...children: Children[]) =>
+      createCreator({ ...(props ?? {}), children } as any);
+
+    fn.code = (template, ...substitutions) =>
+      createCreator({
         ...(props ?? {}),
-        children,
-      };
-
-      return () => createIntrinsic(name, propsWithChildren as any);
-    };
-
-    fn.code = (template, ...substitutions) => {
-      const propsWithChildren = {
-        ...(args[0] ?? {}),
         children: code(template, ...substitutions),
-      };
+      } as any);
 
-      return () => createIntrinsic(name, propsWithChildren as any);
-    };
-
-    fn.text = (template, ...substitutions) => {
-      const propsWithChildren = {
-        ...(args[0] ?? {}),
+    fn.text = (template, ...substitutions) =>
+      createCreator({
+        ...(props ?? {}),
         children: text(template, ...substitutions),
-      };
+      } as any);
 
-      return () => createIntrinsic(name, propsWithChildren as any);
-    };
     return fn;
   };
 }

--- a/packages/core/test/children.test.tsx
+++ b/packages/core/test/children.test.tsx
@@ -1,4 +1,10 @@
-import { children, Children } from "@alloy-js/core";
+import {
+  children,
+  Children,
+  childrenArray,
+  code,
+  isComponentCreator,
+} from "@alloy-js/core";
 import { expect, it } from "vitest";
 
 it("handles a single element", () => {
@@ -25,4 +31,46 @@ it("handles a multiple elements", () => {
       <Bar />
     </Foo>,
   ).toRenderTo(`BarBar`);
+});
+
+it("does not eagerly invoke intrinsic creators from indented code blocks", () => {
+  // Indented lines of a `code` block are wrapped in `indent(...)` intrinsic
+  // creators. `childrenArray`/`children` must keep them opaque rather than
+  // invoking them during keyed-child analysis, otherwise their children
+  // (e.g. refkeys) get materialized against the wrong scope. See issue #429.
+  const arr = childrenArray(
+    () => code`
+      if (x) {
+        return 1;
+      }
+    `,
+  );
+
+  // The indented lines are represented by intrinsic component creators that
+  // are left opaque (still functions, not invoked/materialized) ...
+  expect(arr.some((c) => typeof c === "function")).toBe(true);
+  // ... because they are deferred component creators, which child collection
+  // skips during keyed-child analysis (running them later at insert time).
+  expect(arr.some((c) => isComponentCreator(c))).toBe(true);
+
+  function Wrapper(props: { children?: Children }) {
+    // Force the same children-analysis path a scope-introducing component
+    // (e.g. FunctionDeclaration) uses before rendering its body.
+    const collected = childrenArray(() => props.children);
+    return collected;
+  }
+
+  expect(
+    <Wrapper>
+      {code`
+        if (x) {
+          return 1;
+        }
+      `}
+    </Wrapper>,
+  ).toRenderTo(`
+    if (x) {
+      return 1;
+    }
+  `);
 });

--- a/packages/typescript/test/function-declaration.test.tsx
+++ b/packages/typescript/test/function-declaration.test.tsx
@@ -1,4 +1,5 @@
 import {
+  code,
   List,
   memberRefkey,
   namekey,
@@ -157,6 +158,38 @@ it("supports type parameters by element", () => {
   `);
 });
 
+it("resolves references to function-local symbols from deeply indented code blocks (#429)", () => {
+  const value = refkey();
+  expect(
+    <TestFile>
+      <FunctionDeclaration
+        export
+        name="serialize"
+        parameters={[{ name: "value", type: "string | null", refkey: value }]}
+        returnType="string"
+      >
+        {code`
+          if (value) {
+            if (!${value}) {
+              return ${value} as any;
+            }
+          }
+          return ${value};
+        `}
+      </FunctionDeclaration>
+    </TestFile>,
+  ).toRenderTo(`
+    export function serialize(value: string | null): string {
+      if (value) {
+        if (!value) {
+          return value as any;
+        }
+      }
+      return value;
+    }
+  `);
+});
+
 it("do not add an extra comma when there is no parameters", () => {
   expect(
     <TestFile>
@@ -165,6 +198,34 @@ it("do not add an extra comma when there is no parameters", () => {
   ).toRenderTo(`
     function thisFunctionNameIsTooLongSoTheFormatterWillInsertLineBreakAndIfBreakNodes() {
 
+    }
+  `);
+});
+
+it("resolves references to function-local symbols from indented code blocks (#429)", () => {
+  const value = refkey();
+  expect(
+    <TestFile>
+      <FunctionDeclaration
+        export
+        name="serialize"
+        parameters={[{ name: "value", type: "string | null", refkey: value }]}
+        returnType="string"
+      >
+        {code`
+          if (!${value}) {
+            return ${value} as any;
+          }
+          return ${value};
+        `}
+      </FunctionDeclaration>
+    </TestFile>,
+  ).toRenderTo(`
+    export function serialize(value: string | null): string {
+      if (!value) {
+        return value as any;
+      }
+      return value;
     }
   `);
 });


### PR DESCRIPTION
Fixes #429. **Alternative implementation to #430** — open both so they can be compared; only one should be merged.

## Problem

Referencing a **function-local symbol** (a parameter or local) via a refkey from an **indented** line inside a `code` template throws `Cannot reference a symbol inside a function from outside a function`. Base-level lines work. Regression from `0.23.x`, caused by the eager `createIntrinsic` insert in `0.24.0`.

`code` wraps indented lines in `indent(...)` intrinsic thunks from `sti()`. Scope-introducing components such as `FunctionDeclaration` call `childrenArray(...)` to find keyed children **before** entering their `LexicalScope`. `collectChildren` eagerly invokes plain function children, so the `indent` thunk runs `createIntrinsic` → eager `insert` → `insertRefkey` → `effect`, capturing the **module scope** as owner. The refkey then resolves against the wrong scope.

## This approach: make `sti()` thunks real `ComponentCreator`s

Instead of introducing a dedicated marker (#430's approach), give the thunks produced by `sti()` a `.component` and `.props`, so they are genuine `ComponentCreator`s:

- `collectChildren` **already** skips `ComponentCreator`s (`isComponentCreator`) — deferred thunks must run at their insertion point, not during keyed-child analysis. So the fix reuses existing machinery with no new concept.
- `insert` routes them through `insertComponent` → `runInContext`, running `createIntrinsic` at the real render position inside the correct owner context, so refkeys resolve against the right scope.
- The intrinsic's `component` is given a readable `name` so render-stack / error diagnostics report e.g. `indent` rather than `component`.

## Trade-off vs #430

This is conceptually simpler (no new `_INTRINSIC_CREATOR` symbol; reuses `isComponentCreator`), but it changes how **every** intrinsic produced by `code`/`sti` (every `hbr()`, `indent`, `group`, ...) is inserted: they now go through the **component path** (`insertComponent` → `pushStack` + `beginComponent` debug session, and in rerender-debug mode `component:start`/`component:end` markers) instead of `insertReactive`. That means more render-stack frames / debug-session churn in hot paths.

#430 instead keeps intrinsics on the lighter `insertReactive` path and only opts them out of child-collection via a marker. Pick based on whether treating intrinsics as components (uniform model, heavier path) or as reactive bindings (lighter, extra concept) is preferred.

## Tests

Same regressions as #430:
- `packages/core/test/children.test.tsx` — `childrenArray` keeps intrinsic creators opaque (here: detected as deferred component creators) and renders correctly.
- `packages/typescript/test/function-declaration.test.tsx` — indented and deeply (2-level) indented `code` referencing a parameter refkey.

All package suites pass (1556 tests); `build`, `lint`, `format` clean.
