### PR TITLE
Fix dev-publish: run chronus bin directly to bypass pnpm frozen-lockfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - run: node node_modules/.bin/chronus version --prerelease
+      - run: pnpm chronus version --prerelease
         name: Bump prerelease version
 
-      - run: NODE_AUTH_TOKEN="" node node_modules/.bin/chronus publish --access public --tag next
+      - run: NODE_AUTH_TOKEN="" pnpm chronus publish --access public --tag next
         name: Publish Dev versions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - run: pnpm chronus version --prerelease
+      # Invoke the chronus bin directly (not via `pnpm`) so pnpm's frozen-lockfile
+      # deps check doesn't run: `chronus version --prerelease` rewrites `workspace:`
+      # specifiers in the manifests, which would otherwise make the lockfile look
+      # out of date. `node node_modules/.bin/chronus` cannot be used because that
+      # entry is a shell shim, not a JS file.
+      - run: node_modules/.bin/chronus version --prerelease
         name: Bump prerelease version
 
-      - run: NODE_AUTH_TOKEN="" pnpm chronus publish --access public --tag next
+      - run: NODE_AUTH_TOKEN="" node_modules/.bin/chronus publish --access public --tag next
         name: Publish Dev versions


### PR DESCRIPTION
## What

Fixes the two `Publish` workflow steps that run Chronus after `chronus version --prerelease`.

## Root cause

`chronus version --prerelease` rewrites `workspace:` dependency specifiers in the package manifests (e.g. `@alloy-js/babel-plugin` `workspace:~` → `~0.2.1 || >= 0.2.2-dev.2`). After that, the working-tree manifests no longer match `pnpm-lock.yaml`, so any command invoked through `pnpm` triggers pnpm's frozen-lockfile deps check and fails:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with .../packages/babel-preset-alloy/package.json
```

Commit 6c2a6d5e (#428) tried to bypass pnpm for these steps but used `node node_modules/.bin/chronus`. That entry is a `#!/bin/sh` shim, not a JS file, so Node parsed the shell script as JavaScript:

```
node_modules/.bin/chronus:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^
SyntaxError: missing ) after argument list
```

## Fix

Invoke the Chronus bin **directly** (no `node`, no `pnpm`), which both runs valid code via its shebang and avoids pnpm's frozen-lockfile deps check:

- `node node_modules/.bin/chronus version --prerelease` → `node_modules/.bin/chronus version --prerelease`
- `... node node_modules/.bin/chronus publish --access public --tag next` → `... node_modules/.bin/chronus publish --access public --tag next`

A comment documents why `pnpm` and `node`-prefixed invocation are both avoided.

## Verification

Locally, `node_modules/.bin/chronus --version` prints `1.3.1`, while `node node_modules/.bin/chronus --version` reproduces the `SyntaxError`.

Refs:
- failing run https://github.com/alloy-framework/alloy/actions/runs/28132368376/job/83311410891
- frozen-lockfile failure https://github.com/alloy-framework/alloy/actions/runs/27229719577/job/80406316059
