### PR TITLE
Upgrade to TypeScript 7

### DIFF
--- a/.chronus/changes/feature-cli-native-tsc-2026-7-15.md
+++ b/.chronus/changes/feature-cli-native-tsc-2026-7-15.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/cli"
+---
+
+`alloy build` now uses the native TypeScript compiler binary, adding support for TypeScript 7. Type-checking and declaration emit shell out to the project's `tsc` instead of the (now removed) programmatic compiler API, and watch mode uses Node's built-in recursive file watcher. Requires Node.js >=22.

--- a/.chronus/changes/internal-typescript-api-extractor-2026-7-15.md
+++ b/.chronus/changes/internal-typescript-api-extractor-2026-7-15.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@alloy-js/typescript"
+---
+
+Silence API Extractor `ae-unresolved-link` warnings for `@link` references to namespace members that TypeScript 7 emits as re-exports.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/alloy-framework/alloy.git"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "watch": "tsc -p ./tsconfig.build.json --watch",

--- a/packages/cli/src/babel.ts
+++ b/packages/cli/src/babel.ts
@@ -30,26 +30,33 @@ export async function buildAllFiles(
   options: BuildOptions = {},
 ) {
   await Promise.all(
-    filenames.map(async (file) => {
-      const transform = await buildFile(file, {
-        ...options,
-      });
-      const relativePath = relative(rootDir, file).replace(/\.tsx?$/, ".js");
-      const outPath = join(outDir, relativePath);
-      await mkdir(dirname(outPath), { recursive: true });
-      let code = transform?.code as any;
-      const map = transform?.map;
-      if (map) {
-        const mapPath = `${outPath}.map`;
-        map.sources = map.sources.map((source) => {
-          return relative(dirname(mapPath), file);
-        });
-        await writeFile(mapPath, JSON.stringify(map));
-        code = addSourceMappingUrl(code, mapPath);
-      }
-      await writeFile(outPath, code);
-    }),
+    filenames.map((file) => buildFileToOutput(file, rootDir, outDir, options)),
   );
+}
+
+export async function buildFileToOutput(
+  file: string,
+  rootDir: string,
+  outDir: string,
+  options: BuildOptions = {},
+) {
+  const transform = await buildFile(file, {
+    ...options,
+  });
+  const relativePath = relative(rootDir, file).replace(/\.tsx?$/, ".js");
+  const outPath = join(outDir, relativePath);
+  await mkdir(dirname(outPath), { recursive: true });
+  let code = transform?.code as any;
+  const map = transform?.map;
+  if (map) {
+    const mapPath = `${outPath}.map`;
+    map.sources = map.sources.map((source) => {
+      return relative(dirname(mapPath), file);
+    });
+    await writeFile(mapPath, JSON.stringify(map));
+    code = addSourceMappingUrl(code, mapPath);
+  }
+  await writeFile(outPath, code);
 }
 
 function addSourceMappingUrl(code: string, loc: string) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,17 +1,17 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { rm, watch } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { join } from "pathe";
+import { dirname, join, relative } from "pathe";
 import pc from "picocolors";
-import ts from "typescript";
 
