### PR TITLE
fix(typespec): skip redundant using for cross-file same-namespace ref…

### DIFF
--- a/packages/typespec/src/components/reference/reference.test.tsx
+++ b/packages/typespec/src/components/reference/reference.test.tsx
@@ -59,6 +59,35 @@ it("properly resolves types in the same file and namespace", () => {
   });
 });
 
+it("does not emit a redundant using for cross-file references in the same namespace", () => {
+  const barRefkey = refkey();
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="a.tsp">
+        <Namespace name="A">
+          <ScalarDeclaration name="Bar" refkey={barRefkey} />
+        </Namespace>
+      </SourceFile>
+      <SourceFile path="b.tsp">
+        <Namespace name="A">
+          <Reference refkey={barRefkey} />
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo({
+    "a.tsp": `
+      namespace A;
+
+      scalar Bar`,
+    "b.tsp": `
+      import "./a.tsp";
+
+      namespace A;
+
+      Bar`,
+  });
+});
+
 it("properly resolves types in the same file and different namespace", () => {
   const barRefkey = refkey();
   expect(

--- a/packages/typespec/src/symbols/reference.ts
+++ b/packages/typespec/src/symbols/reference.ts
@@ -8,6 +8,7 @@ import {
 } from "@alloy-js/core";
 import { isNamespaceSymbol, NamespaceSymbol } from "../index.js";
 import { NamedTypeScope } from "../scopes/named-type.js";
+import { NamespaceScope } from "../scopes/namespace.js";
 import { ProgramScope } from "../scopes/program.js";
 import { SourceFileScope, useSourceFileScope } from "../scopes/source-file.js";
 import { relativePath } from "../util.js";
@@ -95,7 +96,7 @@ export function ref(refkey: Refkey): Ref<RefResult | undefined> {
       }
     }
 
-    if (nsToUse && !nsToUse.isGlobal) {
+    if (nsToUse && !nsToUse.isGlobal && !isOriginInNamespace(pathUp, nsToUse)) {
       scope.addUsing(nsToUse);
     }
 
@@ -110,4 +111,21 @@ export function ref(refkey: Refkey): Ref<RefResult | undefined> {
  */
 function validateSymbolReachable(pathDown: OutputScope[]): boolean {
   return !pathDown.some((s) => s instanceof NamedTypeScope);
+}
+
+/**
+ * Checks whether the origin scope (the reference site) is already inside
+ * the given namespace. When true, a `using` statement is redundant because
+ * the namespace's members are already in scope.
+ */
+function isOriginInNamespace(
+  pathUp: OutputScope[],
+  ns: NamespaceSymbol,
+): boolean {
+  const nsFqn = ns.getFullyQualifiedName();
+  return pathUp.some(
+    (s) =>
+      s instanceof NamespaceScope &&
+      s.ownerSymbol.getFullyQualifiedName() === nsFqn,
+  );
 }


### PR DESCRIPTION
…erences

When two files share the same namespace, a reference from one to the other should emit an import but not a using statement, since the namespace members are already in scope. Add isOriginInNamespace check to suppress the redundant using.