### PR TITLE
fix(typespec): isolate model expression scopes to prevent property de…

### DIFF
--- a/packages/typespec/src/components/model/model-declaration.test.tsx
+++ b/packages/typespec/src/components/model/model-declaration.test.tsx
@@ -5,8 +5,10 @@ import { resetProgram } from "../../contexts/program.js";
 import { createTypeSpecNamePolicy } from "../../name-policy.js";
 import { DecoratorApplication } from "../decorator/decorator-application.jsx";
 import { Namespace } from "../namespace/namespace.jsx";
+import { OperationDeclaration } from "../operation/operation-declaration.jsx";
 import { Reference } from "../reference/reference.jsx";
 import { SourceFile } from "../source-file/source-file.jsx";
+import { UnionExpression } from "../union/union-expression.jsx";
 import { ModelDeclaration } from "./model-declaration.jsx";
 import { ModelExpression } from "./model-expression.jsx";
 import { ModelProperty } from "./model-property.jsx";
@@ -499,6 +501,54 @@ it("renders a model property with a numeric default value", () => {
   ).toRenderTo(`
     model Dog {
       age: uint8 = 0
+    }
+  `);
+});
+
+it("does not deconflict property names across separate model expressions", () => {
+  expect(
+    <Output namePolicy={createTypeSpecNamePolicy()}>
+      <SourceFile path="main.tsp">
+        <Namespace name="A">
+          <OperationDeclaration
+            name="listThings"
+            parameters={[]}
+            returnType={
+              <UnionExpression
+                types={[
+                  <ModelExpression>
+                    <ModelProperty name="data" type="string[]" />
+                  </ModelExpression>,
+                  <ModelExpression>
+                    <StatementList>
+                      <ModelProperty name="statusCode" type="int32" />
+                      <ModelProperty name="body" type="ErrorResponse" />
+                    </StatementList>
+                  </ModelExpression>,
+                  <ModelExpression>
+                    <StatementList>
+                      <ModelProperty name="statusCode" type="int32" />
+                      <ModelProperty name="body" type="ErrorResponse" />
+                    </StatementList>
+                  </ModelExpression>,
+                ]}
+              />
+            }
+          />
+        </Namespace>
+      </SourceFile>
+    </Output>,
+  ).toRenderTo(`
+    namespace A;
+
+    op listThings(): {
+      data: string[]
+    } | {
+      statusCode: int32;
+      body: ErrorResponse;
+    } | {
+      statusCode: int32;
+      body: ErrorResponse;
     }
   `);
 });

--- a/packages/typespec/src/components/model/model-expression.tsx
+++ b/packages/typespec/src/components/model/model-expression.tsx
@@ -1,9 +1,20 @@
-import { Block, Children } from "@alloy-js/core";
+import { Block, Children, onCleanup, Scope, useScope } from "@alloy-js/core";
+import { NamedTypeScope } from "../../scopes/named-type.js";
+import { NamedTypeSymbol } from "../../symbols/named-type.js";
 
 export interface ModelExpressionProps {
   children?: Children;
 }
 
 export function ModelExpression(props: ModelExpressionProps) {
-  return <Block>{props.children}</Block>;
+  const parentScope = useScope();
+  const sym = new NamedTypeSymbol("{anonymous}", undefined, "model");
+  onCleanup(() => sym.delete());
+  const scope = new NamedTypeScope(sym, parentScope);
+
+  return (
+    <Scope value={scope}>
+      <Block>{props.children}</Block>
+    </Scope>
+  );
 }

--- a/packages/typespec/src/components/model/model-expression.tsx
+++ b/packages/typespec/src/components/model/model-expression.tsx
@@ -1,6 +1,6 @@
-import { Block, Children, onCleanup, Scope, useScope } from "@alloy-js/core";
+import { Block, Children, Scope, useScope } from "@alloy-js/core";
 import { NamedTypeScope } from "../../scopes/named-type.js";
-import { NamedTypeSymbol } from "../../symbols/named-type.js";
+import { createAnonymousModelSymbol } from "../../symbols/factories.js";
 
 export interface ModelExpressionProps {
   children?: Children;
@@ -8,8 +8,7 @@ export interface ModelExpressionProps {
 
 export function ModelExpression(props: ModelExpressionProps) {
   const parentScope = useScope();
-  const sym = new NamedTypeSymbol("{anonymous}", undefined, "model");
-  onCleanup(() => sym.delete());
+  const sym = createAnonymousModelSymbol();
   const scope = new NamedTypeScope(sym, parentScope);
 
   return (

--- a/packages/typespec/src/symbols/factories.ts
+++ b/packages/typespec/src/symbols/factories.ts
@@ -82,6 +82,12 @@ export function createNamedTypeSymbol(
   );
 }
 
+export function createAnonymousModelSymbol() {
+  return withCleanup(
+    new NamedTypeSymbol("{anonymous}", undefined, "model", { transient: true }),
+  );
+}
+
 export function createModelPropertySymbol(
   name: string | Namekey,
   options: OutputSymbolOptions = {},


### PR DESCRIPTION
…confliction

ModelExpression was not creating its own scope, so ModelProperty symbols from sibling expressions shared the parent NamedTypeScope and were incorrectly deconflicted (e.g. statusCode_2, body_2).

Create an anonymous NamedTypeScope in ModelExpression so each expression isolates its own property symbols.