-import { buildAllFiles } from "../babel.js";
-import { getParseCommandLine } from "../typescript.js";
-
-const formatHost: ts.FormatDiagnosticsHost = {
-  getCanonicalFileName: (path) => path,
-  getCurrentDirectory: ts.sys.getCurrentDirectory,
-  getNewLine: () => ts.sys.newLine,
-};
+import { buildAllFiles, buildFileToOutput } from "../babel.js";
+import {
+  getParseCommandLine,
+  resolveTscBin,
+  type Config,
+} from "../typescript.js";
 
 interface BuildValues {
   watch?: boolean;
@@ -37,7 +37,7 @@ export async function buildCommand(argv: string[]) {
 
   const values = args.values as BuildValues;
   if (values.watch) {
-    watchMain(values);
+    await watchMain(values);
   } else {
     await build(values);
   }
@@ -46,40 +46,17 @@ export async function buildCommand(argv: string[]) {
 async function build(values: BuildValues) {
   const { addSourceInfo } = resolveBuildSettings(values);
   const opts = getParseCommandLine();
-  const program = ts.createIncrementalProgram({
-    rootNames: opts.fileNames,
-    options: opts.options,
-    projectReferences: opts.projectReferences,
-  });
-  const emitResult = program.emit();
   const start = new Date().getTime();
 
-  if (values["with-dev"]) {
-    await buildAllFiles(opts.fileNames, opts.rootDir, opts.outDir, {
-      sourceMaps: opts.options.sourceMap,
-      addSourceInfo: false,
-    });
-    const devOutDir = join(opts.outDir, "dev");
-    await buildAllFiles(opts.fileNames, opts.rootDir, devOutDir, {
-      sourceMaps: opts.options.sourceMap,
-      addSourceInfo: true,
-    });
-  } else {
-    await buildAllFiles(opts.fileNames, opts.rootDir, opts.outDir, {
-      sourceMaps: opts.options.sourceMap,
-      addSourceInfo,
-    });
-  }
+  await emitJs(opts, values, addSourceInfo);
 
-  const allDiagnostics = ts
-    .getPreEmitDiagnostics(program as any)
-    .concat(emitResult.diagnostics);
+  const errorCount = await typeCheck(opts);
 
-  reportDiagnostics(allDiagnostics);
-
-  if (allDiagnostics.length > 0) {
+  if (errorCount > 0) {
     // eslint-disable-next-line no-console
-    console.log(`Build completed with ${allDiagnostics.length} errors.`);
+    console.log(
+      `Build completed with ${errorCount} error${errorCount === 1 ? "" : "s"}.`,
+    );
     process.exit(1);
   } else {
     const end = new Date().getTime();
@@ -90,45 +67,202 @@ async function build(values: BuildValues) {
   }
 }
 
-function watchMain(values: BuildValues) {
+async function watchMain(values: BuildValues) {
+  const { addSourceInfo } = resolveBuildSettings(values);
   const opts = getParseCommandLine();
 
-  const createProgram = ts.createSemanticDiagnosticsBuilderProgram;
+  // Initial transpile so JS output exists right away.
+  await emitJs(opts, values, addSourceInfo);
 
-  const host = ts.createWatchCompilerHost(
-    opts.configPath,
-    {},
-    ts.sys,
-    createProgram,
-    reportDiagnostic,
-    reportWatchStatusChanged,
+  // Native tsc handles type-checking and declaration emit in watch mode.
+  spawn(
+    process.execPath,
+    [
+      resolveTscBin(),
+      "-p",
+      opts.configPath,
+      "--watch",
+      "--preserveWatchOutput",
+    ],
+    { stdio: "inherit" },
   );
 
-  const origPostProgramCreate = host.afterProgramCreate;
-  host.afterProgramCreate = async (program) => {
-    ts.sys.clearScreen?.();
-    try {
-      await buildAllFiles(
-        program
-          .getSourceFiles()
-          .filter((x) => !x.isDeclarationFile)
-          .map((x) => x.fileName),
-        opts.rootDir,
-        opts.outDir,
-        {
-          sourceMaps: opts.options.sourceMap,
-          addSourceInfo: true,
-        },
-      );
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(pc.red("Error building files"));
-      // eslint-disable-next-line no-console
-      console.log(e);
+  // Babel handles the JS emit; re-run it whenever a source file changes.
+  // `fs.watch({ recursive: true })` is stable on all platforms since Node 20.
+  await Promise.all(
+    sourceRoots(opts).map((root) =>
+      watchSourceRoot(root, opts, values, addSourceInfo),
+    ),
+  );
+}
+
+async function watchSourceRoot(
+  root: string,
+  opts: Config,
+  values: BuildValues,
+  addSourceInfo: boolean,
+) {
+  // `fs.watch` emits several events for a single change, so debounce per file.
+  const pending = new Map<string, ReturnType<typeof setTimeout>>();
+  for await (const event of watch(root, { recursive: true })) {
+    if (!event.filename || !/\.tsx?$/.test(event.filename)) {
+      continue;
     }
-    origPostProgramCreate!(program);
-  };
-  ts.createWatchProgram(host);
+    const file = join(root, event.filename);
+    clearTimeout(pending.get(file));
+    pending.set(
+      file,
+      setTimeout(() => {
+        pending.delete(file);
+        void onSourceChange(file, opts, values, addSourceInfo);
+      }, 50),
+    );
+  }
+}
+
+async function onSourceChange(
+  file: string,
+  opts: Config,
+  values: BuildValues,
+  addSourceInfo: boolean,
+) {
+  try {
+    if (existsSync(file)) {
+      await emitJsFile(opts, values, addSourceInfo, file);
+      // eslint-disable-next-line no-console
+      console.log(
+        `[${formatTime(new Date())}] Rebuilt ${relative(opts.rootDir, file)}`,
+      );
+    } else {
+      await removeJsFile(opts, values, file);
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(pc.red(`Error building ${relative(opts.rootDir, file)}`));
+    // eslint-disable-next-line no-console
+    console.log(e);
+  }
+}
+
+/** Transpile all source files to JS with babel. */
+async function emitJs(
+  opts: Config,
+  values: BuildValues,
+  addSourceInfo: boolean,
+) {
+  if (values["with-dev"]) {
+    await buildAllFiles(opts.fileNames, opts.rootDir, opts.outDir, {
+      sourceMaps: opts.sourceMap,
+      addSourceInfo: false,
+    });
+    const devOutDir = join(opts.outDir, "dev");
+    await buildAllFiles(opts.fileNames, opts.rootDir, devOutDir, {
+      sourceMaps: opts.sourceMap,
+      addSourceInfo: true,
+    });
+  } else {
+    await buildAllFiles(opts.fileNames, opts.rootDir, opts.outDir, {
+      sourceMaps: opts.sourceMap,
+      addSourceInfo,
+    });
+  }
+}
+
+/** Transpile a single source file to JS with babel (used in watch mode). */
+async function emitJsFile(
+  opts: Config,
+  values: BuildValues,
+  addSourceInfo: boolean,
+  file: string,
+) {
+  if (values["with-dev"]) {
+    await buildFileToOutput(file, opts.rootDir, opts.outDir, {
+      sourceMaps: opts.sourceMap,
+      addSourceInfo: false,
+    });
+    await buildFileToOutput(file, opts.rootDir, join(opts.outDir, "dev"), {
+      sourceMaps: opts.sourceMap,
+      addSourceInfo: true,
+    });
+  } else {
+    await buildFileToOutput(file, opts.rootDir, opts.outDir, {
+      sourceMaps: opts.sourceMap,
+      addSourceInfo,
+    });
+  }
+}
+
+/** Remove the JS output associated with a deleted source file. */
+async function removeJsFile(opts: Config, values: BuildValues, file: string) {
+  const relativePath = relative(opts.rootDir, file).replace(/\.tsx?$/, ".js");
+  const outDirs = values["with-dev"]
+    ? [opts.outDir, join(opts.outDir, "dev")]
+    : [opts.outDir];
+  await Promise.all(
+    outDirs.flatMap((outDir) => {
+      const outPath = join(outDir, relativePath);
+      return [
+        rm(outPath, { force: true }),
+        rm(`${outPath}.map`, { force: true }),
+      ];
+    }),
+  );
+}
+
+/**
+ * Type-check and emit declarations via the native `tsc` binary. Returns the
+ * number of reported errors.
+ */
+function typeCheck(opts: Config): Promise<number> {
+  return new Promise((resolvePromise, reject) => {
+    const chunks: Buffer[] = [];
+    const child = spawn(
+      process.execPath,
+      [resolveTscBin(), "-p", opts.configPath, "--pretty"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    child.stdout?.on("data", (chunk) => chunks.push(chunk));
+    child.stderr?.on("data", (chunk) => chunks.push(chunk));
+    child.on("error", reject);
+    child.on("close", () => {
+      const output = Buffer.concat(chunks).toString("utf8");
+      if (output.length > 0) {
+        // eslint-disable-next-line no-console
+        process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
+      }
+      resolvePromise(countErrors(output));
+    });
+  });
+}
+
+function countErrors(output: string): number {
+  const stripped = stripAnsi(output);
+  const summary = stripped.match(/Found (\d+) errors?/);
+  if (summary) {
+    return Number(summary[1]);
+  }
+  return (stripped.match(/error TS\d+/g) ?? []).length;
+}
+
+// eslint-disable-next-line no-control-regex
+const ansiPattern = /\u001b\[[0-9;]*m/g;
+function stripAnsi(value: string): string {
+  return value.replace(ansiPattern, "");
+}
+
+/**
+ * Minimal set of directories that contain the source files, so watching them
+ * recursively picks up new files without touching `node_modules`/`dist`.
+ */
+function sourceRoots(opts: Config): string[] {
+  const dirs = [...new Set(opts.fileNames.map((file) => dirname(file)))].sort();
+  const roots: string[] = [];
+  for (const dir of dirs) {
+    if (!roots.some((root) => dir === root || dir.startsWith(`${root}/`))) {
+      roots.push(dir);
+    }
+  }
+  return roots;
 }
 
 function resolveBuildSettings(values: BuildValues) {
@@ -150,22 +284,11 @@ function resolveBuildSettings(values: BuildValues) {
   return { mode, addSourceInfo };
 }
 
-function reportDiagnostic(diagnostic: ts.Diagnostic) {
-  reportDiagnostics([diagnostic]);
-}
-function reportDiagnostics(diagnostics: readonly ts.Diagnostic[]) {
-  // eslint-disable-next-line no-console
-  console.log(ts.formatDiagnosticsWithColorAndContext(diagnostics, formatHost));
-}
-
-function reportWatchStatusChanged(diagnostic: ts.Diagnostic) {
-  const time = new Date();
-  const formattedTime = time.toLocaleTimeString("en-US", {
+function formatTime(time: Date): string {
+  return time.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
     second: "2-digit",
     hour12: true,
   });
-  // eslint-disable-next-line no-console
-  console.log(`[${pc.green(formattedTime)}] ${diagnostic.messageText}`);
 }

--- a/packages/cli/src/typescript.ts
+++ b/packages/cli/src/typescript.ts
@@ -1,43 +1,77 @@
-import { dirname, join } from "pathe";
-import * as ts from "typescript";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 
-export interface Config extends ts.ParsedCommandLine {
+import { dirname, join, resolve } from "pathe";
+
+const require = createRequire(import.meta.url);
+
+export interface Config {
+  /** Absolute path to the resolved `tsconfig.json`. */
   configPath: string;
+  /** Absolute root directory used to compute output paths. */
   rootDir: string;
+  /** Absolute output directory. */
   outDir: string;
+  /** Absolute paths of the source files included by the config. */
+  fileNames: string[];
+  /** Whether source maps are enabled. */
+  sourceMap: boolean;
 }
+
+/**
+ * Resolve the path to the `tsc` binary shipped with the project's TypeScript
+ * installation. TypeScript 7+ only exposes the compiler through its binary, so
+ * we shell out to it instead of using the (removed) programmatic API.
+ */
+export function resolveTscBin(): string {
+  const pkgJsonPath = require.resolve("typescript/package.json");
+  return join(dirname(pkgJsonPath), "bin", "tsc");
+}
+
 export function getParseCommandLine(): Config {
   const configPath = findTSConfigFile();
-  const opts = ts.getParsedCommandLineOfConfigFile(
-    configPath,
-    { skipLibCheck: true },
-    {
-      ...ts.sys,
-      onUnRecoverableConfigFileDiagnostic: (diagnostic) => {},
-    },
+  const configDir = dirname(configPath);
+
+  const output = execFileSync(
+    process.execPath,
+    [resolveTscBin(), "-p", configPath, "--showConfig"],
+    { encoding: "utf8" },
   );
-  if (!opts) {
-    throw new Error("Could not parse 'tsconfig.json'.");
-  }
-  const rootDir = opts.options.rootDir ?? dirname(configPath);
-  const outDir = opts.options.outDir ?? join(dirname(configPath), "dist");
+  const config = JSON.parse(output);
+  const options = config.compilerOptions ?? {};
+
+  const fileNames: string[] = (config.files ?? []).map((file: string) =>
+    resolve(configDir, file),
+  );
+  const rootDir = options.rootDir
+    ? resolve(configDir, options.rootDir)
+    : configDir;
+  const outDir = options.outDir
+    ? resolve(configDir, options.outDir)
+    : join(configDir, "dist");
+
   return {
-    ...opts,
     configPath,
     rootDir,
     outDir,
+    fileNames,
+    sourceMap: options.sourceMap ?? false,
   };
 }
 
-function findTSConfigFile() {
-  const configPath = ts.findConfigFile(
-    process.cwd(),
-    ts.sys.fileExists,
-    "tsconfig.json",
-  );
-  if (!configPath) {
-    throw new Error("Could not find a valid 'tsconfig.json'.");
+function findTSConfigFile(): string {
+  let dir = process.cwd();
+  for (;;) {
+    const candidate = join(dir, "tsconfig.json");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
   }
-
-  return configPath;
+  throw new Error("Could not find a valid 'tsconfig.json'.");
 }

--- a/packages/typescript/api-extractor.json
+++ b/packages/typescript/api-extractor.json
@@ -1,4 +1,16 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "../../api-extractor.base.json"
+  "extends": "../../api-extractor.base.json",
+
+  "messages": {
+    "extractorMessageReporting": {
+      // TypeScript 7 emits expando namespace members (e.g. `ArrowFunction.Parameters`)
+      // as re-exports in the .d.ts (`export { FunctionParameters as Parameters }`).
+      // The TypeScript engine bundled with API Extractor cannot resolve `@link`
+      // references to those re-exported members, so silence the false positives.
+      "ae-unresolved-link": {
+        "logLevel": "none"
+      }
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ catalogs:
       specifier: ^1.4.0
       version: 1.4.0
     typescript:
-      specifier: ^6.0.3
-      version: 6.0.3
+      specifier: ^7.0.2
+      version: 7.0.2
     validate-html-nesting:
       specifier: ^1.2.4
       version: 1.2.4
@@ -286,7 +286,7 @@ importers:
         version: 4.22.4
       typedoc:
         specifier: ^0.28.8
-        version: 0.28.19(typescript@6.0.3)
+        version: 0.28.19(typescript@7.0.2)
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -295,7 +295,7 @@ importers:
     dependencies:
       '@babel/core':
         specifier: ^7.24.7
-        version: 7.29.7
+        version: 7.29.7(supports-color@8.1.1)
       '@babel/generator':
         specifier: 'catalog:'
         version: 7.29.7
@@ -304,7 +304,7 @@ importers:
         version: 7.29.7
       '@babel/plugin-syntax-jsx':
         specifier: 'catalog:'
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/types':
         specifier: 'catalog:'
         version: 7.29.7
@@ -323,10 +323,10 @@ importers:
         version: 25.9.2
       babel-plugin-tester:
         specifier: 'catalog:'
-        version: 12.0.0(@babel/core@7.29.7)
+        version: 12.0.0(@babel/core@7.29.7(supports-color@8.1.1))
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -394,7 +394,7 @@ importers:
         version: 25.9.2
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -446,7 +446,7 @@ importers:
         version: 25.9.2
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -477,7 +477,7 @@ importers:
         version: link:../rollup-plugin
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -492,7 +492,7 @@ importers:
         version: 4.2.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -532,7 +532,7 @@ importers:
         version: 7.58.8(@types/node@25.9.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/js-yaml':
         specifier: 'catalog:'
         version: 4.0.9
@@ -547,7 +547,7 @@ importers:
         version: 4.2.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -635,7 +635,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vite:
         specifier: npm:rolldown-vite@7.3.1
         version: rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -650,10 +650,10 @@ importers:
     dependencies:
       '@astrojs/check':
         specifier: 'catalog:'
-        version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
+        version: 0.9.9(prettier@3.8.3)(typescript@7.0.2)
       '@astrojs/starlight':
         specifier: 'catalog:'
-        version: 0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@6.0.3)
+        version: 0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@7.0.2)
       astro:
         specifier: 'catalog:'
         version: 6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -668,7 +668,7 @@ importers:
         version: 4.22.4
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
     devDependencies:
       '@alloy-js/core':
         specifier: workspace:~
@@ -702,7 +702,7 @@ importers:
         version: 4.0.0
       starlight-llms-txt:
         specifier: 'catalog:'
-        version: 0.10.0(@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@6.0.3))(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 0.10.0(@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@7.0.2))(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/go:
     dependencies:
@@ -727,7 +727,7 @@ importers:
         version: 7.58.8(@types/node@25.9.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -736,7 +736,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -764,7 +764,7 @@ importers:
         version: 7.58.8(@types/node@25.9.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -773,7 +773,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -798,7 +798,7 @@ importers:
         version: 7.58.8(@types/node@25.9.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -807,7 +807,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -835,7 +835,7 @@ importers:
         version: 25.9.2
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -869,7 +869,7 @@ importers:
         version: 7.58.8(@types/node@25.9.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/js-yaml':
         specifier: 'catalog:'
         version: 4.0.9
@@ -887,7 +887,7 @@ importers:
         version: 4.2.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -915,7 +915,7 @@ importers:
         version: 7.58.8(@types/node@25.9.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -924,7 +924,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -946,7 +946,7 @@ importers:
         version: 25.9.2
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -965,7 +965,7 @@ importers:
         version: 25.9.2
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/typescript:
     dependencies:
@@ -990,7 +990,7 @@ importers:
         version: 7.58.8(@types/node@25.9.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -999,7 +999,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1024,7 +1024,7 @@ importers:
         version: link:../../packages/rollup-plugin
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -1036,7 +1036,7 @@ importers:
         version: 6.1.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1061,7 +1061,7 @@ importers:
         version: link:../../packages/rollup-plugin
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -1070,7 +1070,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1107,7 +1107,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1144,7 +1144,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1166,7 +1166,7 @@ importers:
         version: link:../../packages/rollup-plugin
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -1175,7 +1175,7 @@ importers:
         version: 10.0.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1203,7 +1203,7 @@ importers:
         version: link:../../packages/typescript
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -1218,7 +1218,7 @@ importers:
         version: 10.2.1
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
 packages:
 
@@ -3680,6 +3680,126 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@typespec/compiler@1.12.0':
     resolution: {integrity: sha512-hKCkHEEDdCpXFyOU8ln+TzBBwonFMbkeUV0zIc+vBETyO8p/Upui3XvEyLOyB4CpKUReHzGeGm3gcFjNc73ygg==}
     engines: {node: '>=22.0.0'}
@@ -5919,9 +6039,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -6496,12 +6616,12 @@ snapshots:
       tunnel: 0.0.6
       undici: 6.26.0
 
-  '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@6.0.3)':
+  '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@7.0.2)':
     dependencies:
-      '@astrojs/language-server': 2.16.10(prettier@3.8.3)(typescript@6.0.3)
+      '@astrojs/language-server': 2.16.10(prettier@3.8.3)(typescript@7.0.2)
       chokidar: 4.0.3
       kleur: 4.1.5
-      typescript: 6.0.3
+      typescript: 7.0.2
       yargs: 17.7.2
     transitivePeerDependencies:
       - prettier
@@ -6526,12 +6646,12 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
-  '@astrojs/language-server@2.16.10(prettier@3.8.3)(typescript@6.0.3)':
+  '@astrojs/language-server@2.16.10(prettier@3.8.3)(typescript@7.0.2)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.4
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@volar/kit': 2.4.28(typescript@6.0.3)
+      '@volar/kit': 2.4.28(typescript@7.0.2)
       '@volar/language-core': 2.4.28
       '@volar/language-server': 2.4.28
       '@volar/language-service': 2.4.28
@@ -6628,7 +6748,7 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@6.0.3)':
+  '@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@7.0.2)':
     dependencies:
       '@astrojs/markdown-remark': 7.2.0
       '@astrojs/mdx': 5.0.6(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -6644,7 +6764,7 @@ snapshots:
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
-      i18next: 26.3.1(typescript@6.0.3)
+      i18next: 26.3.1(typescript@7.0.2)
       js-yaml: 4.2.0
       klona: 2.0.6
       magic-string: 0.30.21
@@ -6692,7 +6812,27 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/core@7.29.7(supports-color@8.1.1)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -6731,7 +6871,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -6740,15 +6880,24 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6757,7 +6906,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6772,13 +6921,13 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -6797,6 +6946,11 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -6844,7 +6998,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -8327,11 +8481,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.61.1
 
-  '@rollup/plugin-typescript@12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@6.0.3)':
+  '@rollup/plugin-typescript@12.3.0(rollup@4.61.1)(tslib@2.8.1)(typescript@7.0.2)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
       resolve: 1.22.12
-      typescript: 6.0.3
+      typescript: 7.0.2
     optionalDependencies:
       rollup: 4.61.1
       tslib: 2.8.1
@@ -8749,6 +8903,66 @@ snapshots:
     dependencies:
       '@types/node': 25.9.2
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@typespec/compiler@1.12.0(@types/node@25.9.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -8830,12 +9044,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@volar/kit@2.4.28(typescript@6.0.3)':
+  '@volar/kit@2.4.28(typescript@7.0.2)':
     dependencies:
       '@volar/language-service': 2.4.28
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
-      typescript: 6.0.3
+      typescript: 7.0.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -9068,10 +9282,10 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-plugin-tester@12.0.0(@babel/core@7.29.7):
+  babel-plugin-tester@12.0.0(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
       '@-xun/fs': 2.0.0
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       core-js: 3.49.0
       lodash.mergewith: 4.6.2
       prettier: 3.8.3
@@ -9886,9 +10100,9 @@ snapshots:
 
   human-signals@8.0.1: {}
 
-  i18next@26.3.1(typescript@6.0.3):
+  i18next@26.3.1(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -11506,10 +11720,10 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-llms-txt@0.10.0(@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@6.0.3))(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)):
+  starlight-llms-txt@0.10.0(@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@7.0.2))(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@astrojs/mdx': 5.0.6(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
-      '@astrojs/starlight': 0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@6.0.3)
+      '@astrojs/starlight': 0.39.3(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@7.0.2)
       '@types/hast': 3.0.4
       '@types/micromatch': 4.0.10
       astro: 6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -11672,13 +11886,13 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typedoc@0.28.19(typescript@6.0.3):
+  typedoc@0.28.19(typescript@7.0.2):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.2.0
       minimatch: 10.2.5
-      typescript: 6.0.3
+      typescript: 7.0.2
       yaml: 2.9.0
 
   typesafe-path@0.2.2: {}
@@ -11689,7 +11903,28 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@2.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,7 +80,7 @@ catalog:
   tailwindcss: ^4.1.18
   tsx: ^4.22.4
   tw-animate-css: ^1.4.0
-  typescript: ^6.0.3
+  typescript: ^7.0.2
   validate-html-nesting: ^1.2.4
   vite: ^8.0.16
   vite-plugin-singlefile: ^2.3.0


### PR DESCRIPTION
Upgrades the repo to **TypeScript 7** (the native Go compiler, now published as `typescript@7`).

## Background
TypeScript 7's `typescript` package only ships the `tsc` binary plus a version export and a new `unstable/*` API — the classic programmatic compiler API (`ts.createProgram`, `ts.sys`, `getParsedCommandLineOfConfigFile`, watch host, `formatDiagnostics…`) is **gone**. The only place using it was `@alloy-js/cli`.

## Changes
- **Catalog**: `typescript` `^6.0.3` → `^7.0.2`.
- **`@alloy-js/cli` `alloy build`** rewritten to use the project's native `tsc` binary:
  - Config parsed via `tsc --showConfig` (child process).
  - Type-check + declaration emit via `tsc -p <config>`; error count parsed to preserve the `Build completed with N errors.` message. JS emit still via babel.
  - Watch mode uses Node's built-in **recursive `fs.watch`** (`node:fs/promises`) + `tsc --watch` — no more `chokidar` dependency.
  - Engine raised to **Node ≥22**.
  - Bonus: the CLI no longer imports a version-specific TS API, so it works with whatever `tsc` the consuming project has installed.
- **`@alloy-js/typescript`**: silenced api-extractor `ae-unresolved-link`. api-extractor (bundles TS 5.9.3) can't resolve `@link` references to namespace members that TS 7 emits as re-exports (`export { FunctionParameters as Parameters }`). Scoped to the only affected package.

## Validation
- `pnpm build` (full workspace) ✔
- `pnpm test` — 1717/1717 ✔
- `pnpm lint` (oxlint `--type-aware`) ✔ · `pnpm format:check` ✔ · `chronus verify` ✔
- `alloy build --watch` smoke-tested: edits, new files (incl. new subdirectories), and deletions all handled.