### PR TITLE
fix(typespec): align package.json exports with dev build convention

### DIFF
--- a/packages/typespec/package.json
+++ b/packages/typespec/package.json
@@ -4,31 +4,36 @@
   "description": "",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "source": "./src/index.ts",
+      "development": "./dist/dev/src/index.js",
       "import": "./dist/src/index.js"
     },
     "./builtins": {
-      "development": "./src/builtins/index.ts",
+      "source": "./src/builtins/index.ts",
+      "development": "./dist/dev/src/builtins/index.js",
       "import": "./dist/src/builtins/index.js"
     },
     "./stc": {
-      "development": "./src/components/stc/index.ts",
+      "source": "./src/components/stc/index.ts",
+      "development": "./dist/dev/src/components/stc/index.js",
       "import": "./dist/src/components/stc/index.js"
     },
     "./testing": {
-      "development": "./testing/index.ts",
+      "source": "./testing/index.ts",
+      "development": "./dist/dev/testing/index.js",
       "import": "./dist/testing/index.js"
     }
   },
   "imports": {
     "#components/*": {
-      "development": "./src/components/*",
+      "source": "./src/components/*",
+      "development": "./dist/dev/src/components/*",
       "default": "./dist/src/components/*"
     }
   },
   "scripts": {
     "generate-docs": "api-extractor run",
-    "build": "alloy build && pnpm run generate-docs",
+    "build": "alloy build --with-dev && pnpm run generate-docs",
     "clean": "rimraf dist/ .temp/",
     "test:watch": "vitest -w",
     "watch": "alloy build --watch",


### PR DESCRIPTION
Update exports to use dist/dev/ paths for development condition and add source condition, matching the pattern used by other language packages (typescript, csharp, etc.). Switch build to use --with-dev so the dev build with source info is produced in dist/dev/.