### PR TITLE
Support attributes on all C# declarations that can have them

### DIFF
--- a/.chronus/changes/feature-csharp-attributes-2026-7-7.md
+++ b/.chronus/changes/feature-csharp-attributes-2026-7-7.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@alloy-js/csharp"
+---
+
+Add `attributes` prop to `EnumDeclaration`, `EnumMember`, `RecordDeclaration`, `Field` and `Constructor`

--- a/packages/csharp/src/components/constructor/constructor.test.tsx
+++ b/packages/csharp/src/components/constructor/constructor.test.tsx
@@ -2,6 +2,7 @@ import { refkey } from "@alloy-js/core";
 import { expect, it } from "vitest";
 
 import { TestNamespace } from "../../../test/utils.jsx";
+import { Attribute } from "../attributes/attributes.jsx";
 import { ClassDeclaration } from "../class/declaration.jsx";
 import { DocSummary } from "../doc/comment.jsx";
 import { Constructor } from "./constructor.jsx";
@@ -119,6 +120,27 @@ it("renders : base() with no arguments", () => {
     public class DerivedClass : BaseClass
     {
         public DerivedClass() : base()
+        {
+            // body
+        }
+    }
+  `);
+});
+
+it("specify attributes", () => {
+  expect(
+    <TestNamespace>
+      <ClassDeclaration public name="TestClass">
+        <Constructor public attributes={[<Attribute name="Test" />]}>
+          // body
+        </Constructor>
+      </ClassDeclaration>
+    </TestNamespace>,
+  ).toRenderTo(`
+    public class TestClass
+    {
+        [Test]
+        public TestClass()
         {
             // body
         }

--- a/packages/csharp/src/components/constructor/constructor.tsx
+++ b/packages/csharp/src/components/constructor/constructor.tsx
@@ -14,6 +14,8 @@ import type { AccessModifiers } from "../../modifiers.js";
 import { computeModifiersPrefix, getAccessModifier } from "../../modifiers.js";
 import { useNamedTypeScope } from "../../scopes/contexts.js";
 import { MethodSymbol } from "../../symbols/method.js";
+import type { AttributesProp } from "../attributes/attributes.jsx";
+import { AttributeList } from "../attributes/attributes.jsx";
 import { DocWhen } from "../doc/comment.jsx";
 import type { ParameterProps } from "../parameters/parameters.jsx";
 import { Parameters } from "../parameters/parameters.jsx";
@@ -30,6 +32,20 @@ export interface ConstructorProps extends AccessModifiers {
 
   /** Refkey */
   refkey?: Refkey;
+
+  /**
+   * Define attributes to attach
+   * @example
+   * ```tsx
+   * <Constructor public attributes={[<Attribute name="Test" />]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * [Test]
+   * public MyClass()
+   * ```
+   */
+  attributes?: AttributesProp;
 
   /**
    * Arguments to pass to the base class constructor.
@@ -96,6 +112,7 @@ export function Constructor(props: ConstructorProps) {
     <MemberDeclaration symbol={ctorSymbol}>
       <MethodScope>
         <DocWhen doc={props.doc} />
+        <AttributeList attributes={props.attributes} endline />
         {modifiers}
         <MemberName />
         <Parameters parameters={props.parameters} />

--- a/packages/csharp/src/components/enum/declaration.test.tsx
+++ b/packages/csharp/src/components/enum/declaration.test.tsx
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 
 import { TestNamespace } from "#test/utils.jsx";
 
+import { Attribute } from "../attributes/attributes.jsx";
 import { EnumDeclaration } from "./declaration.jsx";
 import { EnumMember } from "./member.jsx";
 
@@ -59,6 +60,26 @@ it("renders doc comment", () => {
     {
         One,
         Two
+    }
+  `);
+});
+
+it("specify attributes", () => {
+  expect(
+    <TestNamespace>
+      <EnumDeclaration
+        public
+        name="TestEnum"
+        attributes={[<Attribute name="Flags" />]}
+      >
+        <EnumMember name="One" />
+      </EnumDeclaration>
+    </TestNamespace>,
+  ).toRenderTo(`
+    [Flags]
+    public enum TestEnum
+    {
+        One
     }
   `);
 });

--- a/packages/csharp/src/components/enum/declaration.tsx
+++ b/packages/csharp/src/components/enum/declaration.tsx
@@ -6,6 +6,8 @@ import { computeModifiersPrefix, getAccessModifier } from "../../modifiers.js";
 import { useCSharpNamePolicy } from "../../name-policy.js";
 import { createNamedTypeScope } from "../../scopes/factories.js";
 import { createNamedTypeSymbol } from "../../symbols/factories.js";
+import type { AttributesProp } from "../attributes/attributes.jsx";
+import { AttributeList } from "../attributes/attributes.jsx";
 import { DocWhen } from "../doc/comment.jsx";
 import { Name } from "../Name.jsx";
 
@@ -15,6 +17,23 @@ export interface EnumDeclarationProps extends AccessModifiers {
   /** Doc comment */
   doc?: Children;
   refkey?: Refkey | Refkey[];
+
+  /**
+   * Define attributes to attach
+   * @example
+   * ```tsx
+   * <EnumDeclaration name="Color" attributes={[
+   *  <Attribute name="Flags" />
+   * ]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * [Flags]
+   * enum Color
+   * ```
+   */
+  attributes?: AttributesProp;
+
   children?: Children;
 }
 
@@ -50,6 +69,7 @@ export function EnumDeclaration(props: EnumDeclarationProps) {
   return (
     <Declaration symbol={symbol}>
       <DocWhen doc={props.doc} />
+      <AttributeList attributes={props.attributes} endline />
       {modifiers}enum <Name />
       {!props.children && ";"}
       {props.children && (

--- a/packages/csharp/src/components/enum/member.test.tsx
+++ b/packages/csharp/src/components/enum/member.test.tsx
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 
 import { TestNamespace } from "#test/utils.jsx";
 
+import { Attribute } from "../attributes/attributes.jsx";
 import { EnumDeclaration } from "./declaration.jsx";
 import { EnumMember } from "./member.jsx";
 
@@ -57,6 +58,25 @@ it("renders doc comment", () => {
         /// First value
         One,
         /// Second value
+        Two
+    }
+  `);
+});
+
+it("specify attributes", () => {
+  expect(
+    <TestNamespace>
+      <EnumDeclaration public name="TestEnum">
+        <EnumMember name="One" attributes={[<Attribute name="Obsolete" />]} />,
+        <hbr />
+        <EnumMember name="Two" />
+      </EnumDeclaration>
+    </TestNamespace>,
+  ).toRenderTo(`
+    public enum TestEnum
+    {
+        [Obsolete]
+        One,
         Two
     }
   `);

--- a/packages/csharp/src/components/enum/member.tsx
+++ b/packages/csharp/src/components/enum/member.tsx
@@ -4,6 +4,8 @@ import { createSymbol, MemberDeclaration, MemberName } from "@alloy-js/core";
 import { useCSharpNamePolicy } from "../../name-policy.js";
 import { useNamedTypeScope } from "../../scopes/contexts.js";
 import { CSharpSymbol } from "../../symbols/csharp.js";
+import type { AttributesProp } from "../attributes/attributes.jsx";
+import { AttributeList } from "../attributes/attributes.jsx";
 import { DocWhen } from "../doc/comment.jsx";
 
 // properties for creating a C# enum member
@@ -12,6 +14,20 @@ export interface EnumMemberProps {
   /** Doc comment */
   doc?: Children;
   refkey?: Refkey;
+
+  /**
+   * Define attributes to attach
+   * @example
+   * ```tsx
+   * <EnumMember name="Red" attributes={[<Attribute name="Obsolete" />]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * [Obsolete]
+   * Red
+   * ```
+   */
+  attributes?: AttributesProp;
 }
 
 // a member within a C# enum
@@ -41,6 +57,7 @@ export function EnumMember(props: EnumMemberProps) {
   return (
     <MemberDeclaration symbol={thisEnumValueSymbol}>
       <DocWhen doc={props.doc} />
+      <AttributeList attributes={props.attributes} endline />
       <MemberName />
     </MemberDeclaration>
   );

--- a/packages/csharp/src/components/field/field.test.tsx
+++ b/packages/csharp/src/components/field/field.test.tsx
@@ -2,6 +2,7 @@ import { List, namekey } from "@alloy-js/core";
 import { describe, expect, it } from "vitest";
 
 import { TestNamespace } from "../../../test/utils.jsx";
+import { Attribute } from "../attributes/attributes.jsx";
 import { ClassDeclaration } from "../class/declaration.jsx";
 import { Field } from "./field.jsx";
 
@@ -133,4 +134,23 @@ describe("naming", () => {
     }
   `);
   });
+});
+
+it("specify attributes", () => {
+  expect(
+    <Wrapper>
+      <Field
+        public
+        name="MemberOne"
+        type="string"
+        attributes={[<Attribute name="Test" />]}
+      />
+    </Wrapper>,
+  ).toRenderTo(`
+    public class TestClass
+    {
+        [Test]
+        public string MemberOne;
+    }
+  `);
 });

--- a/packages/csharp/src/components/field/field.tsx
+++ b/packages/csharp/src/components/field/field.tsx
@@ -12,6 +12,8 @@ import {
   nonAccessibilityFromProps,
 } from "../../symbols/csharp.js";
 import { createFieldSymbol } from "../../symbols/factories.js";
+import type { AttributesProp } from "../attributes/attributes.jsx";
+import { AttributeList } from "../attributes/attributes.jsx";
 import { DocWhen } from "../doc/comment.jsx";
 
 /** Field modifiers. */
@@ -35,6 +37,22 @@ export interface FieldProps extends AccessModifiers, FieldModifiers {
   refkey?: Refkey;
   /** Doc comment */
   doc?: Children;
+
+  /**
+   * Define attributes to attach
+   * @example
+   * ```tsx
+   * <Field name="myField" type="int" attributes={[
+   *  <Attribute name="Test" />
+   * ]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * [Test]
+   * int myField;
+   * ```
+   */
+  attributes?: AttributesProp;
 }
 
 /** Render a c# field */
@@ -55,6 +73,7 @@ export function Field(props: FieldProps) {
   return (
     <Declaration symbol={memberSymbol}>
       <DocWhen doc={props.doc} />
+      <AttributeList attributes={props.attributes} endline />
       {modifiers}
       {props.type} <Name />;
     </Declaration>

--- a/packages/csharp/src/components/record/declaration.test.tsx
+++ b/packages/csharp/src/components/record/declaration.test.tsx
@@ -3,6 +3,7 @@ import { code, namekey, refkey } from "@alloy-js/core";
 import { describe, expect, it } from "vitest";
 
 import { TestNamespace } from "../../../test/utils.jsx";
+import { Attribute } from "../attributes/attributes.jsx";
 import { Property } from "../property/property.jsx";
 import { RecordDeclaration } from "./declaration.jsx";
 
@@ -126,4 +127,19 @@ describe("constructor", () => {
       }
   `);
   });
+});
+
+it("specify attributes", () => {
+  expect(
+    <Wrapper>
+      <RecordDeclaration
+        public
+        name="Test"
+        attributes={[<Attribute name="Test" />]}
+      />
+    </Wrapper>,
+  ).toRenderTo(`
+    [Test]
+    public record Test;
+  `);
 });

--- a/packages/csharp/src/components/record/declaration.tsx
+++ b/packages/csharp/src/components/record/declaration.tsx
@@ -12,6 +12,8 @@ import {
   createNamedTypeSymbol,
   createTypeParameterSymbol,
 } from "../../symbols/factories.js";
+import type { AttributesProp } from "../attributes/attributes.jsx";
+import { AttributeList } from "../attributes/attributes.jsx";
 import { DocWhen } from "../doc/comment.jsx";
 import { Name } from "../Name.jsx";
 import type { ParameterProps } from "../parameters/parameters.jsx";
@@ -35,6 +37,22 @@ export interface RecordDeclarationProps
   doc?: core.Children;
   refkey?: core.Refkey;
   typeParameters?: Record<string, core.Refkey>;
+
+  /**
+   * Define attributes to attach
+   * @example
+   * ```tsx
+   * <RecordDeclaration name="MyRecord" attributes={[
+   *  <Attribute name="Test" />
+   * ]} />
+   * ```
+   * This will produce:
+   * ```csharp
+   * [Test]
+   * record MyRecord
+   * ```
+   */
+  attributes?: AttributesProp;
 
   /**
    * Set the primary constructor parameters
@@ -117,6 +135,7 @@ export function RecordDeclaration(props: RecordDeclarationProps) {
   return (
     <core.Declaration symbol={thisRecordSymbol}>
       <DocWhen doc={props.doc} />
+      <AttributeList attributes={props.attributes} endline />
       {modifiers}record <Name />
       {typeParams}
       {props.primaryConstructor && (


### PR DESCRIPTION
Several C# declaration components silently dropped attributes — there was simply no way to emit `[Flags]` on an enum, `[Obsolete]` on an enum member, or `[JsonIgnore]` on a field. `ClassDeclaration`, `StructDeclaration`, `InterfaceDeclaration`, `Method`, `Property` and `Parameter` all took an `attributes` prop; `EnumDeclaration`, `EnumMember`, `RecordDeclaration`, `Field` and `Constructor` did not.

Those five now accept `attributes` with the same shape and rendering as the rest:

```tsx
<EnumDeclaration public name="Color" attributes={[<Attribute name="Flags" />]}>
  <EnumMember name="Red" attributes={[<Attribute name="Obsolete" />]} />
</EnumDeclaration>
```

```csharp
[Flags]
public enum Color
{
    [Obsolete]
    Red
}
```

`VarDeclaration` and namespaces are deliberately left out — C# does not allow attributes on local variables or namespace declarations.

Fixes https://github.com/alloy-framework/alloy/issues/446